### PR TITLE
Revert bClient, bServer, bMultiplayer in SSystemGlobalEnvironment

### DIFF
--- a/Code/Legacy/CryCommon/ISystem.h
+++ b/Code/Legacy/CryCommon/ISystem.h
@@ -595,6 +595,9 @@ struct SSystemGlobalEnvironment
 #if defined(CARBONATED)
     INetwork* pNetwork;
     IGame* pGame;
+    // Used to tell if this is a server/multiplayer instance
+    bool bServer;
+    bool bMultiplayer;
 #endif
     // carbonated end
     AZ::IO::IArchive*          pCryPak;
@@ -621,6 +624,23 @@ struct SSystemGlobalEnvironment
     bool                                            bToolMode;
 
     int                                             retCode = 0;
+
+    // carbonated begin (akostin/mp-413-1): Revert bClient, bServer, bMultiplayer in SSystemGlobalEnvironment
+#if defined(CARBONATED)
+    ILINE const bool IsClient() const
+    {
+#if defined(CONSOLE)
+        return true;
+#else
+        return bClient;
+#endif
+    }
+    ILINE void SetIsClient(bool isClient)
+    {
+        bClient = isClient;
+    }
+#endif
+    // carbonated end
 
     ILINE const bool IsDedicated() const
     {
@@ -702,6 +722,12 @@ struct SSystemGlobalEnvironment
 
 #if !defined(CONSOLE)
 private:
+    // carbonated begin (akostin/mp-413-1): Revert bClient, bServer, bMultiplayer in SSystemGlobalEnvironment
+#if defined(CARBONATED)
+    bool bClient;
+#endif
+    // carbonated end
+
     bool bEditor;          // Engine is running under editor.
     bool bEditorGameMode;  // Engine is in editor game mode.
     bool bEditorSimulationMode;  // Engine is in editor simulation mode.

--- a/Code/Legacy/CrySystem/System.cpp
+++ b/Code/Legacy/CrySystem/System.cpp
@@ -205,6 +205,14 @@ CSystem::CSystem()
     m_env.bIgnoreAllAsserts = false;
     m_env.bNoAssertDialog = false;
 
+    // carbonated begin (akostin/mp-413-1): Revert bClient, bServer, bMultiplayer in SSystemGlobalEnvironment
+#if defined(CARBONATED)
+#if !defined(CONSOLE)
+    m_env.SetIsClient(false);
+#endif
+#endif
+    // carbonated end
+
     //////////////////////////////////////////////////////////////////////////
 
     m_sysNoUpdate = NULL;


### PR DESCRIPTION
## What does this PR do?

Revertув bClient, bServer, bMultiplayer in SSystemGlobalEnvironment

## How was this PR tested?

Tested locally
