### PR TITLE
Fixed multiple issues in particle rendering with mobile render pipeline.

### DIFF
--- a/AutomatedTesting/Registry/viewport.setreg
+++ b/AutomatedTesting/Registry/viewport.setreg
@@ -4,7 +4,8 @@
       "SwitchableRenderPipelines": [
         "Passes/LowEndRenderPipeline.azasset",
         "Passes/MainRenderPipeline.azasset",
-        "Passes/MultiViewRenderPipeline.azasset"
+        "Passes/MultiViewRenderPipeline.azasset",
+        "Passes/Mobile/MobileRenderPipeline.azasset"
       ]
     }
   }

--- a/Code/Legacy/CrySystem/System.cpp
+++ b/Code/Legacy/CrySystem/System.cpp
@@ -374,8 +374,10 @@ void CSystem::ShutDown()
     SAFE_RELEASE(m_env.pMovieSystem);
     SAFE_RELEASE(m_env.pCryFont);
 
+#if defined(CARBONATED)
     // carbonated begin (akostin/mp-402-1): Revert pNetwork in SSystemGlobalEnvironment
     CryNetwork::NetworkInstance::Release();
+#endif
     // carbonated end
 
     if (m_env.pConsole)

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/TintedTransparent_StandardLighting.shader.template
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/TintedTransparent_StandardLighting.shader.template
@@ -54,6 +54,6 @@
       ]
     },
 
-    "DrawList" : "mobileTransparent"
+    "DrawList" : "transparent"
 }
 

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/Transparent_StandardLighting.shader.template
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/Transparent_StandardLighting.shader.template
@@ -54,6 +54,6 @@
       ]
     },
 
-    "DrawList" : "mobileTransparent"
+    "DrawList" : "transparent"
 }
 

--- a/Gems/Atom/Feature/Common/Assets/Passes/Mobile/Pipeline.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/Mobile/Pipeline.pass
@@ -122,7 +122,7 @@
                     ]
                 },
                 {
-                    "Name": "TransparentPass",
+                    "Name": "MobileTransparentPass",
                     "TemplateName": "MobileTransparentParentTemplate",
                     "Connections": [
                         {
@@ -149,7 +149,7 @@
                         {
                             "LocalSlot": "ColorInputOutput",
                             "AttachmentRef": {
-                                "Pass": "TransparentPass",
+                                "Pass": "MobileTransparentPass",
                                 "Attachment": "InputOutput"
                             }
                         },

--- a/Gems/Atom/Feature/Common/Assets/Passes/Mobile/Transparent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/Mobile/Transparent.pass
@@ -15,11 +15,22 @@
                     "ScopeAttachmentUsage": "Shader"
                 },
                 {
+                    "Name": "InputDepth",
+                    "SlotType": "Input",
+                    "ShaderInputName": "m_linearDepthTexture",
+                    "ScopeAttachmentUsage": "Shader",
+                    "ImageViewDesc": {
+                        "AspectFlags": [
+                            "Depth"
+                        ]
+                    }
+                },
+                // Input/Outputs
+                {
                     "Name": "InputOutput",
                     "SlotType": "InputOutput",
                     "ScopeAttachmentUsage": "RenderTarget"
                 },
-                // Input/Outputs
                 {
                     "Name": "DepthStencil",
                     "SlotType": "InputOutput",
@@ -43,7 +54,24 @@
                         "Attachment": "BRDFTexture"
                     }
                 }
-            ]
+            ],
+            "PassData": {
+                "$type": "RasterPassData",
+                "DrawListTag": "transparent",
+                "DrawListSortType": "KeyThenReverseDepth",
+                "BindViewSrg": true,
+                "PassSrgShaderAsset": {
+                    "FilePath": "Shaders/ForwardPassSrg.shader"
+                },
+                "ShaderDataMappings": {
+                    "UintMappings": [
+                        {
+                            "Name": "m_isOriginalDepth",
+                            "Value": 1
+                        }
+                    ]
+                }
+            }
         }
     }
 }

--- a/Gems/Atom/Feature/Common/Assets/Passes/Mobile/TransparentParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/Mobile/TransparentParent.pass
@@ -23,6 +23,13 @@
                     "TemplateName": "MobileTransparentPassTemplate",
                     "Enabled": true,
                     "Connections": [
+                        {
+                            "LocalSlot": "InputDepth",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "DepthStencil"
+                            }
+                        },
                         // Input/Outputs...
                         {
                             "LocalSlot": "DepthStencil",
@@ -38,16 +45,7 @@
                                 "Attachment": "InputOutput"
                             }
                         }
-                    ],
-                    "PassData": {
-                        "$type": "RasterPassData",
-                        "DrawListTag": "mobileTransparent",
-                        "DrawListSortType": "KeyThenReverseDepth",
-                        "BindViewSrg": true,
-                        "PassSrgShaderAsset": {
-                            "FilePath": "Shaders/ForwardPassSrg.shader"
-                        }
-                    }
+                    ]
                 }
             ]
         }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Forward/ForwardPassSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Forward/ForwardPassSrg.azsli
@@ -45,5 +45,7 @@ ShaderResourceGroup PassSrg : SRG_PerPass
     Texture2D<float> m_linearDepthTexture;
 
     // Whether the m_linearDepthTexture is linear depth or original depth
+    // This is useful for render pipeline doesn't have pass to convert original depth to linear depth
+    // We can use m_linearDepthTexture for original depth and set this flag to true. And the shaders can calculate linear depth themselves.
     uint m_isOriginalDepth;
 }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Forward/ForwardPassSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Forward/ForwardPassSrg.azsli
@@ -45,5 +45,8 @@ ShaderResourceGroup PassSrg : SRG_PerPass
     Texture2D<float> m_linearDepthTexture;
 
     // Whether the m_linearDepthTexture is linear depth or original depth
+    // This is useful for render pipeline which doesn't have a pass to convert original depth to linear depth
+    // We can use m_linearDepthTexture for original depth and set this flag to true. 
+    // And the shaders can calculate linear depth themselves.
     uint m_isOriginalDepth;
 }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Forward/ForwardPassSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Forward/ForwardPassSrg.azsli
@@ -43,4 +43,7 @@ ShaderResourceGroup PassSrg : SRG_PerPass
     Texture2D<uint4> m_tileLightData;
     StructuredBuffer<uint> m_lightListRemapped;
     Texture2D<float> m_linearDepthTexture;
+
+    // Whether the m_linearDepthTexture is linear depth or original depth
+    uint m_isOriginalDepth;
 }


### PR DESCRIPTION
## What does this PR do?
- use "transparent" DrawListTag for mobile pipeline's transparent pass. So we won't need to change all the popcornFX shaders to render to a different DrawListTag for mobile render pipeline. (This works if we don't have two different render pipelines for one scene running at same time)
- use "MobileTransparentPass" name instead of "TransparentPass" so distortion passes won't be added. 
- Add "m_isOriginalDepth" to ForwardPassSrg which allows user to use original depth instead of linear depth for soft particles

Note: we still need the changes in this PR https://github.com/carbonated-dev/o3de-gruber/pull/313 to have soft particles working properly. The particles with distortion and lighting also need this change to not break the mobile pipeline. 

## How was this PR tested?

Tested in Editor with all the particle effects in Gruber project
