### PR TITLE
[MADPORT-431] Added a method to despawn all entities via a spawn ticket

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesInterface.h
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesInterface.h
@@ -393,6 +393,11 @@ namespace AzFramework
             m_entityPtrList = entityList;
         }
 
+        const AZ::u32 GetEntitySpawnTicketId() const
+        {
+            return m_entitySpawnTicketId;
+        }
+
         static AZStd::shared_ptr<SpawnableInstanceDescriptor> GetInvalidDescriptor();
 
         bool FinalizeCreateInstance(void* remapContainer,
@@ -528,6 +533,11 @@ namespace AzFramework
          * @return SpawnableInstanceDescriptor
          */
         virtual AZStd::shared_ptr<SpawnableInstanceDescriptor> GetOwningSpawnable(const AZ::EntityId& entityId) = 0;
+
+        // Uses a ticket to despawn entities.
+        // Gets ticket id from SpawnableInstanceDescriptor or from entity definition.
+        // Also removes an associated SpawnableInstanceDescriptor if it exists.
+        virtual void DespawnAllEntitiesInTicketByEntityID(const AZ::EntityId& entityId, DespawnAllEntitiesOptionalArgs optionalArgs = {}) = 0; // async
 #endif
 // Gruber patch end. // LVB. // Support unique instances
 

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesInterface.h
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesInterface.h
@@ -208,6 +208,21 @@ namespace AzFramework
         class SpawnableEntitiesDefinition* m_interface{ nullptr };
     };
 
+// Gruber patch begin // VMED // entity state ticket notificator
+#ifdef CARBONATED
+    class EntitySpawnTicketState :
+        public AZ::EBusTraits
+    {
+    public:
+        virtual ~EntitySpawnTicketState() = default;
+        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
+        virtual void OnRemoveEntities(EntitySpawnTicket::Id) {}
+    };
+
+    typedef AZ::EBus<EntitySpawnTicketState> EntitySpawnTicketStateBus;
+#endif
+// Gruber patch end // VMED
+
     using EntitySpawnCallback = AZStd::function<void(EntitySpawnTicket::Id, SpawnableConstEntityContainerView)>;
     using EntityPreInsertionCallback = AZStd::function<void(EntitySpawnTicket::Id, SpawnableEntityContainerView)>;
     using EntityDespawnCallback = AZStd::function<void(EntitySpawnTicket::Id)>;
@@ -410,7 +425,7 @@ namespace AzFramework
         SpawnableInstanceId m_spawnableInstanceId; ///< UUid of the unique instantiated spawnable
         EntityIdToEntityIdMap m_baseToNewEntityIdMap; ///< Map of old entityId to new
         mutable EntityIdToEntityIdMap m_entityIdToBaseCache; ///< reverse lookup to \ref m_baseToNewEntityIdMap, this is build on demand
-        AZ::u32 m_entitySpawnTicketId; // reserved for Spawnable access
+        AZ::u32 m_entitySpawnTicketId; ///< Spawned ticket id
         EntityPtrList m_entityPtrList;
 
         // The lookup is built lazily when accessing the map, but constness is desirable

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesManager.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesManager.cpp
@@ -67,11 +67,11 @@ namespace AzFramework
             optionalArgs.m_serializeContext == nullptr ? m_defaultSerializeContext : optionalArgs.m_serializeContext;
         queueEntry.m_completionCallback = AZStd::move(optionalArgs.m_completionCallback);
         queueEntry.m_preInsertionCallback = AZStd::move(optionalArgs.m_preInsertionCallback);
-        // Gruber patch begin // VMED // Custom entity id remapper
+// Gruber patch begin // VMED // Custom entity id remapper
 #ifdef CARBONATED
         queueEntry.m_customEntityIdMapper = optionalArgs.m_customEntityIdMapper;
 #endif
-        // Gruber patch end // VMED // Custom entity id remapper
+// Gruber patch end // VMED // Custom entity id remapper
         QueueRequest(ticket, optionalArgs.m_priority, AZStd::move(queueEntry));
     }
 
@@ -297,7 +297,7 @@ namespace AzFramework
         return queue.m_delayed.empty() ? CommandQueueStatus::NoCommandsLeft : CommandQueueStatus::HasCommandsLeft;
     }
 
