### PR TITLE
Memory savings for metal backend (~100+MB)

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Factory.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Factory.h
@@ -18,6 +18,7 @@
 #endif
 
 AZ_CVAR_EXTERNED(bool, r_gpuMarkersMergeGroups);
+AZ_CVAR_EXTERNED(bool, r_enablePsoCaching);
 
 namespace AZ::RHI
 {

--- a/Gems/Atom/RHI/Code/Source/RHI/Factory.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Factory.cpp
@@ -32,6 +32,14 @@ static bool s_pixGpuMarkersEnabled = true;
 static bool s_usingWarpDevice = false;
 AZ_CVAR(bool, r_gpuMarkersMergeGroups, false, nullptr, AZ::ConsoleFunctorFlags::Null, "Enable merging of gpu markers in order to track payload (i.e all the scopes) per command list.");
 
+AZ_CVAR(
+    bool,
+    r_enablePsoCaching,
+    false,
+    nullptr,
+    AZ::ConsoleFunctorFlags::DontReplicate,
+    "If true the active RHI backend will try to write out PSO cache (as long as it is able to). By default it is false.");
+
 
 namespace AZ::RHI
 {

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/BufferView.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/BufferView.cpp
@@ -67,7 +67,9 @@ namespace AZ
                                                                          offset : m_memoryView.GetOffset()
                                                                     bytesPerRow : bytesPerRow];
                 AZ_Assert(mtlTexture, "Failed to create texture");
-
+                [mtlTextureDesc release];
+                mtlTextureDesc = nil;
+                
                 RHI::Ptr<MetalResource> textureViewResource = MetalResource::Create(MetalResourceDescriptor{ mtlTexture, ResourceType::MtlTextureType });
                 m_imageBufferMemoryView = MemoryView(textureViewResource, 0, (viewDescriptor.m_elementCount * bytesPerPixel), 0);
             }

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandQueueCommandBuffer.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandQueueCommandBuffer.cpp
@@ -36,6 +36,8 @@ namespace AZ
                     MTLCommandBufferDescriptor* mtlCommandBufferDesc = [[MTLCommandBufferDescriptor alloc] init];
                     mtlCommandBufferDesc.errorOptions = MTLCommandBufferErrorOptionEncoderExecutionStatus;
                     m_mtlCommandBuffer = [m_hwQueue commandBufferWithDescriptor:mtlCommandBufferDesc];
+                    [mtlCommandBufferDesc release];
+                    mtlCommandBufferDesc = nil;
                 }
             }
 #endif

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Device.cpp
@@ -385,7 +385,10 @@ namespace AZ
             
             m_features.m_unboundedArrays = m_metalDevice.argumentBuffersSupport == MTLArgumentBuffersTier2;
             m_features.m_unboundedArrays = false; //Remove this when unbounded array support is added to spirv-cross
-            m_features.m_simulateBindlessUA = true; // Simulate unbounded arrays for Bindless srg
+            
+            // Metal backend is able to simulate unbounded arrays for Bindless srg. However it is disabled by default as it uses up memory and we dont have
+            // any features that is using Bindless at the moment.
+            m_features.m_simulateBindlessUA = false;
 
             //Values taken from https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf
             m_limits.m_maxImageDimension1D = 8192;

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineState.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineState.cpp
@@ -10,6 +10,7 @@
 #include <Atom/RHI.Reflect/Metal/PipelineLayoutDescriptor.h>
 #include <Atom/RHI.Reflect/Metal/ShaderStageFunction.h>
 #include <Atom/RHI.Reflect/ShaderStageFunction.h>
+#include <Atom/RHI/Factory.h>
 #include <RHI/Conversions.h>
 #include <RHI/Device.h>
 #include <RHI/PipelineState.h>
@@ -78,6 +79,7 @@ namespace AZ
             {
                 dispatch_data_t dispatchByteCodeData = dispatch_data_create(shaderByteCode, byteCodeLength, NULL, DISPATCH_DATA_DESTRUCTOR_DEFAULT);
                 lib = [mtlDevice newLibraryWithData:dispatchByteCodeData error:&error];
+                dispatch_release(dispatchByteCodeData);
             }
             else
             {
@@ -195,7 +197,16 @@ namespace AZ
                 }
                 AZ_Assert(false, "Could not create Pipeline object!.");
             }
+            AZ_Assert(m_graphicsPipelineState, "Could not create Pipeline object!.");
             
+            //We keep the descriptors alive in case we want to build the PSO cache. Delete them otherwise.
+            if (!r_enablePsoCaching)
+            {
+                [m_renderPipelineDesc release];
+                m_renderPipelineDesc = nil;
+            }
+            
+             
             m_pipelineStateMultiSampleState = descriptor.m_renderStates.m_multisampleState;
             
             //Cache the rasterizer state
@@ -241,6 +252,13 @@ namespace AZ
             }
             
             AZ_Assert(m_computePipelineState, "Could not create Pipeline object!.");
+            
+            //We keep the descriptors alive in case we want to build the PSO cache. Delete them otherwise.
+            if (!r_enablePsoCaching)
+            {
+                [m_computePipelineDesc release];
+                m_computePipelineDesc = nil;
+            }
             
             if (m_computePipelineState)
             {

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/Shader.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/Shader.cpp
@@ -197,8 +197,11 @@ namespace AZ
 
             if (m_pipelineLibraryHandle.IsValid())
             {
-                SavePipelineLibrary();
-
+                if (r_enablePsoCaching)
+                {
+                    SavePipelineLibrary();
+                }
+                
                 m_pipelineStateCache->ReleaseLibrary(m_pipelineLibraryHandle);
                 m_pipelineStateCache = nullptr;
                 m_pipelineLibraryHandle = {};


### PR DESCRIPTION
## What does this PR do?

- Disable Bindless by default as no rendering features are using it on metal
- Clean up shader byte code after pso creation
- Clean up PSOdescriptors if pso caching is not enabled
- Hooked up saving of PSO cache to a car which is disabled by default

## How was this PR tested?

Tested MadWorld on iOS
