### PR TITLE
Reverted pGame in SSystemGlobalEnvironment

### DIFF
--- a/Code/Legacy/CryCommon/ISystem.h
+++ b/Code/Legacy/CryCommon/ISystem.h
@@ -48,6 +48,7 @@ namespace AZ::IO
 // carbonated begin (akostin/mp-402-1): Revert pNetwork in SSystemGlobalEnvironment
 #if defined(CARBONATED)
 struct INetwork;
+struct IGame;
 #endif
 // carbonated end
 struct IConsole;
@@ -593,6 +594,7 @@ struct SSystemGlobalEnvironment
     // carbonated begin (akostin/mp-402-1): Revert pNetwork in SSystemGlobalEnvironment
 #if defined(CARBONATED)
     INetwork* pNetwork;
+    IGame* pGame;
 #endif
     // carbonated end
     AZ::IO::IArchive*          pCryPak;
@@ -813,6 +815,14 @@ struct ISystem
     virtual ::IConsole* GetIConsole() = 0;
     virtual IRemoteConsole* GetIRemoteConsole() = 0;
     virtual ISystemEventDispatcher* GetISystemEventDispatcher() = 0;
+
+    // carbonated begin (akostin/mp-402-2): Revert pGame in SSystemGlobalEnvironment
+#if defined(CARBONATED)
+    virtual IGame* GetIGame() = 0;
+    virtual void SetIGame(IGame* pGame) = 0;
+#endif
+    // carbonated end
+
 
     virtual bool IsDevMode() const = 0;
     //////////////////////////////////////////////////////////////////////////

--- a/Code/Legacy/CrySystem/System.h
+++ b/Code/Legacy/CrySystem/System.h
@@ -184,6 +184,14 @@ public:
     ICmdLine* GetICmdLine() override{ return m_pCmdLine; }
     ILevelSystem* GetILevelSystem() override;
     ISystemEventDispatcher* GetISystemEventDispatcher() override { return m_pSystemEventDispatcher; }
+
+    // carbonated begin (akostin/mp-402-2): Revert pGame in SSystemGlobalEnvironment
+#if defined(CARBONATED)
+    void SetIGame(IGame* pGame) override { m_env.pGame = pGame; }
+    IGame* GetIGame() override { return m_env.pGame; }
+#endif
+    // carbonated end
+
     //////////////////////////////////////////////////////////////////////////
     // retrieves the perlin noise singleton instance
     CPNoise3* GetNoiseGen() override;


### PR DESCRIPTION
## What does this PR do?

Reverted pGame in SSystemGlobalEnvironment to avoid issues for non monolithic builds

## How was this PR tested?

Tested locally
