### PR TITLE
[MADPORT-439] Place characters on the ground workaround

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
@@ -1274,6 +1274,10 @@ namespace AzFramework
 
     void TransformComponent::ComputeLocalTM()
     {
+#ifdef CARBONATED
+        // In CARBONATED the m_worldTM does not send permanently to the clients via NetBindings. Only m_localTM is sent permamently.
+        m_localTM = m_worldTM;
+#else
         if (m_parentTM)
         {
             m_localTM = m_parentTM->GetWorldTM().GetInverse() * m_worldTM;
@@ -1282,7 +1286,7 @@ namespace AzFramework
         {
             m_localTM = m_worldTM;
         }
-
+#endif
         AZ::TransformNotificationBus::Event(
             m_notificationBus, &AZ::TransformNotificationBus::Events::OnTransformChanged, m_localTM, m_worldTM);
         m_transformChangedEvent.Signal(m_localTM, m_worldTM);


### PR DESCRIPTION
## What does this PR do?

Placed characters on the ground (workaround)

See details in the comments https://jira.carbonated.com:8443/browse/MADPORT-439

1) In CARBONATED the m_worldTM does not send permanently to the clients via NetBindings. Only m_localTM is sent permanently.
2) In LY the entity with character component is a root for the character entity,  but in O3DE the entity with character component is a child for the character entity (it has a parent)

NOTE: can add a ticket for the future modification

## How was this PR tested?

Locally
