### PR TITLE
Add an external Entity Id remapper to SpawnableEntitiesManager

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesInterface.h
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesInterface.h
@@ -231,6 +231,12 @@ namespace AzFramework
         AZ::SerializeContext* m_serializeContext { nullptr };
         //! The priority at which this call will be executed.
         SpawnablePriority m_priority { SpawnablePriority_Default };
+// Gruber patch begin // VMED // Custom entity id remapper
+#ifdef CARBONATED
+        //! Custom entity id remapper.
+        AZStd::unordered_map<AZ::EntityId, AZ::EntityId> m_customEntityIdMapper;
+#endif
+// Gruber patch end // VMED 
     };
 
     struct SpawnEntitiesOptionalArgs final

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesManager.h
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesManager.h
@@ -142,6 +142,11 @@ namespace AzFramework
             Ticket* m_ticket;
             EntitySpawnTicket::Id m_ticketId;
             uint32_t m_requestId;
+// Gruber patch begin // VMED // Custom entity id remapper
+#ifdef CARBONATED
+            EntityIdToEntityIdMap m_customEntityIdMapper;
+#endif
+// Gruber patch end // VMED 
         };
         struct SpawnEntitiesCommand final
         {
@@ -331,6 +336,10 @@ namespace AzFramework
         // Support the same generated entity ids on all clients and on the server
         void InitializeEntityIdMappingsWithSeed(
             AZ::EntityId seedEntityId, const Spawnable::EntityList& entities, EntityIdMap& idMap, AZStd::unordered_set<AZ::EntityId>& previouslySpawned);
+
+        void InitializeEntityIdMappingsWithExternalRemapper(
+            const Spawnable::EntityList& entities, EntityIdMap& idMap, AZStd::unordered_set<AZ::EntityId>& previouslySpawned,
+            const EntityIdToEntityIdMap& customEntityIdMapper);
 #endif
 // Gruber patch end. // LVB. // Support unique instances
 


### PR DESCRIPTION
## What does this PR do?

Add an external Entity Id remapper
This feature used in PR https://github.com/carbonated-dev/o3de-gruber/pull/309

## How was this PR tested?

Locally
