### PR TITLE
[Error handling] Overriding assert handling for script canvas

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/Interpreted/ExecutionStateInterpretedUtility.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/Interpreted/ExecutionStateInterpretedUtility.cpp
@@ -33,7 +33,11 @@ namespace ExecutionStateInterpretedUtilityCpp
                 param.m_typeId = debugDataSource.m_slotDatumType.GetAZType();
                 debugDataSource.m_fromStack = FromLuaStack(behaviorContext, &param, behaviorClassUnused);
                 // Gruber patch. // LVB. // Adding the type of the function that can't be found
-                SC_RUNTIME_CHECK(debugDataSource.m_fromStack, "LuaLoadFromStack function not found for type %s", param.m_typeId.ToString<AZStd::string>().data())
+                //SC_RUNTIME_CHECK(debugDataSource.m_fromStack, "LuaLoadFromStack function not found for type %s", param.m_typeId.ToString<AZStd::string>().data())
+                if (debugDataSource.m_fromStack == nullptr)
+                {
+                    AZ_Warning("ExecutionStateInterpretedUtilityCpp", false, "LuaLoadFromStack function not found for type %s", param.m_typeId.ToString<AZStd::string>().data());
+                }
             }            
         }
     }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/Interpreted/ExecutionStateInterpretedUtility.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/Interpreted/ExecutionStateInterpretedUtility.cpp
@@ -38,6 +38,7 @@ namespace ExecutionStateInterpretedUtilityCpp
                 {
                     AZ_Warning("ExecutionStateInterpretedUtilityCpp", false, "LuaLoadFromStack function not found for type %s", param.m_typeId.ToString<AZStd::string>().data());
                 }
+                // Gruber patch end.
             }            
         }
     }


### PR DESCRIPTION
## What does this PR do?

Warning the errors instead of asserting in runtime. This keeps the build running instead of crashing it

## How was this PR tested?

Run the build