### PR TITLE
Vlagutin/lua script missing class fix

### DIFF
--- a/Code/Framework/AzCore/AzCore/Script/ScriptContext.cpp
+++ b/Code/Framework/AzCore/AzCore/Script/ScriptContext.cpp
@@ -197,15 +197,20 @@ namespace AZ
             // Lua:
             lua_rawgeti(m_lua, LUA_REGISTRYINDEX, m_lambdaRegistryIndex);
             // Lua: lambda
-
+// Gruber patch begin. // LVB. // "success" is used to analyze "bool" result of ExposedLambda::StackPush
+            bool success = true;
             for (int i = 0; i < numArguments; ++i)
             {
-                ExposedLambda::StackPush(m_lua, behaviorContext, argsBVPs[i]);
+                success = ExposedLambda::StackPush(m_lua, behaviorContext, argsBVPs[i]);
             }
 
             // Lua: lambda, args...
-            Internal::LuaSafeCall(m_lua, numArguments, 0);
+            if (success)
+            {
+                Internal::LuaSafeCall(m_lua, numArguments, 0);
+            }
         }
+// Gruber patch end. // LVB. // "success" is used to analyze "bool" result of ExposedLambda::StackPush
 
         // \note Do not use, these are here for compiler compatibility only
         ExposedLambda()
@@ -230,8 +235,8 @@ namespace AZ
                 ? reinterpret_cast<T*>(argument.GetValueAddress())
                 : nullptr;
         }
-
-        static void StackPush(lua_State* lua, AZ::BehaviorContext* context, AZ::BehaviorArgument& argument)
+// Gruber patch begin. // LVB. // Was "void". Now it returns "bool"
+        static bool StackPush(lua_State* lua, AZ::BehaviorContext* context, AZ::BehaviorArgument& argument)
         {
             if (auto cStringPtr = GetAs<const char*>(argument))
             {
@@ -248,9 +253,11 @@ namespace AZ
             }
             else
             {
-                AZ::StackPush(lua, context, argument);
+                return AZ::StackPush(lua, context, argument);
             }
+            return true;
         }
+// Gruber patch end. // LVB. // Was "void". Now it returns "bool"
 
         int m_lambdaRegistryIndex;
         int m_refCountRegistryIndex;
@@ -3330,25 +3337,36 @@ LUA_API const Node* lua_getDummyNode()
             LuaLoadFromStack fromStack = FromLuaStack(context, &param, bcClass);
             return fromStack(lua, index, param, bcClass, allocator);
         }
-
         bool StackRead(lua_State* lua, int index, AZ::BehaviorArgument& param, AZ::StackVariableAllocator* allocator)
         {
             return StackRead(lua, index, ScriptContext::FromNativeContext(lua)->GetBoundContext(), param, allocator);
         }
 
-        void StackPush(lua_State* lua, AZ::BehaviorContext* context, AZ::BehaviorArgument& param)
+// Gruber patch begin. // LVB. // It were "void" functions. Now they return "bool"
+        bool StackPush(lua_State* lua, AZ::BehaviorContext* context, AZ::BehaviorArgument& param)
         {
             AZ::BehaviorClass* unused = nullptr;
             LuaPrepareValue prepareValue = nullptr;
             LuaPushToStack pushToStack = ToLuaStack(context, &param, &prepareValue, unused);
-            AZ_Assert(pushToStack != nullptr, "No LuaPushToStack function found for typeid: %s", param.m_typeId.ToString<AZStd::string>().data());
+#if defined(CARBONATED)
+            if (!pushToStack)
+            {
+                AZ_Error("ScriptContext", false, "No LuaPushToStack function found for typeid: %s", param.m_typeId.ToString<AZStd::string>().data());
+                return false;
+            }
+#else
+            AZ_Assert(
+                pushToStack != nullptr, "No LuaPushToStack function found for typeid: %s", param.m_typeId.ToString<AZStd::string>().data());
+#endif
             pushToStack(lua, param);
+            return true;
         }
 
-        void StackPush(lua_State* lua, AZ::BehaviorArgument& param)
+        bool StackPush(lua_State* lua, AZ::BehaviorArgument& param)
         {
-            StackPush(lua, ScriptContext::FromNativeContext(lua)->GetBoundContext(), param);
+            return StackPush(lua, ScriptContext::FromNativeContext(lua)->GetBoundContext(), param);
         }
