### PR TITLE
Fix an issue that ImageMipChainAsset wasn't released after it's used by StreamingImageAsset

### DIFF
--- a/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
@@ -2388,9 +2388,16 @@ namespace AZ::Data
         uint64_t totalSize = 0;
 
         AZStd::lock_guard<AZStd::recursive_mutex> assetLock(m_assetMutex);
+
+        // we need to cache the AssetStreamInfo since json objects are referencing the names in it. 
+        AZStd::vector<AssetStreamInfo> cachedStreamInfos;
+        cachedStreamInfos.reserve(m_assets.size());
+
         for (const auto& assetEntry : m_assets)
         {
-            AssetStreamInfo streamInfo = GetLoadStreamInfoForAsset(assetEntry.first, assetEntry.second->GetType());
+            cachedStreamInfos.emplace_back(GetLoadStreamInfoForAsset(assetEntry.first, assetEntry.second->GetType()));
+
+            const AssetStreamInfo& streamInfo = cachedStreamInfos.back();
             totalSize += streamInfo.m_dataLen;
             auto& typeInfo = assetTypeInfos[AZStd::string(assetEntry.second->RTTI_GetTypeName())];
             typeInfo.size += streamInfo.m_dataLen;

--- a/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
@@ -2436,7 +2436,7 @@ namespace AZ::Data
         path /= "log";
 
         [[maybe_unused]] const bool dirCreated = AZ::IO::SystemFile::CreateDir(path.c_str());
-        AZ_Assert(dirCreated, "Failed to create a MemoryCaptures directory for gpu pool dump, requested path = %s", path.c_str())
+        AZ_Assert(dirCreated, "Failed to create destination folder for asset info dump '%s'", path.c_str())
 
         time_t ltime;
         time(&ltime);

--- a/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
@@ -24,6 +24,9 @@
 #include <AzCore/IO/FileIO.h>
 #include <AzCore/Console/IConsole.h>
 #include <AzCore/Console/ILogger.h>
+#include <AzCore/Utils/Utils.h>
+#include <AzCore/JSON/stringbuffer.h>
+#include <AzCore/JSON/prettywriter.h>
 #include <cinttypes>
 #include <utility>
 #include <AzCore/Serialization/ObjectStream.h>
@@ -2368,6 +2371,91 @@ namespace AZ::Data
     {
         return AZStd::shared_ptr<AssetContainer>( aznew AssetContainer(AZStd::move(asset), loadParams, isReload));
     }
+
+    void AssetManager::DumpLoadedAssetsInfo()
+    {
+        rapidjson::Document doc;
+
+        rapidjson::Value& docRoot = doc.SetObject();
+        rapidjson::Value infoArray(rapidjson::kArrayType);
+
+        struct TypeInfo
+        {
+            uint64_t size = 0;
+            uint64_t count = 0;
+        };
+        AZStd::map<AZStd::string, TypeInfo> assetTypeInfos;
+        uint64_t totalSize = 0;
+
+        AZStd::lock_guard<AZStd::recursive_mutex> assetLock(m_assetMutex);
+        for (const auto& assetEntry : m_assets)
+        {
+            AssetStreamInfo streamInfo = GetLoadStreamInfoForAsset(assetEntry.first, assetEntry.second->GetType());
+            totalSize += streamInfo.m_dataLen;
+            auto& typeInfo = assetTypeInfos[AZStd::string(assetEntry.second->RTTI_GetTypeName())];
+            typeInfo.size += streamInfo.m_dataLen;
+            typeInfo.count++;
+
+            rapidjson::Value assetInfoObject(rapidjson::kObjectType);
+
+            assetInfoObject.AddMember("Type", rapidjson::StringRef(assetEntry.second->RTTI_GetTypeName()), doc.GetAllocator());
+            assetInfoObject.AddMember("Path", rapidjson::StringRef(streamInfo.m_streamName.c_str()), doc.GetAllocator());
+            assetInfoObject.AddMember("SizeInBytes", static_cast<uint64_t>(streamInfo.m_dataLen), doc.GetAllocator());
+            assetInfoObject.AddMember("RefCount", static_cast<uint64_t>(assetEntry.second->GetUseCount()), doc.GetAllocator());
+            infoArray.PushBack(assetInfoObject, doc.GetAllocator());
+        }
+                
+        rapidjson::Value typeSizeArray(rapidjson::kArrayType);
+        for (const auto& [typeName, typeInfo] : assetTypeInfos)
+        {
+            rapidjson::Value typeInfoObject(rapidjson::kObjectType);
+            typeInfoObject.AddMember("AssetType", rapidjson::StringRef(typeName.c_str()), doc.GetAllocator());
+            typeInfoObject.AddMember("TotalSize", typeInfo.size, doc.GetAllocator());
+            typeInfoObject.AddMember("Count", typeInfo.count, doc.GetAllocator());
+            typeSizeArray.PushBack(typeInfoObject, doc.GetAllocator());
+        }
+
+        docRoot.AddMember("Total Asset Size", totalSize, doc.GetAllocator());
+        docRoot.AddMember("Total size per type", typeSizeArray, doc.GetAllocator());
+        docRoot.AddMember("Assets", infoArray, doc.GetAllocator());
+
+        rapidjson::StringBuffer jsonStringBuffer;
+        rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(jsonStringBuffer);
+        doc.Accept(writer);
+
+        // write to a json file
+        AZ::IO::Path path = AZStd::string_view(AZ::Utils::GetProjectUserPath());
+
+        path /= "log";
+
+        [[maybe_unused]] const bool dirCreated = AZ::IO::SystemFile::CreateDir(path.c_str());
+        AZ_Assert(dirCreated, "Failed to create a MemoryCaptures directory for gpu pool dump, requested path = %s", path.c_str())
+
+        time_t ltime;
+        time(&ltime);
+        tm today;
+
+#if AZ_TRAIT_USE_SECURE_CRT_FUNCTIONS
+        localtime_s(&today, &ltime);
+#else
+        today = *localtime(&ltime);
+#endif
+        char assetDumpFileName[128];
+        strftime(assetDumpFileName, sizeof(assetDumpFileName), "%Y-%m-%d.%H-%M-%S", &today);
+        AZStd::string filename =
+            AZStd::string::format("%s/AssetMemoryLog_%s.%ld.json", path.c_str(), assetDumpFileName, static_cast<long>(ltime));
+
+        AZ::IO::SystemFile outputFile;
+        if (!outputFile.Open(filename.c_str(), AZ::IO::SystemFile::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY))
+        {
+            AZ_Error("AssetManager", false, AZStd::string::format("Failed to open file %s for writing", filename.c_str()).c_str());
+            return;
+        }
+        
+        outputFile.Write(jsonStringBuffer.GetString(), jsonStringBuffer.GetSize());
+        outputFile.Close();
+    }
+
 } // namespace AZ::Data
 
 size_t AZStd::hash<AZ::Data::AssetContainerKey>::operator()(const AZ::Data::AssetContainerKey& obj) const

