### PR TITLE
Implemented missed CARBONATED part of code in UiCanvasBus

### DIFF
--- a/Gems/LyShine/Code/Include/LyShine/Bus/UiCanvasBus.h
+++ b/Gems/LyShine/Code/Include/LyShine/Bus/UiCanvasBus.h
@@ -366,6 +366,16 @@ public: // member functions
 
     //! Called when the canvas sends an action to the listener
     virtual void OnAction(AZ::EntityId entityId, const LyShine::ActionName& actionName) = 0;
+#if defined(CARBONATED)
+    //! Called when the canvas sends an action to the listener (With bonus multitouch info)
+    virtual void OnActionMultitouch(
+        [[maybe_unused]] AZ::EntityId entityId,
+        [[maybe_unused]] const LyShine::ActionName& actionName,
+        [[maybe_unused]] const AZ::Vector2& actionPosition,
+        [[maybe_unused]] int multiTouchIndex){};
+    //! Called when the canvas's enabled state changed
+    virtual void OnEnableStateChanged([[maybe_unused]] AZ::EntityId entityId, [[maybe_unused]] bool state){};
+#endif
 };
 
 typedef AZ::EBus<UiCanvasActionNotification> UiCanvasNotificationBus;

--- a/Gems/LyShine/Code/Include/LyShine/Bus/UiCanvasBus.h
+++ b/Gems/LyShine/Code/Include/LyShine/Bus/UiCanvasBus.h
@@ -366,6 +366,7 @@ public: // member functions
 
     //! Called when the canvas sends an action to the listener
     virtual void OnAction(AZ::EntityId entityId, const LyShine::ActionName& actionName) = 0;
+// Carbonated begin. (vlagutin/CarbonatedUiCanvasBus): Missing custom (CARBONATED) multitouch functionality from LY
 #if defined(CARBONATED)
     //! Called when the canvas sends an action to the listener (With bonus multitouch info)
     virtual void OnActionMultitouch(
@@ -376,6 +377,7 @@ public: // member functions
     //! Called when the canvas's enabled state changed
     virtual void OnEnableStateChanged([[maybe_unused]] AZ::EntityId entityId, [[maybe_unused]] bool state){};
 #endif
+// Carbonated end
 };
 
 typedef AZ::EBus<UiCanvasActionNotification> UiCanvasNotificationBus;

--- a/Gems/LyShine/Code/Source/UiCanvasComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiCanvasComponent.cpp
@@ -82,7 +82,7 @@ public:
     {
         Call(FN_OnAction, entityId, actionName);
     }
-	
+    
 #if defined(CARBONATED)
     void OnActionMultitouch(AZ::EntityId entityId, const LyShine::ActionName& actionName, const AZ::Vector2& position, int multitouchIndex) override
     {

--- a/Gems/LyShine/Code/Source/UiCanvasComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiCanvasComponent.cpp
@@ -2510,9 +2510,11 @@ void UiCanvasComponent::Reflect(AZ::ReflectContext* context)
             ->Event("SetTooltipDisplayElement", &UiCanvasBus::Events::SetTooltipDisplayElement)
             ->Event("GetHoverInteractable", &UiCanvasBus::Events::GetHoverInteractable)
             ->Event("ForceHoverInteractable", &UiCanvasBus::Events::ForceHoverInteractable)
+// Carbonated begin. (vlagutin/CarbonatedUiCanvasBus): Missing custom (CARBONATED) multitouch functionality from LY
 #if defined CARBONATED
             ->Event("GetMousePosition", &UiCanvasBus::Events::GetMousePosition)
 #endif
+// Carbonated end
             ->Event("ForceEnterInputEventOnInteractable", &UiCanvasBus::Events::ForceEnterInputEventOnInteractable);
 
 

--- a/Gems/LyShine/Code/Source/UiCanvasComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiCanvasComponent.cpp
@@ -68,6 +68,7 @@ class UiCanvasNotificationBusBehaviorHandler
     , public AZ::BehaviorEBusHandler
 {
 public:
+// Carbonated begin. (vlagutin/CarbonatedUiCanvasBus): Missing custom (CARBONATED) multitouch functionality from LY
 #if defined(CARBONATED)
     AZ_EBUS_BEHAVIOR_BINDER(UiCanvasNotificationBusBehaviorHandler, "{64014B4F-E12F-4839-99B0-426B5717DB44}", AZ::SystemAllocator,
         OnAction,
@@ -77,12 +78,12 @@ public:
     AZ_EBUS_BEHAVIOR_BINDER(UiCanvasNotificationBusBehaviorHandler, "{64014B4F-E12F-4839-99B0-426B5717DB44}", AZ::SystemAllocator,
         OnAction);
 #endif
-
+// Carbonated end
     void OnAction(AZ::EntityId entityId, const LyShine::ActionName& actionName) override
     {
         Call(FN_OnAction, entityId, actionName);
     }
-    
+// Carbonated begin. (vlagutin/CarbonatedUiCanvasBus): Missing custom (CARBONATED) multitouch functionality from LY
 #if defined(CARBONATED)
     void OnActionMultitouch(AZ::EntityId entityId, const LyShine::ActionName& actionName, const AZ::Vector2& position, int multitouchIndex) override
     {
@@ -94,6 +95,7 @@ public:
         Call(FN_OnEnableStateChanged, canvasEntityId, enabled);
     }
 #endif
+// Carbonated end
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -184,6 +186,7 @@ public:
     }
 };
 
+// Carbonated begin. (vlagutin/CarbonatedUiCanvasBus): Missing custom (CARBONATED) multitouch functionality from LY
 #if defined(CARBONATED)
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //! UiCanvasEnabledStateNotificationBus Behavior context handler class
@@ -201,7 +204,7 @@ public:
     }
 };
 #endif
