### PR TITLE
Fixes for iPhone 8 Plus which is close to min spec and is a tier 1 AB device 

### DIFF
--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/AzslShaderBuilderSystemComponent.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/AzslShaderBuilderSystemComponent.cpp
@@ -83,7 +83,7 @@ namespace AZ
             // Register Shader Asset Builder
             AssetBuilderSDK::AssetBuilderDesc shaderAssetBuilderDescriptor;
             shaderAssetBuilderDescriptor.m_name = "Shader Asset Builder";
-            shaderAssetBuilderDescriptor.m_version = 121; // Add support for metal shader language 2.2
+            shaderAssetBuilderDescriptor.m_version = 122; // Fix the handling of typed buffers for metal shader related dummy entries
             shaderAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern( AZStd::string::format("*.%s", RPI::ShaderSourceData::Extension), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
             shaderAssetBuilderDescriptor.m_busId = azrtti_typeid<ShaderAssetBuilder>();
             shaderAssetBuilderDescriptor.m_createJobFunction = AZStd::bind(&ShaderAssetBuilder::CreateJobs, &m_shaderAssetBuilder, AZStd::placeholders::_1, AZStd::placeholders::_2);
@@ -108,7 +108,7 @@ namespace AZ
                 shaderVariantAssetBuilderDescriptor.m_name = "Shader Variant Asset Builder";
                 // Both "Shader Variant Asset Builder" and "Shader Asset Builder" produce ShaderVariantAsset products. If you update
                 // ShaderVariantAsset you will need to update BOTH version numbers, not just "Shader Variant Asset Builder".
-                shaderVariantAssetBuilderDescriptor.m_version = 38; // Add support for metal shader language 2.2
+                shaderVariantAssetBuilderDescriptor.m_version = 39; // // Fix the handling of typed buffers for metal shader related dummy entries
                 shaderVariantAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern(AZStd::string::format("*.%s", HashedVariantListSourceData::Extension), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
                 shaderVariantAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern(AZStd::string::format("*.%s", HashedVariantInfoSourceData::Extension), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
                 shaderVariantAssetBuilderDescriptor.m_busId = azrtti_typeid<ShaderVariantAssetBuilder>();

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/MobilePipelineScript.lua
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/MobilePipelineScript.lua
@@ -36,7 +36,7 @@ function MaterialTypeSetup(context)
     end
     
     if(lightingModel == "Skin") then
-        Error("The low end pipeline does not support the Skin lighting model. This combination should not be used at runtime.")
+        Error("The mobile pipeline does not support the Skin lighting model. This combination should not be used at runtime.")
         -- This returns 'true' to pass the build, the surface won't be rendered at runtime.
         -- TODO(MaterialPipeline): Instead of rendering nothing, either render an error shader (like a magenta surface) or fall back to StandardLighting.
         --                         For an error shader, .materialtype needs to have new field for an ObjectSrg azsli file separate from "materialShaderCode", so that

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
@@ -715,7 +715,20 @@ namespace AZ
                     structuredBufferTempStructs += AZStd::string::format("struct type_RWStructuredDummyBuffer%i_DescSet%i\n{\n    DummySRG_%s_DescSet%i _m0[%i];\n};\n", regId, groupLayoutIndex, shaderInputBuffer.m_name.GetCStr(), groupLayoutIndex, shaderInputBuffer.m_count);
 
                     //Create the final resource entry to be added to the set
-                    AZStd::string dummyResource = AZStd::string::format("device type_RWStructuredDummyBuffer%i_DescSet%i* dummyStructuredBuffer%i [[id(%i)]];", regId, groupLayoutIndex, regId, regId);
+                    AZStd::string dummyResource;
+                    switch(shaderInputBuffer.m_type)
+                    {
+                        case RHI::ShaderInputBufferType::Typed:
+                        {
+                            dummyResource = AZStd::string::format("texture_buffer<float> TypedDummyBuffer%i [[id(%i)]];", regId, regId);
+                            break;
+                        }
+                        default:
+                        {
+                            dummyResource = AZStd::string::format("device type_RWStructuredDummyBuffer%i_DescSet%i* dummyStructuredBuffer%i [[id(%i)]];", regId, groupLayoutIndex, regId, regId);
+                            break;
+                        }
+                    }
                     m_argBufferEntries.insert(AZStd::make_pair(dummyResource, regId));
                 }
                 else

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineLibrary.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineLibrary.cpp
@@ -76,6 +76,14 @@ namespace AZ
             {
                 m_renderPipelineStates.emplace(hash, pipelineStateDesc);
             }
+            else
+            {
+                if (RHI::Validation::IsEnabled())
+                {
+                    NSLog(@" error => %@ ", [*error userInfo] );
+                }
+                AZ_Assert(false, "Could not create Pipeline object!.");
+            }
             return graphicsPipelineState;
         }
         

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineState.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineState.cpp
@@ -187,7 +187,15 @@ namespace AZ
                 m_graphicsPipelineState = [device.GetMtlDevice() newRenderPipelineStateWithDescriptor:m_renderPipelineDesc options : MTLPipelineOptionBufferTypeInfo reflection : &ref error : &error];
             }
             
-            AZ_Assert(m_graphicsPipelineState, "Could not create Pipeline object!.");
+            if(m_graphicsPipelineState==nil)
+            {
+                if (RHI::Validation::IsEnabled())
+                {
+                    NSLog(@" error => %@ ", [error userInfo] );
+                }
+                AZ_Assert(false, "Could not create Pipeline object!.");
+            }
+            
             m_pipelineStateMultiSampleState = descriptor.m_renderStates.m_multisampleState;
             
             //Cache the rasterizer state


### PR DESCRIPTION
## What does this PR do?

- Fixed a gpu crash related to skinning.  For tier 1 Argument Buffer devices it seems like size of the pointer (device type_RWStructuredDummyBuffer1_DescSet0* vs texture_buffer<float>) differs in size and hence it messed up the pointers within an Argument buffer for Skinning shader.
- Bumped the shader version
- Added some code to print the error log in case a PSO compilation fails.

## How was this PR tested?

Tested via running centralplaza_flythrough_stripped. on iPhone 8 Plus
![IMG_0011](https://github.com/carbonated-dev/o3de/assets/47460854/485ca5f7-b126-4a8c-a197-ac7414ce7e07)