--- a/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
@@ -2461,6 +2461,8 @@ namespace AZ::Data
         
         outputFile.Write(jsonStringBuffer.GetString(), jsonStringBuffer.GetSize());
         outputFile.Close();
+
+        AZ_TracePrintf("AssetManager", "Loaded assets size info is saved to file [%s]", filename.c_str());
     }
 
 } // namespace AZ::Data

--- a/Code/Framework/AzCore/AzCore/Asset/AssetManager.h
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetManager.h
@@ -324,6 +324,9 @@ namespace AZ
             */
             bool HasActiveJobsOrStreamerRequests();
 
+            // memory debug output
+            void DumpLoadedAssetsInfo();
+
         protected:
             AssetManager(const Descriptor& desc);
             virtual ~AssetManager();

--- a/Code/Framework/AzCore/AzCore/Memory/SystemAllocator.cpp
+++ b/Code/Framework/AzCore/AzCore/Memory/SystemAllocator.cpp
@@ -24,8 +24,6 @@
 
 #include <AzCore/Memory/HphaAllocator.h>
 
-#define USE_OS_ALLOCATE 1
-
 namespace AZ
 {
     //////////////////////////////////////////////////////////////////////////
@@ -84,11 +82,7 @@ namespace AZ
 
         byteSize = MemorySizeAdjustedUp(byteSize);
 
-#if USE_OS_ALLOCATE
-        SystemAllocator::pointer address = AZ_OS_MALLOC(byteSize, alignment);
-#else
         SystemAllocator::pointer address = m_subAllocator->allocate(byteSize, alignment);
-#endif
 
         if (address == nullptr)
         {
@@ -122,11 +116,7 @@ namespace AZ
         byteSize = MemorySizeAdjustedUp(byteSize);
         AZ_PROFILE_MEMORY_FREE(MemoryReserved, ptr);
         AZ_MEMORY_PROFILE(ProfileDeallocation(ptr, byteSize, alignment, nullptr));
-#if USE_OS_ALLOCATE
-        AZ_OS_FREE(ptr);
-#else
         m_subAllocator->deallocate(ptr, byteSize, alignment);
-#endif
     }
 
     //=========================================================================
@@ -139,11 +129,7 @@ namespace AZ
 
         AZ_PROFILE_MEMORY_FREE(MemoryReserved, ptr);
 
-#if USE_OS_ALLOCATE
-        pointer newAddress = AZ_OS_REALLOC(ptr, newSize, newAlignment);
-#else
         pointer newAddress = m_subAllocator->reallocate(ptr, newSize, newAlignment);
-#endif
 
 #if defined(AZ_ENABLE_TRACING)
         [[maybe_unused]] const size_type allocatedSize = get_allocated_size(newAddress, 1);
@@ -160,13 +146,8 @@ namespace AZ
     //=========================================================================
     SystemAllocator::size_type SystemAllocator::get_allocated_size(pointer ptr, align_type alignment) const
     {
-#if USE_OS_ALLOCATE
-        return ptr ? AZ_OS_MSIZE(ptr, alignment) : 0;
-#else
         size_type allocSize = MemorySizeAdjustedDown(m_subAllocator->get_allocated_size(ptr, alignment));
-
         return allocSize;
-#endif
     }
 
 } // namespace AZ

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageBuilderComponent.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageBuilderComponent.cpp
@@ -74,7 +74,7 @@ namespace ImageProcessingAtom
         builderDescriptor.m_busId = azrtti_typeid<ImageBuilderWorker>();
         builderDescriptor.m_createJobFunction = AZStd::bind(&ImageBuilderWorker::CreateJobs, &m_imageBuilder, AZStd::placeholders::_1, AZStd::placeholders::_2);
         builderDescriptor.m_processJobFunction = AZStd::bind(&ImageBuilderWorker::ProcessJob, &m_imageBuilder, AZStd::placeholders::_1, AZStd::placeholders::_2);
