### PR TITLE
Enable rest of carbonated specific methods in EMotionFX

### DIFF
--- a/Gems/EMotionFX/Code/Include/Integration/ActorComponentBus.h
+++ b/Gems/EMotionFX/Code/Include/Integration/ActorComponentBus.h
@@ -96,6 +96,9 @@ namespace EMotionFX
             // Use this to alter the actor asset.
             virtual void SetActorAsset(AZ::Data::Asset<EMotionFX::Integration::ActorAsset> actorAsset) = 0;
 
+            // Returns actor asset
+            virtual AZ::Data::Asset<AZ::Data::AssetData> GetActorAsset() = 0; // carbonated EMotionFX_port
+
             // Use this bus to enable or disable the actor instance update in the job scheduler system.
             // This could be useful if you want to manually update the actor instance.
             virtual void EnableInstanceUpdate(bool enableInstanceUpdate) = 0;

--- a/Gems/EMotionFX/Code/Include/Integration/AnimGraphComponentBus.h
+++ b/Gems/EMotionFX/Code/Include/Integration/AnimGraphComponentBus.h
@@ -194,6 +194,13 @@ namespace EMotionFX
 
             /// Set the name of the active motion set.
             virtual void SetActiveMotionSet(const char* activeMotionSetName) = 0;
+
+            // carbonated begin EMotionFX_port
+#if defined(CARBONATED)
+            virtual AZ::Data::Asset<AZ::Data::AssetData> GetAnimGraphAsset() = 0;
+            virtual AZ::Data::Asset<AZ::Data::AssetData> GetMotionSetAsset() = 0;
+#endif
+            // carbonated end EMotionFX_port
         };
 
         using AnimGraphComponentRequestBus = AZ::EBus<AnimGraphComponentRequests>;

--- a/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.cpp
@@ -212,6 +212,13 @@ namespace EMotionFX
             CheckActorCreation();
         }
 
+        // carbonated begin EMotionFX_port
+        AZ::Data::Asset<AZ::Data::AssetData> ActorComponent::GetActorAsset()
+        {
+            return m_configuration.m_actorAsset;
+        }
+        // carbonated end EMotionFX_port
+
         void ActorComponent::EnableInstanceUpdate(bool enable)
         {
             if (m_actorInstance)

--- a/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.h
+++ b/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.h
@@ -120,6 +120,7 @@ namespace EMotionFX
             bool GetRenderActorVisible() const override;
             SkinningMethod GetSkinningMethod() const override;
             void SetActorAsset(AZ::Data::Asset<ActorAsset> actorAsset) override;
+            AZ::Data::Asset<AZ::Data::AssetData> GetActorAsset(); // carbonated EMotionFX_port
             void EnableInstanceUpdate(bool enable) override;
 
             //////////////////////////////////////////////////////////////////////////

--- a/Gems/EMotionFX/Code/Source/Integration/Components/AnimGraphComponent.h
+++ b/Gems/EMotionFX/Code/Source/Integration/Components/AnimGraphComponent.h
@@ -144,6 +144,19 @@ namespace EMotionFX
             void SetActiveMotionSet(const char* activeMotionSetName) override;
             //////////////////////////////////////////////////////////////////////////
 
+            // carbonated begin EMotionFX_port
+#if defined(CARBONATED)
+            AZ::Data::Asset<AZ::Data::AssetData> GetAnimGraphAsset()
+            {
+                return m_configuration.m_animGraphAsset;
+            }
+            AZ::Data::Asset<AZ::Data::AssetData> GetMotionSetAsset()
+            {
+                return m_configuration.m_motionSetAsset;
+            }
+#endif
+            // carbonated end EMotionFX_port
+
             //////////////////////////////////////////////////////////////////////////
             // ActorComponentNotificationBus::Handler
             void OnActorInstanceCreated(EMotionFX::ActorInstance* /*actorInstance*/) override;


### PR DESCRIPTION
Enable rest of carbonated specific methods in EMotionFX
Also adds ActorComponent::GetActorAsset() method that is absent in o3de but present in LY