### PR TITLE
Compilation fix when CARBONATED is not defined

### DIFF
--- a/Code/Editor/GameEngine.cpp
+++ b/Code/Editor/GameEngine.cpp
@@ -886,9 +886,9 @@ void CGameEngine::OnEditorNotifyEvent(EEditorNotifyEvent event)
         }
     }
     break;
+    }
 #endif
     // carbonated end
-    }
 }
 
 void CGameEngine::OnAreaModified([[maybe_unused]] const AABB& modifiedArea)


### PR DESCRIPTION
## What does this PR do?

Compilation fix when CARBONATED is not defined

## How was this PR tested?

Tested locally.
