### PR TITLE
Az/silhouette improvements

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Silhouette/SilhouetteFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Silhouette/SilhouetteFeatureProcessor.cpp
@@ -65,25 +65,18 @@ namespace AZ::Render
     void SilhouetteFeatureProcessor::Deactivate()
     {
         DisableSceneNotification();
+
+        m_rasterPass = nullptr;
+        m_compositePass = nullptr;
     }
 
     void SilhouetteFeatureProcessor::SetPassesEnabled(bool enabled)
     {
-        if (auto scene = GetParentScene(); scene != nullptr)
+        if (m_compositePass && m_rasterPass)
         {
-            const auto mergeTemplateName = Name("SilhouettePassTemplate");
-            auto compositePassFilter = AZ::RPI::PassFilter::CreateWithTemplateName(mergeTemplateName, scene);
-            if (auto foundPass = AZ::RPI::PassSystemInterface::Get()->FindFirstPass(compositePassFilter); foundPass)
-            {
-                foundPass->SetEnabled(enabled);
-            }
+            m_compositePass->SetEnabled(enabled);
+            m_rasterPass->SetEnabled(enabled);
 
-            const auto gatherTemplateName = Name("SilhouetteGatherPassTemplate");
-            auto gatherPassFilter = AZ::RPI::PassFilter::CreateWithTemplateName(gatherTemplateName, scene);
-            if (auto foundPass = AZ::RPI::PassSystemInterface::Get()->FindFirstPass(gatherPassFilter); foundPass)
-            {
-                foundPass->SetEnabled(enabled);
-            }
         }
     }
 
@@ -91,36 +84,25 @@ namespace AZ::Render
     {
         if (auto scene = GetParentScene(); scene != nullptr)
         {
-            const auto mergeTemplateName = Name("SilhouettePassTemplate");
-            auto compositePassFilter = AZ::RPI::PassFilter::CreateWithTemplateName(mergeTemplateName, scene);
-            auto compositePass = AZ::RPI::PassSystemInterface::Get()->FindFirstPass(compositePassFilter);
-
-            const auto gatherTemplateName = Name("SilhouetteGatherPassTemplate");
-            auto gatherPassFilter = AZ::RPI::PassFilter::CreateWithTemplateName(gatherTemplateName, scene);
-            auto gatherPass = AZ::RPI::PassSystemInterface::Get()->FindFirstPass(gatherPassFilter);
-
-            if (compositePass && gatherPass)
+            if (m_compositePass && m_rasterPass)
             {
-                AZ::RPI::RasterPass* rasterPass = static_cast<AZ::RPI::RasterPass*> (gatherPass);
-
                 // Get DrawList from the dynamic draw interface and view
-                AZStd::vector<RHI::DrawListView> drawLists = AZ::RPI::DynamicDrawInterface::Get()->GetDrawListsForPass(rasterPass);
-
-                const AZStd::vector<AZ::RPI::ViewPtr>& views = rasterPass->GetRenderPipeline()->GetViews(gatherPass->GetPipelineViewTag());
+                AZStd::vector<RHI::DrawListView> drawLists = AZ::RPI::DynamicDrawInterface::Get()->GetDrawListsForPass(m_rasterPass);
+                const AZStd::vector<AZ::RPI::ViewPtr>& views = m_rasterPass->GetRenderPipeline()->GetViews(m_rasterPass->GetPipelineViewTag());
                 RHI::DrawListView viewDrawList;
                 if (!views.empty())
                 {
                     const AZ::RPI::ViewPtr& view = views.front();
-                    viewDrawList = view->GetDrawList(gatherPass->GetDrawListTag());
+                    viewDrawList = view->GetDrawList(m_rasterPass->GetDrawListTag());
                 }
 
                 if (drawLists.empty() && viewDrawList.empty())
                 {
-                    compositePass->SetEnabled(false);
+                    m_compositePass->SetEnabled(false);
                 }
                 else
                 {
-                    compositePass->SetEnabled(true);
+                    m_compositePass->SetEnabled(true);
                 }
             }
         }
@@ -138,12 +120,17 @@ namespace AZ::Render
         auto compositePassFilter = AZ::RPI::PassFilter::CreateWithTemplateName(mergeTemplateName, renderPipeline);
         if (auto foundPass = AZ::RPI::PassSystemInterface::Get()->FindFirstPass(compositePassFilter); foundPass)
         {
-            return;
+            m_compositePass = foundPass;
         }
 
         const auto gatherTemplateName = Name("SilhouetteGatherPassTemplate");
         auto gatherPassFilter = AZ::RPI::PassFilter::CreateWithTemplateName(gatherTemplateName, renderPipeline);
         if (auto foundPass = AZ::RPI::PassSystemInterface::Get()->FindFirstPass(gatherPassFilter); foundPass)
+        {
+            m_rasterPass = static_cast<AZ::RPI::RasterPass*>(foundPass);
+        }
+
+        if (m_compositePass && m_rasterPass)
         {
             return;
         }
@@ -172,6 +159,7 @@ namespace AZ::Render
 
         if (auto pass = RPI::PassSystemInterface::Get()->CreatePassFromRequest(&gatherPassRequest); pass != nullptr)
         {
+            m_rasterPass = static_cast<AZ::RPI::RasterPass*>(pass.get());
             renderPipeline->AddPassAfter(pass, forwardProcessPassName);
         }
 
@@ -185,6 +173,7 @@ namespace AZ::Render
 
         if (auto pass = RPI::PassSystemInterface::Get()->CreatePassFromRequest(&compositePassRequest); pass != nullptr)
         {
+            m_compositePass = pass.get();
             renderPipeline->AddPassAfter(pass, postProcessPassName);
         }
     }

