### PR TITLE
Avoid duplicating logs in the debugger console

### DIFF
--- a/Code/Framework/AzCore/AzCore/Debug/Trace.cpp
+++ b/Code/Framework/AzCore/AzCore/Debug/Trace.cpp
@@ -569,7 +569,7 @@ namespace AZ::Debug
             window = g_dbgSystemWnd;
         }
 
-        Platform::OutputToDebugger(window, message);
+        //Platform::OutputToDebugger(window, message); // carbonated (akostin/mp-402-2): Avoid duplicating logs in the debugger console
 
         if (!DebugInternal::g_suppressEBusCalls)
         {
@@ -584,6 +584,7 @@ namespace AZ::Debug
             }
         }
 
+        Platform::OutputToDebugger(window, message); // carbonated (akostin/mp-402-2): Avoid duplicating logs in the debugger console
         RawOutput(window, message);
     }
 


### PR DESCRIPTION
## What does this PR do?

Existed code of Trace::Output duplicated debug console output (formatted with timestamp and raw), issued by AZ_Printf or AZ_TracePrintf

## How was this PR tested?

Built locally and verified that no duplication occurs. 
