### PR TITLE
Revert legacy pNetwork in SSystemGlobalEnvironment

### DIFF
--- a/Code/Legacy/CryCommon/ISystem.h
+++ b/Code/Legacy/CryCommon/ISystem.h
@@ -45,6 +45,11 @@ namespace AZ::IO
 {
     struct IArchive;
 }
+// carbonated begin (akostin/mp-402-1): Revert pNetwork in SSystemGlobalEnvironment
+#if defined(CARBONATED)
+struct INetwork;
+#endif
+// carbonated end
 struct IConsole;
 struct IRemoteConsole;
 struct IRenderer;
@@ -585,6 +590,11 @@ struct SSystemUpdateStats
 //   ISystem
 struct SSystemGlobalEnvironment
 {
+    // carbonated begin (akostin/mp-402-1): Revert pNetwork in SSystemGlobalEnvironment
+#if defined(CARBONATED)
+    INetwork* pNetwork;
+#endif
+    // carbonated end
     AZ::IO::IArchive*          pCryPak;
     AZ::IO::FileIOBase*        pFileIO;
     ICryFont*                  pCryFont;

--- a/Code/Legacy/CrySystem/CMakeLists.txt
+++ b/Code/Legacy/CrySystem/CMakeLists.txt
@@ -10,6 +10,11 @@ o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} ${O
 
 add_subdirectory(XML)
 
+if(CARBONATED)
+set(azcommonaddon_dependency Legacy::CryCommonAddon)
+set(aznetworkaddon_dependency Legacy::CryNetworkAddon)
+endif()
+
 ly_add_target(
     NAME CrySystem.Static STATIC
     NAMESPACE Legacy
@@ -32,6 +37,8 @@ ly_add_target(
             Legacy::CrySystem.XMLBinary
             Legacy::RemoteConsoleCore
             AZ::AzFramework
+            ${azcommonaddon_dependency}
+            ${aznetworkaddon_dependency}
         PUBLIC
             Gem::AudioSystem.API
 )

--- a/Code/Legacy/CrySystem/System.cpp
+++ b/Code/Legacy/CrySystem/System.cpp
@@ -38,6 +38,7 @@
 #if defined(CARBONATED)
 #include <CryCommon/CrySystemPostTickBus.h>
 #include <CryCommon/CrySystemPreTickBus.h>
+#include "CryNetwork/CryNetwork.h"
 #endif
 // carbonated end
 
@@ -372,6 +373,11 @@ void CSystem::ShutDown()
 
     SAFE_RELEASE(m_env.pMovieSystem);
     SAFE_RELEASE(m_env.pCryFont);
+
+    // carbonated begin (akostin/mp-402-1): Revert pNetwork in SSystemGlobalEnvironment
+    CryNetwork::NetworkInstance::Release();
+    // carbonated end
+
     if (m_env.pConsole)
     {
         ((CXConsole*)m_env.pConsole)->FreeRenderResources();

--- a/Code/Legacy/CrySystem/SystemInit.cpp
+++ b/Code/Legacy/CrySystem/SystemInit.cpp
@@ -1065,7 +1065,7 @@ bool CSystem::Init(const SSystemInitParams& startupParams)
         // NETWORK
         //////////////////////////////////////////////////////////////////////////
 
-        m_env.pNetwork = CryNetwork::NetworkInstance::Get();
+        m_env.pNetwork = CryNetwork::NetworkInstance::Create();
         if (!m_env.pNetwork)
         {
             AZ_Assert(false, "Network System did not initialize correctly; it was not found in the system environment.");

--- a/Code/Legacy/CrySystem/SystemInit.cpp
+++ b/Code/Legacy/CrySystem/SystemInit.cpp
@@ -87,6 +87,12 @@
 #include <AzFramework/Archive/Archive.h>
 #include <CrySystemBus.h>
 
+// carbonated begin (akostin/mp-402-1): Revert pNetwork in SSystemGlobalEnvironment
+#if defined(CARBONATED)
+#include "CryNetwork/CryNetwork.h"
+#endif
+// carbonated end
+
 #if defined(ANDROID)
 #include <AzCore/Android/Utils.h>
 #endif
@@ -1052,6 +1058,22 @@ bool CSystem::Init(const SSystemInitParams& startupParams)
                 &AzFramework::InputSystemCursorRequests::SetSystemCursorState,
                 AzFramework::SystemCursorState::ConstrainedAndHidden);
         }
+
+        // carbonated begin (akostin/mp-402-1): Revert pNetwork in SSystemGlobalEnvironment
+#if defined(CARBONATED)
+        //////////////////////////////////////////////////////////////////////////
+        // NETWORK
+        //////////////////////////////////////////////////////////////////////////
+
+        m_env.pNetwork = CryNetwork::NetworkInstance::Get();
+        if (!m_env.pNetwork)
+        {
+            AZ_Assert(false, "Network System did not initialize correctly; it was not found in the system environment.");
+            return false;
+        }
+        InlineInitializationProcessing("CSystem::Init InitNetwork");
+#endif
+        // carbonated end
 
         // CONSOLE
         //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## What does this PR do?

Revert legacy pNetwork in SSystemGlobalEnvironment as it is the most relevant structure for such a singleton.

## How was this PR tested?

Built locally