--- a/Gems/Atom/Feature/Common/Code/Source/Silhouette/SilhouetteFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Silhouette/SilhouetteFeatureProcessor.cpp
@@ -115,7 +115,6 @@ namespace AZ::Render
         {
             return;
         }
-
         // update our render pass members in case they were added as part of a pipeline 
         UpdatePasses(renderPipeline);
 
@@ -170,6 +169,9 @@ namespace AZ::Render
             m_compositePass = pass.get();
             renderPipeline->AddPassAfter(pass, postProcessPassName);
         }
+
+        // remember which render pipeline we added our passes to
+        m_renderPipeline = renderPipeline;
     }
 
     void SilhouetteFeatureProcessor::OnRenderPipelineChanged(AZ::RPI::RenderPipeline* pipeline, [[maybe_unused]] AZ::RPI::SceneNotification::RenderPipelineChangeType changeType)
@@ -180,6 +182,13 @@ namespace AZ::Render
 
     void SilhouetteFeatureProcessor::UpdatePasses(AZ::RPI::RenderPipeline* renderPipeline)
     {
+        // if we assigned passes to a render pipeline already (m_renderPipeline) then ignore
+        // all other render pipelines
+        if (m_renderPipeline && renderPipeline != m_renderPipeline)
+        {
+            return;
+        }
+
         m_compositePass = nullptr;
 
         const auto mergeTemplateName = Name("SilhouettePassTemplate");
@@ -197,5 +206,8 @@ namespace AZ::Render
         {
             m_rasterPass = static_cast<AZ::RPI::RasterPass*>(foundPass);
         }
+
+        // remember which render pipeline we found our passes on
+        m_renderPipeline = (m_compositePass && m_rasterPass) ? renderPipeline : nullptr;
     }
 } // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Source/Silhouette/SilhouetteFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Silhouette/SilhouetteFeatureProcessor.h
@@ -10,6 +10,12 @@
 
 #include <Atom/RPI.Public/FeatureProcessor.h>
 
