### PR TITLE
[iOS][Memory] Additional image procession restrictions to save the memory

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/Albedo.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/Albedo.preset
@@ -32,7 +32,7 @@
                 "Name": "Albedo",
                 "RGB_Weight": "CIEXYZ",
                 "PixelFormat": "ASTC_6x6",
-                "MaxTextureSize": 2048,
+                "MaxTextureSize": 512,
                 "DiscardAlpha": true,
                 "IsPowerOf2": true,
                 "MipMapSetting": {

--- a/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/Emissive.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/Emissive.preset
@@ -30,7 +30,7 @@
                 "Name": "Emissive",
                 "RGB_Weight": "CIEXYZ",
                 "PixelFormat": "ASTC_6x6",
-                "MaxTextureSize": 2048,
+                "MaxTextureSize": 512,
                 "DiscardAlpha": true,
                 "MipMapSetting": {
                   "MipGenType": "Box"

--- a/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/Normals.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/Normals.preset
@@ -38,7 +38,7 @@
                 "DestColor": "Linear",
                 "PixelFormat": "ASTC_4x4",
                 "DiscardAlpha": true,
-                "MaxTextureSize": 1024,
+                "MaxTextureSize": 512,
                 "IsPowerOf2": true,
                 "MipRenormalize": true,
                 "MipMapSetting": {

--- a/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/NormalsWithSmoothness.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/NormalsWithSmoothness.preset
@@ -40,7 +40,7 @@
                 "DestColor": "Linear",
                 "PixelFormat": "ASTC_4x4",
                 "PixelFormatAlpha": "ASTC_4x4",
-                "MaxTextureSize": 2048,
+                "MaxTextureSize": 512,
                 "IsPowerOf2": true,
                 "GlossFromNormal": 1,
                 "MipRenormalize": true,

--- a/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/Opacity.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/Opacity.preset
@@ -36,7 +36,7 @@
                 "DestColor": "Linear",
                 "PixelFormat": "ASTC_4x4",
                 "Swizzle": "rrr1",
-                "MaxTextureSize": 2048,
+                "MaxTextureSize": 512,
                 "IsPowerOf2": true,
                 "MipMapSetting": {
                     "MipGenType": "Box"

--- a/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/Reflectance.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/Reflectance.preset
@@ -35,7 +35,7 @@
                 "DestColor": "Linear",
                 "PixelFormat": "ASTC_6x6",
                 "Swizzle": "rrr1",
-                "MaxTextureSize": 2048,
+                "MaxTextureSize": 512,
                 "IsPowerOf2": true,
                 "MipMapSetting": {
                     "MipGenType": "Box"


### PR DESCRIPTION
## What does this PR do?
This is required to save the memory to launch the level on iOS device. Additional image procession restrictions to save the memory.


## How was this PR tested?

Launched asset processor and ensured the processed images in the Cached folder are changed.
