### PR TITLE
Fix the order of adding typed instances of system assets

### DIFF
--- a/Code/LauncherUnified/Launcher.cpp
+++ b/Code/LauncherUnified/Launcher.cpp
@@ -533,6 +533,13 @@ namespace O3DELauncher
 
             if (CreateSystemInterface)
             {
+                // carbonated begin (akostin/mp305): Fix the order of adding typed instances of system assets
+                // Process queued events before creating system interface.
+                // In particular, it is required to add typed instances of system assets (StreamingImageAsset, ResourcePoolAsset,
+                // AttachmentImageAsset) to the InstanceDatabase.
+                AZ::TickBus::ExecuteQueuedEvents();
+                // carbonated end
+
                 systemInitParams.pSystem = CreateSystemInterface(systemInitParams);
             }
         }


### PR DESCRIPTION
## What does this PR do?

Process queued events before creating system interface. In particular, it is required to add typed instances of system assets (StreamingImageAsset, ResourcePoolAsset, AttachmentImageAsset) to the InstanceDatabase.

## How was this PR tested?

Tested locally.