-        builderDescriptor.m_version = 33;
+        builderDescriptor.m_version = 34;   // change ImageMipchainAsset reference to NoLoad
         builderDescriptor.m_analysisFingerprint = ImageProcessingAtom::BuilderSettingManager::Instance()->GetAnalysisFingerprint();
         m_imageBuilder.BusConnect(builderDescriptor.m_busId);
         AssetBuilderSDK::AssetBuilderBus::Broadcast(&AssetBuilderSDK::AssetBuilderBusTraits::RegisterBuilderInformation, builderDescriptor);

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageAssetProducer.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageAssetProducer.cpp
@@ -197,9 +197,7 @@ namespace ImageProcessingAtom
             // Add all the mip chain assets as dependencies except the tail mip chain since its embedded in the StreamingImageAsset
             if (it->Get() != mipChains.begin()->Get())
             {
-                // Use PreLoad for mipchain assets for now.
-                // [GFX TODO] [ATOM-14467] Remove unnecessary code in StreamingImage::OnAssetReloaded when runtime switching dependency load behavior is supported
-                product.m_dependencies.push_back(AssetBuilderSDK::ProductDependency(it->GetId(), AZ::Data::ProductDependencyInfo::CreateFlags(AZ::Data::AssetLoadBehavior::PreLoad)));
+                product.m_dependencies.push_back(AssetBuilderSDK::ProductDependency(it->GetId(), AZ::Data::ProductDependencyInfo::CreateFlags(AZ::Data::AssetLoadBehavior::NoLoad)));
             }
         }
 

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageAssetProducer.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageAssetProducer.cpp
@@ -197,6 +197,9 @@ namespace ImageProcessingAtom
             // Add all the mip chain assets as dependencies except the tail mip chain since its embedded in the StreamingImageAsset
             if (it->Get() != mipChains.begin()->Get())
             {
+                // Note: we don't want to preload the mipchain assets here to reduce loading time and memory footprint.
+                // The mipchain assets will be loaded by StreamingImage automatically or loaded when user is accessing the mipmap data via
+                // StreamingImageAsset::GetSubImageData() function
                 product.m_dependencies.push_back(AssetBuilderSDK::ProductDependency(it->GetId(), AZ::Data::ProductDependencyInfo::CreateFlags(AZ::Data::AssetLoadBehavior::NoLoad)));
             }
         }

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/StreamingImageAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/StreamingImageAsset.h
@@ -82,7 +82,7 @@ namespace AZ
             //! Given a mip chain index, returns the number of mip levels in the chain.
             size_t GetMipCount(size_t mipChainIndex) const;
 
