### PR TITLE
[MADPORT-453] Migration 23.10 issue with missing #include

### DIFF
--- a/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorApplyMotionSetComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorApplyMotionSetComponent.cpp
@@ -8,6 +8,7 @@
 
 #if defined(CARBONATED)
 #include <AzCore/Asset/AssetManager.h>
+#include <AzCore/Asset/AssetSerializer.h> // Gruber patch // VMED
 #include <AzCore/Script/ScriptProperty.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>


### PR DESCRIPTION
## What does this PR do?

Added missing #include (required for build with UNITY_BUILD=OFF)

## How was this PR tested?

Verified locally
