### PR TITLE
Mobile render pipeline alpha cutout and background fixes

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/ForwardPass_StandardLighting_CustomZ.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/ForwardPass_StandardLighting_CustomZ.azsli
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+ 
+#define MATERIALPIPELINE_SHADER_HAS_PIXEL_STAGE 1
+
+// TODO(MaterialPipeline): In the end, after all refactoring and rearranging of our shader code is done, some of these flags might become unnecessary and should be re-evaluated.
+// Some of these setting used to be in ShaderQualityOptions.azsli as a basic/limited solution for multiple pipelines.
+// TODO(MaterialPipeline), instead of UNIFIED_FORWARD_OUTPUT, fork ForwardPassOutput.azsli
+#define UNIFIED_FORWARD_OUTPUT 1
+#define FORCE_IBL_IN_FORWARD_PASS 1
+#define FORCE_EARLY_DEPTH_STENCIL 0
+#define OUTPUT_DEPTH 0
+#define FORCE_OPAQUE 1
+#define OUTPUT_SUBSURFACE 0
+
+#define ENABLE_TRANSMISSION 0
+#define ENABLE_SHADER_DEBUGGING 0
+#define ENABLE_CLEAR_COAT 0
+#define ENABLE_SHADOWS 1
+#define ENABLE_FULLSCREEN_SHADOW 0
+#define ENABLE_LIGHT_CULLING 0
+#define ENABLE_DISK_LIGHTS 1
+#define ENABLE_AREA_LIGHTS 0
+#define ENABLE_AREA_LIGHT_VALIDATION    0
+#define ENABLE_PHYSICAL_SKY 0
+#define ENABLE_MERGE_FILMIC_TONEMAP 1
+#define ENABLE_DECALS 0
+#define ENABLE_REFLECTIONPROBE_PARALLAXCORRECTION 0
+#define ENABLE_REFLECTIONPROBE_BLENDING 0
+#define ENABLE_SPECULARAA 0
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include MATERIAL_TYPE_AZSLI_FILE_PATH
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include <Atom/Features/Pipeline/Forward/ForwardPassSrg.azsli>
+
+// TODO(MaterialPipeline): I don't like how this file #includes something from BasePBR. I'd rather it include a file
+// called StandardPBR_LightingData.azsli which just #includes the BasePBR file. Otherwise this looks suspicious like
+// a mistake of some kind.
+#include "../../../Shaders/Materials/BasePBR/BasePBR_LightingData.azsli"
+#include "../../../Shaders/Materials/StandardPBR/StandardPBR_LightingBrdf.azsli"
+#include "../../../Shaders/Materials/StandardPBR/StandardPBR_LightingEval.azsli"
+
+#include "MobileForwardPassVertexAndPixel.azsli"
+
+

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/ForwardPass_StandardLighting_CustomZ.shader.template
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/ForwardPass_StandardLighting_CustomZ.shader.template
@@ -1,0 +1,50 @@
+{
+    "Source" : "TEMPLATE_AZSL_PATH",
+
+    "DepthStencilState" :
+    {
+        "Depth" :
+        {
+            "Enable" : true,
+            "CompareFunc" : "GreaterEqual"
+        },
+        "Stencil" :
+        {
+            "Enable" : true,
+            "ReadMask" : "0x00",
+            "WriteMask" : "0xFF",
+            "FrontFace" :
+            {
+                "Func" : "Always",
+                "DepthFailOp" : "Keep",
+                "FailOp" : "Keep",
+                "PassOp" : "Replace"
+            },
+            "BackFace" :
+            {
+                "Func" : "Always",
+                "DepthFailOp" : "Keep",
+                "FailOp" : "Keep",
+                "PassOp" : "Replace"
+            }
+        }
+    },
+
+    "ProgramSettings":
+    {
+      "EntryPoints":
+      [
+        {
+          "name": "VertexShader",
+          "type": "Vertex"
+        },
+        {
+          "name": "PixelShader",
+          "type": "Fragment"
+        }
+      ]
+    },
+
+    "DrawList" : "mobileForward"
+}
+

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/MobilePipeline.materialpipeline
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/MobilePipeline.materialpipeline
@@ -13,6 +13,11 @@
             "tag": "forward"
         },
         {
+            "shader": "./ForwardPass_StandardLighting_CustomZ.shader.template",
+            "azsli": "./ForwardPass_StandardLighting_CustomZ.azsli",
+            "tag": "forward_customZ"
+        },
+        {
             "shader": "./Transparent_StandardLighting.shader.template",
             "azsli": "./Transparent_StandardLighting.azsli",
             "tag": "transparent"
@@ -21,6 +26,11 @@
             "shader": "../Common/ShadowmapPass.shader.template",
             "azsli": "../Common/DepthPass.azsli",
             "tag": "shadow"
+        },
+        {
+            "shader": "../Common/ShadowmapPass_CustomZ.shader.template",
+            "azsli": "../Common/DepthPass_CustomZ.azsli",
+            "tag": "shadow_customZ"
         },
         // TODO(MaterialPipeline): The TintedTransparent shaders uses the same azsli file as the normal Transparent shaders, they just need
         // a different blend state. This results in a redundant shader compilation. We should find some way to reuse the same compiled bytecode
@@ -59,7 +69,6 @@
                 "type": "Bool",
                 "defaultValue": false
             }
-            // Note we don't include "hasPerPixelDepth" because the VR pipeline will be highly optimized, and unlikely to ever support PDO or similar features.
         ],
         "functors": 
         [

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/MobilePipelineScript.lua
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/MobilePipelineScript.lua
@@ -27,7 +27,9 @@ function MaterialTypeSetup(context)
             Warning("The multi view pipeline does not support the Enhanced lighting model. Will use Standard lighting as a fallback.")
         end
         
+        context:IncludeShader("ShadowmapPass_CustomZ")
         context:IncludeShader("ForwardPass_StandardLighting")
+        context:IncludeShader("ForwardPass_StandardLighting_CustomZ")
         context:IncludeShader("Transparent_StandardLighting")
         context:IncludeShader("TintedTransparent_StandardLighting")
         return true

--- a/Gems/Atom/Feature/Common/Assets/Passes/Mobile/Forward.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/Mobile/Forward.pass
@@ -52,9 +52,9 @@
                     "LoadStoreAction": {
                         "ClearValue": {
                             "Value": [
-                                0.0,
-                                0.0,
-                                0.0,
+                                0.4,
+                                0.4,
+                                0.4,
                                 0.0
                             ]
                         },

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PostProcessing/Tonemap.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PostProcessing/Tonemap.azsli
@@ -12,7 +12,12 @@
 real3 ApplyFilmicTonemap(real3 color)
 {
     // Apply filmic curve. 
-    return (color * (6.2 * color + 0.5)) / (color * (6.2 * color + 1.7)+ 0.06);
+    real a = 2.51f; // 6.2
+    real b = 0.03f; // 0.5
+    real c = 2.43f; // 6.2
+    real d = 0.59f; // 1.7
+    real e = 0.14f; // 0.06
+    return saturate((color * (a * color + b)) / (color * (c * color + d)+ e));
 }
 
 real3 ApplyManualExposure(real3 color, real exposure)


### PR DESCRIPTION
## What does this PR do?
- Alpha cutout support for both forward and shadow passes. (Tree rendering issue)
- Skybox issue with cloud (change background color from black to grey)
- Adjust the flimic mapping (it was too bright)

## How was this PR tested?

A level with cutout material in Editor
