### PR TITLE
[MADPORT-440] Avoid workaround from MADPORT-439 using EntityHelpers::DetachEntityFromParent

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
@@ -1274,10 +1274,6 @@ namespace AzFramework
 
     void TransformComponent::ComputeLocalTM()
     {
-#ifdef CARBONATED
-        // In CARBONATED the m_worldTM does not send permanently to the clients via NetBindings. Only m_localTM is sent permamently.
-        m_localTM = m_worldTM;
-#else
         if (m_parentTM)
         {
             m_localTM = m_parentTM->GetWorldTM().GetInverse() * m_worldTM;
@@ -1286,7 +1282,7 @@ namespace AzFramework
         {
             m_localTM = m_worldTM;
         }
-#endif
+
         AZ::TransformNotificationBus::Event(
             m_notificationBus, &AZ::TransformNotificationBus::Events::OnTransformChanged, m_localTM, m_worldTM);
         m_transformChangedEvent.Signal(m_localTM, m_worldTM);


### PR DESCRIPTION
This reverts commit 9207c60d18a410731d4ec67e8b37e81b8f5ff5cb.
https://jira.carbonated.com:8443/browse/MADPORT-440

## What does this PR do?

Avoid workaround for MADPORT-439 using EntityHelpers::DetachEntityFromParent
See https://github.com/carbonated-dev/o3de-gruber/pull/329

## How was this PR tested?

Locally
