### PR TITLE
[MADPORT-422] Remap the level entity ids with the same values on server and clients by the same way on the different C++ platforms (Win, Mac, iOS, Linux, etc)

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesManager.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesManager.cpp
@@ -13,6 +13,7 @@
 #include <AzCore/Settings/SettingsRegistry.h>
 #include <AzCore/std/parallel/scoped_lock.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
+#include <AzCore/std/sort.h> // Gruber patch // VMED
 #include <AzFramework/Components/TransformComponent.h>
 #include <AzFramework/Entity/GameEntityContextBus.h>
 #include <AzFramework/Spawnable/Spawnable.h>
@@ -467,13 +468,13 @@ namespace AzFramework
         // Sort entity ids to get the same id remap order on the different platforms (Win, Mac, iOS, etc)
         AzFramework::EntityIdList sortedEntityIds;
         sortedEntityIds.reserve(entities.size());
-        for (auto& entity : entities)
+        for (const auto& entity : entities)
         {
             sortedEntityIds.push_back(entity->GetId());
         }
-        std::sort(sortedEntityIds.begin(), sortedEntityIds.end());
+        AZStd::sort(sortedEntityIds.begin(), sortedEntityIds.end());
 
-        for (auto& entityId : sortedEntityIds)
+        for (const auto& entityId : sortedEntityIds)
         {
             idMap.emplace(entityId, seedEntityId);
             seedEntityId = AZ::EntityId(static_cast<AZ::u64>(seedEntityId)+1);

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesManager.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesManager.cpp
@@ -464,9 +464,18 @@ namespace AzFramework
         idMap.reserve(entities.size());
         previouslySpawned.reserve(entities.size());
 
+        // Sort entity ids to get the same id remap order on the different platforms (Win, Mac, iOS, etc)
+        AzFramework::EntityIdList sortedEntityIds;
+        sortedEntityIds.reserve(entities.size());
         for (auto& entity : entities)
         {
-            idMap.emplace(entity->GetId(), seedEntityId);
+            sortedEntityIds.push_back(entity->GetId());
+        }
+        std::sort(sortedEntityIds.begin(), sortedEntityIds.end());
+
+        for (auto& entityId : sortedEntityIds)
+        {
+            idMap.emplace(entityId, seedEntityId);
             seedEntityId = AZ::EntityId(static_cast<AZ::u64>(seedEntityId)+1);
         }
     }


### PR DESCRIPTION
https://jira.carbonated.com:8443/browse/MADPORT-422

## What does this PR do?

Remapped the level entity ids with the same values on server and clients by the same way on the different C++ platforms (Win, Mac, iOS, Linux, etc.)

## How was this PR tested?

Verified locally
