### PR TITLE
Misc fixes to succeed with the build of default new project on macOS/iOS

### DIFF
--- a/Code/Framework/AzCore/Platform/iOS/AzCore/Module/DynamicModuleHandle_iOS.cpp
+++ b/Code/Framework/AzCore/Platform/iOS/AzCore/Module/DynamicModuleHandle_iOS.cpp
@@ -19,7 +19,7 @@ namespace AZ
             return AZ::IO::FixedMaxPath(AZ::Utils::GetExecutableDirectory()) / "Frameworks";
         }
 
-        void* OpenModule(const AZ::OSString& fileName, bool& alreadyOpen)
+        void* OpenModule(const AZ::IO::FixedMaxPathString& fileName, bool& alreadyOpen)
         {
             void* handle = dlopen(fileName.c_str(), RTLD_NOLOAD);
             alreadyOpen = (handle != nullptr);

--- a/Code/LauncherUnified/Platform/iOS/launcher_project_ios.cmake
+++ b/Code/LauncherUnified/Platform/iOS/launcher_project_ios.cmake
@@ -32,7 +32,7 @@ target_sources(${project_name}.GameLauncher PRIVATE ${ly_game_resource_folder}/I
 set_target_properties(${project_name}.GameLauncher PROPERTIES
     MACOSX_BUNDLE_INFO_PLIST ${ly_game_resource_folder}/Info.plist
     RESOURCE ${ly_game_resource_folder}/Images.xcassets
-    XCODE_ATTRIBUTE_ASSETCATALOG_COMPILER_APPICON_NAME ${project_name}AppIcon
+    XCODE_ATTRIBUTE_ASSETCATALOG_COMPILER_APPICON_NAME AppIcon
     XCODE_ATTRIBUTE_ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME LaunchImage
 )
 

--- a/Gems/Atom/Asset/Shader/Config/Platform/iOS/shader_build_options.json
+++ b/Gems/Atom/Asset/Shader/Config/Platform/iOS/shader_build_options.json
@@ -5,7 +5,6 @@
         "azslc": ["--min-descriptors=64,4,-1,-1,-1" //Sets,Spaces,Samplers,Textures,Buffers
                 , "--unique-idx"
                 , "--namespace=mt"
-                , "--namespace=vk"
                 , "--pad-root-const"
         ],
         "dxc": ["-spirv"

--- a/cmake/Platform/Common/Clang/Configurations_clang.cmake
+++ b/cmake/Platform/Common/Clang/Configurations_clang.cmake
@@ -33,6 +33,7 @@ ly_append_configurations_options(
         -Wno-reorder
         -Wno-switch
         -Wno-undefined-var-template
+        -Wno-deprecated-declarations # workaround for MTLCommandBufferErrorBlacklisted is deprecated
 
         ###################
         # Enabled warnings (that are disabled by default)


### PR DESCRIPTION
## What does this PR do?

This is PR includes misc fixes for build issues of the default New Project on macOS/iOS.

Ventura 13.4.1 and Xcode 14.3.1. were used.

1. [DynamicModuleHandle_iOS.cpp](https://github.com/carbonated-dev/o3de/compare/carbonated/stabilization/2305...carbonated-dev:o3de:akostin/PlatformFixes?expand=1#diff-41a19ce217a5212b617c739039231cd6e9c7ed3e7fc2eaae5bbe9f410d274624)

Fix for a link issue.

2. [launcher_project_ios.cmake](https://github.com/carbonated-dev/o3de/compare/carbonated/stabilization/2305...carbonated-dev:o3de:akostin/PlatformFixes?expand=1#diff-8198c29f868b97b48104425f25711c4db5a726f221026142ac4ce788774489e3)

Asset naming issue.

3. [shader_build_options.json](https://github.com/carbonated-dev/o3de/compare/carbonated/stabilization/2305...carbonated-dev:o3de:akostin/PlatformFixes?expand=1#diff-afd8d7a1ef42b0766f47f4d552444b7481216a1170750ae79b4404c25ddcdc05) 

Fix some iOS shader generation issues. Please see [this discord thread](https://discord.com/channels/805939474655346758/816043793576886273/1093658637823660092) for details.

4. [Configurations_clang.cmake](https://github.com/carbonated-dev/o3de/compare/carbonated/stabilization/2305...carbonated-dev:o3de:akostin/PlatformFixes?expand=1#diff-ed335a5307bd9b053c511348493d1b4f123510de28a2fa87c4c337882f97d181)

Workaround for warnings as errors triggered by deprecated declarations like `MTLCommandBufferError.MTLCommandBufferErrorBlacklisted` or `MTLRenderPipelineDescriptor.sampleCount` 


## How was this PR tested?

Local build succeeded.