+// Gruber patch end. // LVB. // It were "void" functions. Now they return "bool"
 
         LuaPushToStack ToLuaStack(BehaviorContext* context, const BehaviorParameter* param, LuaPrepareValue* prepareParam, BehaviorClass*& behaviorClass)
         {

--- a/Code/Framework/AzCore/AzCore/Script/ScriptContext.cpp
+++ b/Code/Framework/AzCore/AzCore/Script/ScriptContext.cpp
@@ -198,6 +198,7 @@ namespace AZ
             lua_rawgeti(m_lua, LUA_REGISTRYINDEX, m_lambdaRegistryIndex);
             // Lua: lambda
 // Gruber patch begin. // LVB. // "success" is used to analyze "bool" result of ExposedLambda::StackPush
+#if defined(CARBONATED)
             bool success = true;
             for (int i = 0; i < numArguments; ++i)
             {
@@ -209,6 +210,15 @@ namespace AZ
             {
                 Internal::LuaSafeCall(m_lua, numArguments, 0);
             }
+#else
+            for (int i = 0; i < numArguments; ++i)
+            {
+                ExposedLambda::StackPush(m_lua, behaviorContext, argsBVPs[i]);
+            }
+
+            // Lua: lambda, args...
+            Internal::LuaSafeCall(m_lua, numArguments, 0);
+#endif
         }
 // Gruber patch end. // LVB. // "success" is used to analyze "bool" result of ExposedLambda::StackPush
 

--- a/Code/Framework/AzCore/AzCore/Script/ScriptContext.h
+++ b/Code/Framework/AzCore/AzCore/Script/ScriptContext.h
@@ -955,8 +955,8 @@ namespace AZ
     LuaLoadFromStack FromLuaStack(AZ::BehaviorContext* context, const AZ::BehaviorParameter* param, AZ::BehaviorClass*& behaviorClass);
     LuaPushToStack ToLuaStack(AZ::BehaviorContext* context, const AZ::BehaviorParameter* param, LuaPrepareValue* prepareParamOut, AZ::BehaviorClass*& behaviorClass);
 
-    void StackPush(lua_State* lua, AZ::BehaviorContext* context, AZ::BehaviorArgument& param);
-    void StackPush(lua_State* lua, AZ::BehaviorArgument& param);
+    bool StackPush(lua_State* lua, AZ::BehaviorContext* context, AZ::BehaviorArgument& param);  // Gruber patch. // LVB. // Was "void". Now it returns "bool"
+    bool StackPush(lua_State* lua, AZ::BehaviorArgument& param);                                // Gruber patch. // LVB. // Was "void". Now it returns "bool"
     bool StackRead(lua_State* lua, int index, AZ::BehaviorContext* context,  AZ::BehaviorArgument& param, AZ::StackVariableAllocator*);
     bool StackRead(lua_State* lua, int index, AZ::BehaviorArgument& param, AZ::StackVariableAllocator* = nullptr);
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/Interpreted/ExecutionInterpretedAPI.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/Interpreted/ExecutionInterpretedAPI.cpp
@@ -472,7 +472,8 @@ namespace ScriptCanvas
         //////////////////////////////////////////////////////////////////////////
         // \todo ScriptCanvas will probably need its own version of all of these functions
         //////////////////////////////////////////////////////////////////////////
-        void StackPush(lua_State* lua, AZ::BehaviorContext* context, AZ::BehaviorArgument& argument)
+// Gruber patch begin. // LVB. // Was "void". Now it returns "bool"
+        bool StackPush(lua_State* lua, AZ::BehaviorContext* context, AZ::BehaviorArgument& argument)
         {
             using namespace ExecutionInterpretedAPICpp;
 
@@ -492,9 +493,11 @@ namespace ScriptCanvas
             else
             {
                 // \todo determine whether or not to adjust this for return results
-                AZ::StackPush(lua, context, argument);
+                return AZ::StackPush(lua, context, argument);   // Gruber patch. // LVB. // Was "void". Now it returns "bool"
             }
+            return true;
         }
+// Gruber patch end. // LVB. // Was "void". Now it returns "bool"
 
         bool StackRead(lua_State* lua, AZ::BehaviorContext* context, int index, AZ::BehaviorArgument& param, AZ::StackVariableAllocator* allocator)
         {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/Interpreted/ExecutionInterpretedAPI.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/Interpreted/ExecutionInterpretedAPI.h
@@ -65,7 +65,7 @@ namespace ScriptCanvas
 
         void SetInterpretedExecutionModeRelease();
 
-        void StackPush(lua_State* lua, AZ::BehaviorContext* context, AZ::BehaviorArgument& param);
+        bool StackPush(lua_State* lua, AZ::BehaviorContext* context, AZ::BehaviorArgument& param);  // Gruber patch. // LVB. // Was "void". Now it returns "bool"
 
         bool StackRead(lua_State* lua, AZ::BehaviorContext* context, int index, AZ::BehaviorArgument& param, AZ::StackVariableAllocator* allocator);
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/Interpreted/ExecutionStateInterpretedUtility.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/Interpreted/ExecutionStateInterpretedUtility.cpp
@@ -32,7 +32,8 @@ namespace ExecutionStateInterpretedUtilityCpp
                 AZ::BehaviorParameter param;
                 param.m_typeId = debugDataSource.m_slotDatumType.GetAZType();
                 debugDataSource.m_fromStack = FromLuaStack(behaviorContext, &param, behaviorClassUnused);
-                SC_RUNTIME_CHECK(debugDataSource.m_fromStack, "LuaLoadFromStack function not found")
+                // Gruber patch. // LVB. // Adding the type of the function that can't be found
+                SC_RUNTIME_CHECK(debugDataSource.m_fromStack, "LuaLoadFromStack function not found for type %s", param.m_typeId.ToString<AZStd::string>().data())
             }            
         }
     }


### PR DESCRIPTION
## What does this PR do?

In some cases Script Canvas Editor saves into .scriptcanvas file a reference to an unknown BehaviorContext (for example {34090800-E280-53DD-BE6D-EDD57451B4AD}). 
Later during start of the application it reports an Assert (LuaLoadFromStack function not found for type {34090800-E280-53DD-BE6D-EDD57451B4AD}) but we can continue if we ignore this Assert.
But when an according event is fired and the script is trying to execute required part then the application crashes.
The fix is to analyze the result of StackPush methods and don't execute the next line of the code.
 
## How was this PR tested?

The application crashed before but now it reports the error and continues to work