-
+// Carbonated end
 // Anonymous namespace
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 namespace
@@ -1011,10 +1014,11 @@ void UiCanvasComponent::SetEnabled(bool enabled)
     {
         m_enabled = enabled;
         MarkRenderGraphDirty();
+// Carbonated begin. (vlagutin/CarbonatedUiCanvasBus): Missing custom (CARBONATED) multitouch functionality from LY
 #if defined(CARBONATED)
         EBUS_EVENT(UiCanvasNotificationBus, OnEnableStateChanged, GetEntityId(), m_enabled);
 #endif
-
+// Carbonated end
         UiCanvasEnabledStateNotificationBus::Broadcast(
             &UiCanvasEnabledStateNotificationBus::Events::OnCanvasEnabledStateChanged, GetEntityId(), m_enabled);
     }
@@ -1232,8 +1236,8 @@ bool UiCanvasComponent::HandleInputPositionalEvent(const AzFramework::InputChann
             m_lastMousePosition = viewportPos;
         }
     }
-
-#if defined CARBONATED
+// Carbonated begin. (vlagutin/CarbonatedUiCanvasBus): Missing custom (CARBONATED) multitouch functionality from LY
+#if defined(CARBONATED)
     //Well treat the first finger input as the 'mouse position'
     if (inputSnapshot.m_channelId == AzFramework::InputDeviceTouch::Touch::Index0)
     {
@@ -1243,7 +1247,7 @@ bool UiCanvasComponent::HandleInputPositionalEvent(const AzFramework::InputChann
         }
     }
 #endif
-
+// Carbonated end
     // Currently we are just interested in mouse events and the primary touch for hover events
     if (AzFramework::InputDeviceMouse::IsMouseDevice(inputSnapshot.m_deviceId) ||
         inputSnapshot.m_channelId == AzFramework::InputDeviceTouch::Touch::Index0)
@@ -2547,11 +2551,12 @@ void UiCanvasComponent::Reflect(AZ::ReflectContext* context)
 
         behaviorContext->EBus<UiCanvasInputNotificationBus>("UiCanvasInputNotificationBus")
             ->Handler<UiCanvasInputNotificationBusBehaviorHandler>();
-
+// Carbonated begin. (vlagutin/CarbonatedUiCanvasBus): Missing custom (CARBONATED) multitouch functionality from LY
 #if defined(CARBONATED)
         behaviorContext->EBus<UiCanvasEnabledStateNotificationBus>("UiCanvasEnabledStateNotificationBus")
             ->Handler<UiCanvasEnabledStateNotificationBusBehaviorHandler>();
 #endif
+// Carbonated end
     }
 }
 

--- a/Gems/LyShine/Code/Source/UiInteractableComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiInteractableComponent.cpp
@@ -64,6 +64,9 @@ UiInteractableComponent::UiInteractableComponent()
     , m_isHover(false)
     , m_isPressed(false)
     , m_pressedPoint(0.0f, 0.0f)
+#if defined(CARBONATED)
+    , m_pressedMultiTouchIndex(0)
+#endif
     , m_state(UiInteractableStatesInterface::StateNormal)
     , m_hoverStartActionCallback(nullptr)
     , m_hoverEndActionCallback(nullptr)
@@ -125,7 +128,11 @@ bool UiInteractableComponent::HandleReleased([[maybe_unused]] AZ::Vector2 point)
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 bool UiInteractableComponent::HandleMultiTouchPressed(AZ::Vector2 point, int multiTouchIndex)
 {
+#if defined(CARBONATED)
+    m_pressedMultiTouchIndex = multiTouchIndex;
+#else
     AZ_UNUSED(multiTouchIndex);
+#endif
     bool shouldStayActive = false;
     return m_isHandlingMultiTouchEvents && HandlePressed(point, shouldStayActive);
 }
