### PR TITLE
Add missed entity preprocessing on level loading

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesManager.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesManager.cpp
@@ -564,7 +564,7 @@ namespace AzFramework
 
 // Gruber patch begin // VMED // Preprocess entity components for a level spawnable
 #ifdef CARBONATED
-                constexpr const char* levelSpawnableName = "centralplaza.spawnable"; // FIXME change to evaluated level name or use another way to get the root level entity
+                constexpr const char* levelSpawnableName = "centralplaza.spawnable"; // FIXME change to evaluated level name or use another way to detect a level spawnable
                 const bool isLevelSpawnable = ::strstr(ticket.m_spawnable.GetHint().c_str(), levelSpawnableName) != nullptr;
                 if (isLevelSpawnable)
                 {

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesManager.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesManager.cpp
@@ -562,6 +562,30 @@ namespace AzFramework
                     request.m_preInsertionCallback(request.m_ticketId, SpawnableEntityContainerView(newEntitiesBegin, newEntitiesEnd));
                 }
 
+// Gruber patch begin // VMED // Preprocess entity components for a level spawnable
+#ifdef CARBONATED
+                constexpr const char* levelSpawnableName = "centralplaza.spawnable"; // FIXME change to evaluated level name or use another way to get the root level entity
+                const bool isLevelSpawnable = ::strstr(ticket.m_spawnable.GetHint().c_str(), levelSpawnableName) != nullptr;
+                if (isLevelSpawnable)
+                {
+                    AzFramework::EntityContext* gameContext = nullptr;
+                    AzFramework::GameEntityContextRequestBus::BroadcastResult(
+                        gameContext, &AzFramework::GameEntityContextRequestBus::Events::GetGameEntityContextInstance);
+                    if (gameContext != nullptr)
+                    {
+                        AzFramework::EntityContextEventBus::Event(
+                            gameContext->GetContextId(),
+                            &AzFramework::EntityContextEventBus::Events::OnEntityContextLoadedFromStream,
+                            ticket.m_spawnedEntities);
+                    }
+                    else
+                    {
+                        AZ_Error("SpawnableEntitiesManager::ProcessRequest", false, "Game entity context for level is not found");
+                    }
+                }
+#endif
+// Gruber patch begin // VMED // Preprocess netbinding entity components for level
+
                 // Add to the game context, now the entities are active
                 for (auto it = newEntitiesBegin; it != newEntitiesEnd; ++it)
                 {


### PR DESCRIPTION
## What does this PR do?

Added the missed entity preprocessing on level loading

## How was this PR tested?

Verified locally


##  Note
Push only together with https://github.com/carbonated-dev/o3de-gruber/pull/290