-            //! Get image data for specified mip and slice. It may return empty array if its mipchain assets are not loaded
+            //! Get image data for specified mip and slice. It may trigger mipchain asset loading if the asset wasn't loaded
             AZStd::span<const uint8_t> GetSubImageData(uint32_t mip, uint32_t slice);
 
             //! Returns streaming image pool asset id of the pool that will be used to create the streaming image.

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/StreamingImageAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/StreamingImageAsset.cpp
@@ -172,12 +172,10 @@ namespace AZ
 
         AZStd::span<const uint8_t> StreamingImageAsset::GetSubImageData(uint32_t mip, uint32_t slice)
         {
-            const bool forceLoad = true;
-
             auto mipChainIndex = GetMipChainIndex(mip);
             const ImageMipChainAsset* mipChainAsset = GetImageMipChainAsset(mip);
 
-            if (mipChainAsset == nullptr && forceLoad)
+            if (mipChainAsset == nullptr)
             {
                 MipChain& mipChain = m_mipChains[mipChainIndex];
 

--- a/Gems/AtomLyIntegration/AtomImGuiTools/Code/Source/AtomImGuiToolsSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomImGuiTools/Code/Source/AtomImGuiToolsSystemComponent.cpp
@@ -111,6 +111,11 @@ namespace AtomImGuiTools
     {
         if (ImGui::BeginMenu("Atom Tools"))
         {
+            if (ImGui::MenuItem("Dump loaded Asset info", ""))
+            {
+                AZ::Data::AssetManager::Instance().DumpLoadedAssetsInfo();
+            }
+
             ImGui::MenuItem("Pass Viewer", "", &m_showPassTree);
             ImGui::MenuItem("Gpu Profiler", "", &m_showGpuProfiler);
             if (ImGui::MenuItem("Transient Attachment Profiler", "", &m_showTransientAttachmentProfiler))


### PR DESCRIPTION
## What does this PR do?
The load behavior for ImageMipChainAsset in StreamgingImageAsset was set to PreLoad which cause an issue that when StreamingImage is done using ImageMipChainAsset, it's still staying in memory since StreamgingImageAsset keep the reference of it. 
We changed the load behavior to NoLoad so it won't preload the ImageMipChainAsset when load StreamgingImageAsset. We have to also change the GetSubImageData function to load the mip chain asset so that decal or image gradient system would want to access the mipmap data on cpu directly. 

Other changes:
Added a MACRO to switch memory allocation from Hyha to os allocation. 
Added a debug function to AssetManager which outputs loaded assets files at runtime. 


## How was this PR tested?
Open a level in Editor with decal components. 
Use the ImGui Atom Tools->Dump Asset Size info menu to output loaded assets info. Open the log file AssetMemoryLog*. json under user/log folder and check the ImageMipChainAsset size. It should be a much smaller number compare to VRAM texture size. 

