### PR TITLE
[Error handling] Replacing asserts with warnings

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/ImageBasedLights/ImageBasedLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ImageBasedLights/ImageBasedLightFeatureProcessor.cpp
@@ -87,12 +87,24 @@ namespace AZ
         {
             const constexpr char* DefaultSpecularCubeMapPath = "textures/default/default_iblglobalcm_iblspecular.dds.streamingimage";
             const constexpr char* DefaultDiffuseCubeMapPath = "textures/default/default_iblglobalcm_ibldiffuse.dds.streamingimage";
-
+            
             m_defaultSpecularImage = RPI::LoadStreamingTexture(DefaultSpecularCubeMapPath);
-            AZ_Assert(m_defaultSpecularImage, "Failed to load default specular cubemap");
-
+            // Gruber patch. ivasilec : do not assert here
+            // AZ_Assert(m_defaultSpecularImage, "Failed to load default specular cubemap");
+            if (!m_defaultSpecularImage)
+            {
+                AZ_Warning("ImageBasedLightFeatureProcessor", false, "Failed to load default specular cubemap");
+            }
+            // Gruber end
+            
             m_defaultDiffuseImage = RPI::LoadStreamingTexture(DefaultDiffuseCubeMapPath);
-            AZ_Assert(m_defaultDiffuseImage, "Failed to load default diffuse cubemap");
+            // Gruber patch. ivasilec : do not assert here
+            //AZ_Assert(m_defaultDiffuseImage, "Failed to load default diffuse cubemap");
+            if (!m_defaultDiffuseImage)
+            {
+                AZ_Warning("ImageBasedLightFeatureProcessor", false, "Failed to load default diffuse cubemap");
+            }
+            // Gruber end
         }
 
         Data::Instance<RPI::Image> ImageBasedLightFeatureProcessor::GetInstanceForImage(const Data::Asset<RPI::StreamingImageAsset>& imageAsset, const Data::Instance<RPI::Image>& defaultImage)

--- a/Gems/Atom/Feature/Common/Code/Source/SkyBox/SkyBoxFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkyBox/SkyBoxFeatureProcessor.cpp
@@ -210,7 +210,13 @@ namespace AZ
         {
             const constexpr char* DefaultCubeMapPath = "textures/default/default_skyboxcm.dds.streamingimage";
             m_defaultCubemapTexture = RPI::LoadStreamingTexture(DefaultCubeMapPath);
-            AZ_Assert(m_defaultCubemapTexture, "Failed to load default cubemap");
+            // Gruber patch. ivasilec : do not assert here
+            //AZ_Assert(m_defaultCubemapTexture, "Failed to load default cubemap");
+            if (!m_defaultCubemapTexture)
+            {
+                AZ_Warning("", false, "Failed to load default cubemap");
+            }
+            // Gruber end
         }
 
         void SkyBoxFeatureProcessor::Enable(bool enable)


### PR DESCRIPTION
## What does this PR do?

Warning the errors instead of asserting in runtime. This keeps the build running instead of crashing it

## How was this PR tested?

Launch on iOS device from XCode
