### PR TITLE
Added missing scale operations for CARBONATED (MADPORT-278) for static collision support

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
@@ -842,18 +842,36 @@ namespace AzFramework
         SetLocalTM(newLocalTM);
     }
 
-    AZ::Vector3 TransformComponent::GetLocalScale()
-    {
-        AZ::Vector3 scale = m_localTM.RetrieveScaleExact();
-        return scale;
-    }
-
     AZ::Vector3 TransformComponent::GetWorldScale()
     {
         AZ::Vector3 scale = m_worldTM.RetrieveScaleExact();
         return scale;
     }
 #endif
+
+    
+    AZ::Vector3 TransformComponent::GetLocalScale()
+    {
+        AZ_WarningOnce("TransformComponent", false, "GetLocalScale is deprecated, please use GetLocalUniformScale instead");
+        return AZ::Vector3(m_localTM.GetUniformScale());
+    }
+
+    void TransformComponent::SetLocalUniformScale(float scale)
+    {
+        AZ::Transform newLocalTM = m_localTM;
+        newLocalTM.SetUniformScale(scale);
+        SetLocalTM(newLocalTM);
+    }
+
+    float TransformComponent::GetLocalUniformScale()
+    {
+        return m_localTM.GetUniformScale();
+    }
+
+    float TransformComponent::GetWorldUniformScale()
+    {
+        return m_worldTM.GetUniformScale();
+    }
 
     AZStd::vector<AZ::EntityId> TransformComponent::GetChildren()
     {

--- a/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.h
+++ b/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.h
@@ -88,6 +88,16 @@ namespace AzFramework
         /// a localTM and move the transform relative to the parent.
         void SetParentRelative(AZ::EntityId id) override;
 
+        // Scale modifiers
+        // Get local scale as vector (deprecated)
+        AZ::Vector3 GetLocalScale() override;
+        // Set the uniform scale value in local space.
+        void SetLocalUniformScale([[maybe_unused]] float scale) override;
+        // Get the uniform scale value in local space.
+        float GetLocalUniformScale() override;
+        // Get the uniform scale value in world space.
+        float GetWorldUniformScale() override;
+
 #if defined(CARBONATED)
         //Ignore network updates... currently
         void SetClientSimulated(bool clientSim) override;


### PR DESCRIPTION
## What does this PR do?

Added missing scale operations into TransformComponent (in CARBONATED) for static collision

https://jira.carbonated.com:8443/browse/MADPORT-278

Note: I have copied implementations from original implementation (non-CARBONATED)

## How was this PR tested?

In local Editor version with a simple tests scene
