### PR TITLE
Introduced cmake option CARBONATED instead of patching CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,12 @@ if(NOT ${CMAKE_VERSION} VERSION_LESS "3.24")
     cmake_policy(SET CMP0135 NEW) 
 endif()
 
+OPTION(CARBONATED "Enable Carbonated patches" OFF)
+
+if(CARBONATED)
+    add_compile_definitions(CARBONATED)
+endif(CARBONATED)
+
 include(cmake/LySet.cmake)
 include(cmake/GeneralSettings.cmake)
 include(cmake/FileUtil.cmake)

--- a/Code/Framework/AzCore/CMakeLists.txt
+++ b/Code/Framework/AzCore/CMakeLists.txt
@@ -53,8 +53,6 @@ ly_add_target(
             ${common_dir}
 )
 
-add_compile_definitions(CARBONATED)
-
 ly_add_target(
     NAME AzCore STATIC
     NAMESPACE AZ

--- a/Code/Framework/AzFramework/CMakeLists.txt
+++ b/Code/Framework/AzFramework/CMakeLists.txt
@@ -11,8 +11,6 @@ include(AzFramework/feature_options.cmake)
 o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} ${O3DE_ENGINE_RESTRICTED_PATH} ${LY_ROOT_FOLDER})
 set(common_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/Common)
 
-add_compile_definitions(CARBONATED)
-
 ly_add_target(
     NAME AzFramework STATIC
     NAMESPACE AZ

--- a/Gems/PhysX/Code/CMakeLists.txt
+++ b/Gems/PhysX/Code/CMakeLists.txt
@@ -25,8 +25,6 @@ else()
     set(physx_editor_files physx_unsupported_files.cmake)
 endif()
 
-add_compile_definitions(CARBONATED)
-
 ly_add_target(
     NAME PhysX.Static STATIC
     NAMESPACE Gem


### PR DESCRIPTION
Introduced cmake option CARBONATED instead of patching CMakeLists.txt of code components and gems

## What does this PR do?

Patching only some CMakeLists.txt to enable the CARBONATED compile definition can be potentially dangerous. When the CARBONATED definition is passed to the compiler, it exposes extended class functionality. If a client includes the affected header(s) with and without CARBONATED in the same project, this can lead to a disaster. Setting CARBONATED at the highest level guarantees safeness. Also the number of changes in CMakeLists.txt's minimizes.

By default the new option is off. In this case the project will be configured without the precompiler symbol CARBONATED. All Carbonated specific changes will be off.

Notice that configuring O3DE with the enabled option, i.e. `-DCARBONATED=ON`, will generate all O3DE projects with the precompiler symbol CARBONATED defined!

This change is supposed to apply only to the Carbonated fork.

## How was this PR tested?

Tested by local full rebuild.