@@ -134,7 +141,13 @@ bool UiInteractableComponent::HandleMultiTouchPressed(AZ::Vector2 point, int mul
 bool UiInteractableComponent::HandleMultiTouchReleased(AZ::Vector2 point, int multiTouchIndex)
 {
     AZ_UNUSED(multiTouchIndex);
+#if defined(CARBONATED)
+    bool handled = m_isHandlingMultiTouchEvents && HandleReleased(point);
+    m_pressedMultiTouchIndex = 0;
+    return handled;
+#else
     return m_isHandlingMultiTouchEvents && HandleReleased(point);
+#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -511,6 +524,9 @@ void UiInteractableComponent::Reflect(AZ::ReflectContext* context)
             ->Event("IsHandlingMultiTouchEvents", &UiInteractableBus::Events::IsHandlingMultiTouchEvents)
             ->Event("SetIsHandlingMultiTouchEvents", &UiInteractableBus::Events::SetIsHandlingMultiTouchEvents)
             ->Event("GetIsAutoActivationEnabled", &UiInteractableBus::Events::GetIsAutoActivationEnabled)
+#if defined(CARBONATED)
+            ->Event("LostActiveStatus", &UiInteractableBus::Events::LostActiveStatus)
+#endif
             ->Event("SetIsAutoActivationEnabled", &UiInteractableBus::Events::SetIsAutoActivationEnabled);
 
         behaviorContext->EBus<UiInteractableActionsBus>("UiInteractableActionsBus")
@@ -707,6 +723,10 @@ void UiInteractableComponent::TriggerPressedAction()
         UiElementBus::EventResult(canvasEntityId, GetEntityId(), &UiElementBus::Events::GetCanvasEntityId);
         // Queue the event to prevent deletions during the input event
         UiCanvasNotificationBus::QueueEvent(canvasEntityId, &UiCanvasNotificationBus::Events::OnAction, GetEntityId(), m_pressedActionName);
+#if defined(CARBONATED)
+        UiCanvasNotificationBus::QueueEvent(canvasEntityId, &UiCanvasNotificationBus::Events::OnActionMultitouch, GetEntityId(), m_pressedActionName, m_pressedPoint, m_pressedMultiTouchIndex);
+#endif
+
     }
 }
 
@@ -730,6 +750,9 @@ void UiInteractableComponent::TriggerReleasedAction()
         // Queue the event to prevent deletions during the input event
         UiCanvasNotificationBus::QueueEvent(
             canvasEntityId, &UiCanvasNotificationBus::Events::OnAction, GetEntityId(), m_releasedActionName);
+#if defined(CARBONATED)
+        UiCanvasNotificationBus::QueueEvent(canvasEntityId, &UiCanvasNotificationBus::Events::OnActionMultitouch, GetEntityId(), m_releasedActionName, m_pressedPoint, m_pressedMultiTouchIndex);
+#endif
     }
 }
 

--- a/Gems/LyShine/Code/Source/UiInteractableComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiInteractableComponent.cpp
@@ -64,9 +64,11 @@ UiInteractableComponent::UiInteractableComponent()
     , m_isHover(false)
     , m_isPressed(false)
     , m_pressedPoint(0.0f, 0.0f)
+// Carbonated begin. (vlagutin/CarbonatedUiCanvasBus): Missing custom (CARBONATED) multitouch functionality from LY
 #if defined(CARBONATED)
     , m_pressedMultiTouchIndex(0)
 #endif
+// Carbonated end
     , m_state(UiInteractableStatesInterface::StateNormal)
     , m_hoverStartActionCallback(nullptr)
     , m_hoverEndActionCallback(nullptr)
@@ -128,11 +130,13 @@ bool UiInteractableComponent::HandleReleased([[maybe_unused]] AZ::Vector2 point)
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 bool UiInteractableComponent::HandleMultiTouchPressed(AZ::Vector2 point, int multiTouchIndex)
 {
+// Carbonated begin. (vlagutin/CarbonatedUiCanvasBus): Missing custom (CARBONATED) multitouch functionality from LY
 #if defined(CARBONATED)
     m_pressedMultiTouchIndex = multiTouchIndex;
 #else
     AZ_UNUSED(multiTouchIndex);
 #endif
+// Carbonated end
     bool shouldStayActive = false;
     return m_isHandlingMultiTouchEvents && HandlePressed(point, shouldStayActive);
 }
