### PR TITLE
Ltullues/pendingcomponentfix

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorDisabledCompositionComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorDisabledCompositionComponent.cpp
@@ -66,7 +66,7 @@ namespace AzToolsFramework
                         // the template is null and the component should not be added.
                         if (component && component->GetUnderlyingComponentType() != genericComponentWrapperTypeId)
                         {
-                            componentInstance->m_disabledComponents.emplace(componentKey, component);
+                            componentInstance->AddDisabledComponent(component);
                         }
                     }
                 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorPendingCompositionComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorPendingCompositionComponent.cpp
@@ -67,7 +67,7 @@ namespace AzToolsFramework
                         // the template is null and the component should not be added.
                         if (component && component->GetUnderlyingComponentType() != genericComponentWrapperTypeId)
                         {
-                            componentInstance->m_pendingComponents.emplace(componentKey, component);
+                            componentInstance->AddPendingComponent(component);
                         }
                     }
                 }


### PR DESCRIPTION
## What does this PR do?

EditorPendingCompositionComponent will crash during destruction because it holds on to invalid component pointers.  This is because EditorPendingCompositionComponentSerializer adds the pending components by old/invalid keys.  The fix is for EditorPendingCompositionComponentSerializer to use AddPendingComponent so the correct key can be used during insertion into m_pendingComponents.  

This, then, allows RemovePendingComponent to find and remove the entry as expected later on.

## How was this PR tested?

Local testing - open up a level with a entities that contain EditorPendingCompositionComponents with keys that do not match what the respective component "GetSerializedIdentifier" returns.  Delete these entities.  Without the fix a crash will happen in the dtor of EditorPendingCompositionComponents when manually deleting the component pointers out of m_pendingComponents.