+namespace AZ::RPI
+{
+    class Pass;
+    class RasterPass;
+}
+
 namespace AZ::Render
 {
     // Adds a silhouette gather pass and a silhouette full screen pass for drawing and
@@ -42,6 +48,10 @@ namespace AZ::Render
 
         //! RPI::SceneNotificationBus
         void OnEndPrepareRender() override;
+
+    private:
+        AZ::RPI::RasterPass* m_rasterPass = nullptr;
+        AZ::RPI::Pass* m_compositePass = nullptr;
     };
 }
 

--- a/Gems/Atom/Feature/Common/Code/Source/Silhouette/SilhouetteFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Silhouette/SilhouetteFeatureProcessor.h
@@ -55,6 +55,7 @@ namespace AZ::Render
 
         AZ::RPI::RasterPass* m_rasterPass = nullptr;
         AZ::RPI::Pass* m_compositePass = nullptr;
+        AZ::RPI::RenderPipeline* m_renderPipeline = nullptr;
     };
 }
 

--- a/Gems/Atom/Feature/Common/Code/Source/Silhouette/SilhouetteFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Silhouette/SilhouetteFeatureProcessor.h
@@ -48,8 +48,11 @@ namespace AZ::Render
 
         //! RPI::SceneNotificationBus
         void OnEndPrepareRender() override;
+        void OnRenderPipelineChanged(AZ::RPI::RenderPipeline* pipeline, AZ::RPI::SceneNotification::RenderPipelineChangeType changeType) override;
 
     private:
+        void UpdatePasses(AZ::RPI::RenderPipeline* renderPipeline);
+
         AZ::RPI::RasterPass* m_rasterPass = nullptr;
         AZ::RPI::Pass* m_compositePass = nullptr;
     };

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/BufferView.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/BufferView.cpp
@@ -55,17 +55,12 @@ namespace AZ
                                                                            usage : textureUsage];
                 mtlTextureDesc.textureType = MTLTextureTypeTextureBuffer;
 
-                uint32_t bytesPerRow = viewDescriptor.m_elementCount * bytesPerPixel;
+                [[maybe_unused]] uint32_t bytesPerRow = viewDescriptor.m_elementCount * bytesPerPixel;
                 AZ_Assert(bytesPerRow == (viewDescriptor.m_elementCount * viewDescriptor.m_elementSize), "Mismatch for bytesPerRow");
                 
-                id<MTLDevice> hwDevice = device.GetMtlDevice();
-                const NSUInteger rowAlignment = [hwDevice minimumLinearTextureAlignmentForPixelFormat: ConvertPixelFormat(viewDescriptor.m_elementFormat)];
-                const size_t rowAlignmentBytes = aznumeric_cast<size_t>(rowAlignment);
-                bytesPerRow = aznumeric_cast<uint32_t>(RHI::AlignUpNPOT(aznumeric_cast<size_t>(bytesPerRow), rowAlignmentBytes));
-
-                id<MTLTexture> mtlTexture = [mtlBuffer newTextureWithDescriptor : mtlTextureDesc
-                                                                         offset : m_memoryView.GetOffset()
-                                                                    bytesPerRow : bytesPerRow];
+                id<MTLTexture> mtlTexture = [mtlBuffer newTextureWithDescriptor:mtlTextureDesc
+                                                                         offset:m_memoryView.GetOffset()
+                                                                    bytesPerRow:(viewDescriptor.m_elementCount * bytesPerPixel)];
                 AZ_Assert(mtlTexture, "Failed to create texture");
 
                 RHI::Ptr<MetalResource> textureViewResource = MetalResource::Create(MetalResourceDescriptor{ mtlTexture, ResourceType::MtlTextureType });


### PR DESCRIPTION
## What does this PR do?

- revert bufferview change that would likely lead to invalid row calculations
- avoid per-frame filters and use cached pass pointers instead

## How was this PR tested?

- Tested in custom level in windows editor
- used r_silhouette cvar to turn feature on/off
- turned the camera in game to look away and then back again at the silhouettes to verify there were no issues when out of frame