@@ -141,6 +145,7 @@ bool UiInteractableComponent::HandleMultiTouchPressed(AZ::Vector2 point, int mul
 bool UiInteractableComponent::HandleMultiTouchReleased(AZ::Vector2 point, int multiTouchIndex)
 {
     AZ_UNUSED(multiTouchIndex);
+// Carbonated begin. (vlagutin/CarbonatedUiCanvasBus): Missing custom (CARBONATED) multitouch functionality from LY
 #if defined(CARBONATED)
     bool handled = m_isHandlingMultiTouchEvents && HandleReleased(point);
     m_pressedMultiTouchIndex = 0;
@@ -148,6 +153,7 @@ bool UiInteractableComponent::HandleMultiTouchReleased(AZ::Vector2 point, int mu
 #else
     return m_isHandlingMultiTouchEvents && HandleReleased(point);
 #endif
+// Carbonated end
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -524,9 +530,11 @@ void UiInteractableComponent::Reflect(AZ::ReflectContext* context)
             ->Event("IsHandlingMultiTouchEvents", &UiInteractableBus::Events::IsHandlingMultiTouchEvents)
             ->Event("SetIsHandlingMultiTouchEvents", &UiInteractableBus::Events::SetIsHandlingMultiTouchEvents)
             ->Event("GetIsAutoActivationEnabled", &UiInteractableBus::Events::GetIsAutoActivationEnabled)
+// Carbonated begin. (vlagutin/CarbonatedUiCanvasBus): Missing custom (CARBONATED) multitouch functionality from LY
 #if defined(CARBONATED)
             ->Event("LostActiveStatus", &UiInteractableBus::Events::LostActiveStatus)
 #endif
+// Carbonated end
             ->Event("SetIsAutoActivationEnabled", &UiInteractableBus::Events::SetIsAutoActivationEnabled);
 
         behaviorContext->EBus<UiInteractableActionsBus>("UiInteractableActionsBus")
@@ -723,10 +731,11 @@ void UiInteractableComponent::TriggerPressedAction()
         UiElementBus::EventResult(canvasEntityId, GetEntityId(), &UiElementBus::Events::GetCanvasEntityId);
         // Queue the event to prevent deletions during the input event
         UiCanvasNotificationBus::QueueEvent(canvasEntityId, &UiCanvasNotificationBus::Events::OnAction, GetEntityId(), m_pressedActionName);
+// Carbonated begin. (vlagutin/CarbonatedUiCanvasBus): Missing custom (CARBONATED) multitouch functionality from LY
 #if defined(CARBONATED)
         UiCanvasNotificationBus::QueueEvent(canvasEntityId, &UiCanvasNotificationBus::Events::OnActionMultitouch, GetEntityId(), m_pressedActionName, m_pressedPoint, m_pressedMultiTouchIndex);
 #endif
-
+// Carbonated end
     }
 }
 
@@ -750,9 +759,11 @@ void UiInteractableComponent::TriggerReleasedAction()
         // Queue the event to prevent deletions during the input event
         UiCanvasNotificationBus::QueueEvent(
             canvasEntityId, &UiCanvasNotificationBus::Events::OnAction, GetEntityId(), m_releasedActionName);
+// Carbonated begin. (vlagutin/CarbonatedUiCanvasBus): Missing custom (CARBONATED) multitouch functionality from LY
 #if defined(CARBONATED)
         UiCanvasNotificationBus::QueueEvent(canvasEntityId, &UiCanvasNotificationBus::Events::OnActionMultitouch, GetEntityId(), m_releasedActionName, m_pressedPoint, m_pressedMultiTouchIndex);
 #endif
+// Carbonated end
     }
 }
 

--- a/Gems/LyShine/Code/Source/UiInteractableComponent.h
+++ b/Gems/LyShine/Code/Source/UiInteractableComponent.h
@@ -171,6 +171,11 @@ protected: // data members
     //! the viewport position at which the press event occured (only valid if m_isPressed is true)
     AZ::Vector2 m_pressedPoint;
 
+#if defined(CARBONATED)
+    //! the multitouch position at which the press event occured (only valid if m_isPressed is true)
+    int m_pressedMultiTouchIndex;
+#endif
+
     //! The current interactable state. This is stored so that we can detect state changes.
     UiInteractableStatesInterface::State m_state;
 

--- a/Gems/LyShine/Code/Source/UiInteractableComponent.h
+++ b/Gems/LyShine/Code/Source/UiInteractableComponent.h
@@ -170,12 +170,12 @@ protected: // data members
 
     //! the viewport position at which the press event occured (only valid if m_isPressed is true)
     AZ::Vector2 m_pressedPoint;
-
+// Carbonated begin. (vlagutin/CarbonatedUiCanvasBus): Missing custom (CARBONATED) multitouch functionality from LY
 #if defined(CARBONATED)
     //! the multitouch position at which the press event occured (only valid if m_isPressed is true)
     int m_pressedMultiTouchIndex;
 #endif
-
+// Carbonated end
     //! The current interactable state. This is stored so that we can detect state changes.
     UiInteractableStatesInterface::State m_state;
 


### PR DESCRIPTION
## What does this PR do?

Restoring the customized (CARBONATED) parts of the code from LY to O3DE

## How was this PR tested?

During regular play no more errors from LUA script
