### PR TITLE
Restored support for NetworkContext and OnCryEditorGameInitialize event

### DIFF
--- a/Code/Editor/CMakeLists.txt
+++ b/Code/Editor/CMakeLists.txt
@@ -12,6 +12,11 @@ endif()
 
 add_subdirectory(Plugins)
 
+if(CARBONATED)
+set(azcommonaddon_dependency Legacy::CryCommonAddon)
+endif()
+
+
 ly_add_target(
     NAME EditorCore SHARED
     NAMESPACE Legacy
@@ -38,6 +43,7 @@ ly_add_target(
             3rdParty::Qt::Gui
             3rdParty::Qt::Widgets
             AZ::AzToolsFramework
+            ${azcommonaddon_dependency}
 )
 
 # Header only target to prevent linkage against editor libraries when is not needed. Eventually the targets that depend
@@ -104,6 +110,7 @@ ly_add_target(
             3rdParty::Qt::Concurrent
             3rdParty::TIFF
             Legacy::CryCommon
+            ${azcommonaddon_dependency}
             Legacy::EditorCommon
             AZ::AzCore
             AZ::AzToolsFramework
@@ -165,6 +172,7 @@ ly_add_target(
         PRIVATE
             3rdParty::Qt::Core
             Legacy::CryCommon
+            ${azcommonaddon_dependency}
     RUNTIME_DEPENDENCIES
         Legacy::CrySystem
         Legacy::EditorLib
@@ -211,6 +219,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                 3rdParty::Qt::Widgets
                 Legacy::EditorCore
                 Legacy::CryCommon
+                ${azcommonaddon_dependency}
                 AZ::AzCore
     )
     ly_add_googletest(
@@ -239,6 +248,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                 3rdParty::Qt::Widgets
                 3rdParty::Qt::Test
                 Legacy::CryCommon
+                ${azcommonaddon_dependency}
                 AZ::AzToolsFramework
                 AZ::AzToolsFramework.Tests
                 AZ::AzFrameworkTestShared

--- a/Code/Editor/CMakeLists.txt
+++ b/Code/Editor/CMakeLists.txt
@@ -16,7 +16,6 @@ if(CARBONATED)
 set(azcommonaddon_dependency Legacy::CryCommonAddon)
 endif()
 
-
 ly_add_target(
     NAME EditorCore SHARED
     NAMESPACE Legacy

--- a/Code/Editor/EditorToolsApplication.cpp
+++ b/Code/Editor/EditorToolsApplication.cpp
@@ -18,6 +18,12 @@
 #include <AzToolsFramework/Thumbnails/ThumbnailerComponent.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserComponent.h>
 
+// carbonated begin (akostin/mp226): Add NetworkContext to ReflectionManager instance
+#if defined(CARBONATED)
+#include <AzFramework/Network/NetworkContext.h>
+#endif
+// carbonated end
+
 // Editor
 #include "MainWindow.h"
 #include "Controls/ReflectedPropertyControl/ReflectedVar.h"
@@ -122,6 +128,12 @@ namespace EditorInternal
     void EditorToolsApplication::CreateReflectionManager()
     {
         ToolsApplication::CreateReflectionManager();
+        // carbonated begin (akostin/mp226): Add NetworkContext to ReflectionManager instance
+#if defined(CARBONATED)
+        // Setup NetworkContext
+        AZ::ReflectionEnvironment::GetReflectionManager()->AddReflectContext<AzFramework::NetworkContext>();
+#endif
+        // carbonated end
 
         GetSerializeContext()->CreateEditContext();
     }

--- a/Code/Editor/GameEngine.h
+++ b/Code/Editor/GameEngine.h
@@ -24,6 +24,12 @@ struct IInitializeUIInfo;
 
 #include <AzCore/Module/DynamicModuleHandle.h>
 
+// carbonated begin (akostin/mp226): IEditorGame* to dispatch notifications to NetContext
+#if defined(CARBONATED)
+#include <CryCommon/IEditorGame.h>
+#endif
+// carbonated end
+
 class ThreadedOnErrorHandler : public QObject
 {
     Q_OBJECT
@@ -137,6 +143,11 @@ private:
     bool m_bJustCreated;
     bool m_bIgnoreUpdates;
     ISystem* m_pISystem;
+    // carbonated begin (akostin/mp226): IEditorGame* to dispatch notifications to NetContext
+#if defined(CARBONATED)
+    IEditorGame* m_pEditorGame;
+#endif
+    // carbonated end
     AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     Matrix34 m_playerViewTM;
     struct SSystemUserCallback* m_pSystemUserCallback;

--- a/Code/Framework/AzFramework/AzFramework/Application/Application.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Application/Application.cpp
@@ -80,6 +80,12 @@
 #include <cctype>
 #include <stdio.h>
 
+// carbonated begin (akostin/mp226): Add NetworkContext to ReflectionManager instance
+#if defined(CARBONATED)
+#include <AzFramework/Network/NetworkContext.h>
+#endif
+// carbonated end
+
 [[maybe_unused]] static const char* s_azFrameworkWarningWindow = "AzFramework";
 
 namespace AzFramework
@@ -150,6 +156,12 @@ namespace AzFramework
 
         ApplicationRequests::Bus::Handler::BusConnect();
         AZ::UserSettingsFileLocatorBus::Handler::BusConnect();
+
+        // carbonated begin (akostin/mp226): Add NetworkContext to ReflectionManager instance
+        #if defined(CARBONATED)
+        NetSystemRequestBus::Handler::BusConnect();
+        #endif
+        // carbonated end
     }
 
     Application::~Application()
@@ -158,6 +170,12 @@ namespace AzFramework
         {
             Stop();
         }
+
+        // carbonated begin (akostin/mp226): Add NetworkContext to ReflectionManager instance
+        #if defined(CARBONATED)
+        NetSystemRequestBus::Handler::BusDisconnect();
+        #endif
+        // carbonated end
 
         AZ::UserSettingsFileLocatorBus::Handler::BusDisconnect();
         ApplicationRequests::Bus::Handler::BusDisconnect();
@@ -797,5 +815,22 @@ namespace AzFramework
         }
         return value;
     }
+
+    // carbonated begin (akostin/mp226): Add NetworkContext to ReflectionManager instance
+#if defined(CARBONATED)
+    ////////////////////////////////////////////////////////////////////////////
+    NetworkContext* Application::GetNetworkContext()
+    {
+        NetworkContext* result = nullptr;
+
+        if (auto reflectionManager = AZ::ReflectionEnvironment::GetReflectionManager())
+        {
+            result = reflectionManager->GetReflectContext<AzFramework::NetworkContext>();
+        }
+
+        return result;
+    }
+#endif
+    // carbonated end
 
 } // namespace AzFramework

--- a/Code/Framework/AzFramework/AzFramework/Application/Application.h
+++ b/Code/Framework/AzFramework/AzFramework/Application/Application.h
@@ -21,6 +21,11 @@
 #include <AzFramework/CommandLine/CommandLine.h>
 #include <AzFramework/API/ApplicationAPI.h>
 
+// carbonated begin (akostin/mp226): Add NetworkContext to ReflectionManager instance
+#if defined(CARBONATED)
+#include <AzFramework/Network/NetSystemBus.h>
+#endif
+// carbonated end
 
 namespace AZ
 {
@@ -45,6 +50,11 @@ namespace AzFramework
         : public AZ::ComponentApplication
         , public AZ::UserSettingsFileLocatorBus::Handler
         , public ApplicationRequests::Bus::Handler
+        // carbonated begin (akostin/mp226): Add NetworkContext to ReflectionManager instance
+#if defined(CARBONATED)
+        , public NetSystemRequestBus::Handler
+#endif
+        // carbonated end
     {
     public:
         // Base class for platform specific implementations of the application.
@@ -131,6 +141,15 @@ namespace AzFramework
 
         // Convenience function that should be called instead of the standard exit() function to ensure platform requirements are met.
         static void Exit(int errorCode) { ApplicationRequests::Bus::Broadcast(&ApplicationRequests::TerminateOnError, errorCode); }
+
+        // carbonated begin (akostin/mp226): Add NetworkContext to ReflectionManager instance
+#if defined(CARBONATED)
+        //////////////////////////////////////////////////////////////////////////
+        //! NetSystemEventBus::Handler
+        //////////////////////////////////////////////////////////////////////////
+        NetworkContext* GetNetworkContext() override;
+#endif
+        // carbonated end
 
     protected:
 

--- a/Code/Framework/AzFramework/CMakeLists.txt
+++ b/Code/Framework/AzFramework/CMakeLists.txt
@@ -11,7 +11,7 @@ include(AzFramework/feature_options.cmake)
 o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} ${O3DE_ENGINE_RESTRICTED_PATH} ${LY_ROOT_FOLDER})
 set(common_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/Common)
 if(CARBONATED)
-set(azframeworkaddon_dependency AZ::AzFrameworkAddon)
+set(azframeworkaddon_dependency AZ::AzFrameworkAddon.Static)
 set(gridmate_dependency AZ::GridMate)
 endif()
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/Core/EditorFrameworkApplication.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/Core/EditorFrameworkApplication.cpp
@@ -28,6 +28,12 @@
 
 #include <AzFramework/CommandLine/CommandLine.h>
 
+// carbonated begin (akostin/mp226): Add NetworkContext to ReflectionManager instance
+#if defined(CARBONATED)
+#include <AzFramework/Network/NetworkContext.h>
+#endif
+// carbonated end
+
 #include <AzToolsFramework/UI/LegacyFramework/UIFramework.hxx>
 #include <AzToolsFramework/UI/LegacyFramework/CustomMenus/CustomMenusAPI.h>
 
@@ -151,6 +157,13 @@ namespace LegacyFramework
     void Application::CreateReflectionManager()
     {
         AZ::ComponentApplication::CreateReflectionManager();
+
+// carbonated begin (akostin/mp226): Add NetworkContext to ReflectionManager instance
+#if defined(CARBONATED)
+        // Setup NetworkContext
+        AZ::ReflectionEnvironment::GetReflectionManager()->AddReflectContext<AzFramework::NetworkContext>();
+#endif
+// carbonated end
         GetSerializeContext()->CreateEditContext();
     }
 

--- a/Code/Legacy/CryCommon/CrySystemBus.h
+++ b/Code/Legacy/CryCommon/CrySystemBus.h
@@ -32,6 +32,13 @@ public:
     //! In-Editor systems have been created and initialized.
     virtual void OnCryEditorInitialized() {}
 
+    // carbonated begin (akostin/mp226): revert this LY event to subscribe to Editor Game Initialize.
+#if defined(CARBONATED)
+    //! In-Editor systems initialize game.
+    virtual void OnCryEditorGameInitialize() {}
+#endif
+    // carbonated end
+
     //! Editor has started a level export
     virtual void OnCryEditorBeginLevelExport() {}
 


### PR DESCRIPTION
## What does this PR do?

Reverted support for NetworkContext and OnCryEditorGameInitialize event.

## How was this PR tested?

Build locally.
