### PR TITLE
Added missing contextBehaviour for CARBONATED TransformComponent

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
@@ -1472,8 +1472,6 @@ namespace AzFramework
                 ->Event("GetLocalScale", &AZ::TransformBus::Events::GetLocalScale)
                     ->Attribute("Scale", AZ::Edit::Attributes::PropertyScale)
                 ->VirtualProperty("Scale", "GetLocalScale", "SetLocalScale")
-                ->Event("GetLocalScale", &AZ::TransformBus::Events::GetLocalScale)
-                    ->Attribute("Scale", AZ::Edit::Attributes::PropertyScale)
                 ->Event("SetLocalUniformScale", &AZ::TransformBus::Events::SetLocalUniformScale)
                 ->Event("GetLocalUniformScale", &AZ::TransformBus::Events::GetLocalUniformScale)
                 ->VirtualProperty("Uniform Scale", "GetLocalUniformScale", "SetLocalUniformScale")

--- a/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
@@ -1472,9 +1472,15 @@ namespace AzFramework
                 ->Event("GetLocalScale", &AZ::TransformBus::Events::GetLocalScale)
                     ->Attribute("Scale", AZ::Edit::Attributes::PropertyScale)
                 ->VirtualProperty("Scale", "GetLocalScale", "SetLocalScale")
+                ->Event("GetLocalScale", &AZ::TransformBus::Events::GetLocalScale)
+                    ->Attribute("Scale", AZ::Edit::Attributes::PropertyScale)
+                ->Event("SetLocalUniformScale", &AZ::TransformBus::Events::SetLocalUniformScale)
+                ->Event("GetLocalUniformScale", &AZ::TransformBus::Events::GetLocalUniformScale)
+                ->VirtualProperty("Uniform Scale", "GetLocalUniformScale", "SetLocalUniformScale")
 #if 0
                 ->Event("GetWorldScale", &AZ::TransformBus::Events::GetWorldScale)
 #endif
+                ->Event("GetWorldUniformScale", &AZ::TransformBus::Events::GetWorldUniformScale)
                 ->Event("GetChildren", &AZ::TransformBus::Events::GetChildren)
                 ->Event("GetAllDescendants", &AZ::TransformBus::Events::GetAllDescendants)
                 ->Event("GetEntityAndAllDescendants", &AZ::TransformBus::Events::GetEntityAndAllDescendants)


### PR DESCRIPTION
## What does this PR do?
Additional changes for PR https://github.com/carbonated-dev/o3de/pull/24

Added missing contextBehaviour for CARBONATED TransformComponent.
Copied from original O3DE TransformComponent implementation.

## How was this PR tested?

Verified via a local build