-    // Gruber patch begin. // LVB. // Support unique instances
+// Gruber patch begin. // LVB. // Support unique instances
 #ifdef CARBONATED
     AZStd::shared_ptr<SpawnableInstanceDescriptor> SpawnableEntitiesManager::GetOwningSpawnable(const AZ::EntityId& entityId)
     {

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesManager.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesManager.cpp
@@ -939,6 +939,13 @@ namespace AzFramework
     auto SpawnableEntitiesManager::ProcessRequest(DespawnAllEntitiesCommand& request) -> CommandResult
     {
         Ticket& ticket = *request.m_ticket;
+
+// Gruber patch begin // VMED // entity state ticket notificator
+#ifdef CARBONATED
+        EntitySpawnTicketStateBus::Broadcast(&EntitySpawnTicketStateBus::Events::OnRemoveEntities, ticket.m_ticketId);
+#endif
+// Gruber patch end // VMED // entity state ticket notificator
+
         if (request.m_requestId == ticket.m_currentRequestId)
         {
             for (AZ::Entity* entity : ticket.m_spawnedEntities)
@@ -978,6 +985,13 @@ namespace AzFramework
     auto SpawnableEntitiesManager::ProcessRequest(DespawnEntityCommand& request) -> CommandResult
     {
         Ticket& ticket = *request.m_ticket;
+
+// Gruber patch begin // VMED // entity state ticket notificator
+#ifdef CARBONATED
+        EntitySpawnTicketStateBus::Broadcast(&EntitySpawnTicketStateBus::Events::OnRemoveEntities, ticket.m_ticketId);
+#endif
+// Gruber patch end // VMED // entity state ticket notificator
+
         if (request.m_requestId == ticket.m_currentRequestId)
         {
             AZStd::vector<AZ::Entity*>& spawnedEntities = request.m_ticket->m_spawnedEntities;

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesManager.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesManager.cpp
@@ -311,9 +311,11 @@ namespace AzFramework
 
     void SpawnableEntitiesManager::DespawnAllEntitiesInTicketByEntityID(const AZ::EntityId& entityId, DespawnAllEntitiesOptionalArgs optionalArgs)
     {
+        constexpr EntitySpawnTicket::Id InvalidTicketId = (EntitySpawnTicket::Id)-1;
+
         if (entityId.IsValid())
         {
-            EntitySpawnTicket::Id ticketId = 0;
+            EntitySpawnTicket::Id ticketId = InvalidTicketId;
 
             AZStd::shared_ptr<SpawnableInstanceDescriptor> spawnableInfo = GetOwningSpawnable(entityId);
             if (spawnableInfo && spawnableInfo->IsValid())
@@ -331,7 +333,7 @@ namespace AzFramework
                 }
             }
 
-            if (ticketId != 0)
+            if (ticketId != InvalidTicketId)
             {
                 SpawnableEntitiesInterface::Get()->RetrieveTicket(ticketId,
                     [optionalArgs](EntitySpawnTicket&& entitySpawnTicket)

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesManager.h
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesManager.h
@@ -87,6 +87,7 @@ namespace AzFramework
 // Gruber patch begin. // LVB. // Support unique instances
 #ifdef CARBONATED
         AZStd::shared_ptr<SpawnableInstanceDescriptor> GetOwningSpawnable(const AZ::EntityId& entityId) override;
+        void DespawnAllEntitiesInTicketByEntityID(const AZ::EntityId& entityId, DespawnAllEntitiesOptionalArgs optionalArgs) override; // async
 #endif
 // Gruber patch end. // LVB. // Support unique instances
 

--- a/Code/Framework/AzFramework/Tests/Mocks/MockSpawnableEntitiesInterface.h
+++ b/Code/Framework/AzFramework/Tests/Mocks/MockSpawnableEntitiesInterface.h
@@ -80,6 +80,7 @@ namespace AzFramework
 // Gruber patch begin // VMED // Added mock for GetOwningSpawnable method
 #ifdef CARBONATED
         MOCK_METHOD1(GetOwningSpawnable, AZStd::shared_ptr<SpawnableInstanceDescriptor>(const AZ::EntityId& entityId));
+        MOCK_METHOD2(DespawnAllEntitiesInTicketByEntityID, void(const AZ::EntityId& entityId, DespawnAllEntitiesOptionalArgs optionalArgs));
 #endif // CARBONATED
 // Gruber patch end // VMED // Added mock for GetOwningSpawnable method
 


### PR DESCRIPTION
## What does this PR do?

Added a method to despawn all entities via a spawn ticket

See also https://github.com/carbonated-dev/o3de-gruber/pull/314

## How was this PR tested?

Verified locally
