### PR TITLE
Add support for shader options within PCF filtering for directional light shadows

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadow.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadow.azsli
@@ -33,7 +33,6 @@ option ShadowFilterMethod o_directional_shadow_filtering_method = ShadowFilterMe
 option bool o_directional_shadow_receiver_plane_bias_enable = true;
 option bool o_blend_between_cascades_enable = false;
 
-
 // DirectionalLightShadow calculates lit ratio for a directional light.
 class DirectionalLightShadow
 {

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadow.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadow.azsli
@@ -33,6 +33,7 @@ option ShadowFilterMethod o_directional_shadow_filtering_method = ShadowFilterMe
 option bool o_directional_shadow_receiver_plane_bias_enable = true;
 option bool o_blend_between_cascades_enable = false;
 
+
 // DirectionalLightShadow calculates lit ratio for a directional light.
 class DirectionalLightShadow
 {
@@ -76,6 +77,7 @@ DirectionalShadowCalculator DirectionalLightShadow::MakeShadowCalculator(uint li
     calc.SetWorldNormal(normalVector);
     calc.SetLightIndex(lightIndex);
     calc.SetFilterMode(o_directional_shadow_filtering_method);
+    calc.SetFilteringSampleCount(o_directional_shadow_filtering_sample_count);
     calc.SetWorldPos(worldPos);
     return calc;
 }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadowCalculator.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadowCalculator.azsli
@@ -11,8 +11,8 @@
 #endif
 
 enum class ShadowFilterMethod {None, Pcf, Esm, EsmPcf};
-enum class ShadowFilterSampleCount {Tap0, Tap4, Tap9, Tap16};
-option ShadowFilterSampleCount o_directional_shadow_filtering_sample_count = ShadowFilterSampleCount::Tap16;
+enum class ShadowFilterSampleCount {PcfTap4, PcfTap9, PcfTap16};
+option ShadowFilterSampleCount o_directional_shadow_filtering_sample_count = ShadowFilterSampleCount::PcfTap16;
 
 // avoiding artifact between cascade levels.
 #define PIXEL_MARGIN (1.5)
@@ -308,11 +308,11 @@ float DirectionalShadowCalculator::SamplePcfBicubic(const float3 shadowCoord, co
     
     switch(filteringSampleCountMode)
     {
-        case ShadowFilterSampleCount::Tap4:
+        case ShadowFilterSampleCount::PcfTap4:
             return SampleShadowMapBicubic_4Tap(param);
-        case ShadowFilterSampleCount::Tap9:
+        case ShadowFilterSampleCount::PcfTap9:
             return SampleShadowMapBicubic_9Tap(param);
-        case ShadowFilterSampleCount::Tap16:
+        case ShadowFilterSampleCount::PcfTap16:
             return SampleShadowMapBicubic_16Tap(param);
         default:
             //Use 16 tap by default

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadowCalculator.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadowCalculator.azsli
@@ -61,9 +61,9 @@ class DirectionalShadowCalculator
         m_filterMode = filterMode;
     }
 
-    void SetFilteringSampleCount(const ShadowFilterSampleCount filteringSampleCount)
+    void SetFilteringSampleCount(const ShadowFilterSampleCount filteringSampleCountMode)
     {
-        m_filteringSampleCount = filteringSampleCount;
+        m_filteringSampleCountMode = filteringSampleCountMode;
     }
 
     void GetShadowCascadeRange(float3 shadowCoords[ViewSrg::MaxCascadeCount], int cascadeCount, uint shadowmapSize, out int minShadowCascade, out int maxShadowCascade);
@@ -93,8 +93,8 @@ class DirectionalShadowCalculator
     int m_minCascade;
     int m_maxCascade;
     int m_cascadeCount;
-    ShadowFilterSampleCount m_filteringSampleCount;
     ShadowFilterMethod m_filterMode;
+    ShadowFilterSampleCount m_filteringSampleCountMode;
 
     Texture2DArray<float> m_directionalLightShadowmap;   
     Texture2DArray<float> m_directionalLightExponentialShadowmap;        
@@ -289,7 +289,7 @@ float DirectionalShadowCalculator::GetVisibilityFromLightNoFilter()
 
 float DirectionalShadowCalculator::SamplePcfBicubic(const float3 shadowCoord, const int indexOfCascade)
 {
-    const ShadowFilterSampleCount filteringSampleCount = m_filteringSampleCount;
+    const ShadowFilterSampleCount filteringSampleCountMode = m_filteringSampleCountMode;
     const uint size = ViewSrg::m_directionalLightShadows[m_lightIndex].m_shadowmapSize;
     
     SampleShadowMapBicubicParameters param;
@@ -306,19 +306,19 @@ float DirectionalShadowCalculator::SamplePcfBicubic(const float3 shadowCoord, co
     param.receiverPlaneDepthBias = m_receiverShadowPlaneBiasEnable ? ComputeReceiverPlaneDepthBias(m_shadowPosDX[indexOfCascade], m_shadowPosDY[indexOfCascade]) : 0;
 #endif
     
-    [branch]
-    if (filteringSampleCount == ShadowFilterSampleCount::Tap4)
+    switch(filteringSampleCountMode)
     {
-        return SampleShadowMapBicubic_4Tap(param);
+        case ShadowFilterSampleCount::Tap4:
+            return SampleShadowMapBicubic_4Tap(param);
+        case ShadowFilterSampleCount::Tap9:
+            return SampleShadowMapBicubic_9Tap(param);
+        case ShadowFilterSampleCount::Tap16:
+            return SampleShadowMapBicubic_16Tap(param);
+        default:
+            //Use 16 tap by default
+            return SampleShadowMapBicubic_16Tap(param);
     }
-    else if (filteringSampleCount == ShadowFilterSampleCount::Tap9)
-    {
-        return SampleShadowMapBicubic_9Tap(param);
-    }
-    else
-    {
-        return SampleShadowMapBicubic_16Tap(param);
-    }
+    return 0.0f;
 }
 
 float DirectionalShadowCalculator::GetVisibilityFromLightPcf()

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadowCalculator.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadowCalculator.azsli
@@ -11,6 +11,8 @@
 #endif
 
 enum class ShadowFilterMethod {None, Pcf, Esm, EsmPcf};
+enum class ShadowFilterSampleCount {Tap0, Tap4, Tap9, Tap16};
+option ShadowFilterSampleCount o_directional_shadow_filtering_sample_count = ShadowFilterSampleCount::Tap16;
 
 // avoiding artifact between cascade levels.
 #define PIXEL_MARGIN (1.5)
@@ -59,6 +61,11 @@ class DirectionalShadowCalculator
         m_filterMode = filterMode;
     }
 
+    void SetFilteringSampleCount(const ShadowFilterSampleCount filteringSampleCount)
+    {
+        m_filteringSampleCount = filteringSampleCount;
+    }
+
     void GetShadowCascadeRange(float3 shadowCoords[ViewSrg::MaxCascadeCount], int cascadeCount, uint shadowmapSize, out int minShadowCascade, out int maxShadowCascade);
     float GetVisibility();
     float GetThickness();
@@ -86,6 +93,7 @@ class DirectionalShadowCalculator
     int m_minCascade;
     int m_maxCascade;
     int m_cascadeCount;
+    ShadowFilterSampleCount m_filteringSampleCount;
     ShadowFilterMethod m_filterMode;
 
     Texture2DArray<float> m_directionalLightShadowmap;   
@@ -281,7 +289,7 @@ float DirectionalShadowCalculator::GetVisibilityFromLightNoFilter()
 
 float DirectionalShadowCalculator::SamplePcfBicubic(const float3 shadowCoord, const int indexOfCascade)
 {
-    const uint filteringSampleCount = ViewSrg::m_directionalLightShadows[m_lightIndex].m_filteringSampleCount;
+    const ShadowFilterSampleCount filteringSampleCount = m_filteringSampleCount;
     const uint size = ViewSrg::m_directionalLightShadows[m_lightIndex].m_shadowmapSize;
     
     SampleShadowMapBicubicParameters param;
@@ -299,11 +307,11 @@ float DirectionalShadowCalculator::SamplePcfBicubic(const float3 shadowCoord, co
 #endif
     
     [branch]
-    if (filteringSampleCount <= 4)
+    if (filteringSampleCount == ShadowFilterSampleCount::Tap4)
     {
         return SampleShadowMapBicubic_4Tap(param);
     }
-    else if (filteringSampleCount <= 9)
+    else if (filteringSampleCount == ShadowFilterSampleCount::Tap9)
     {
         return SampleShadowMapBicubic_9Tap(param);
     }

--- a/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/CoreLights/ViewSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/CoreLights/ViewSrg.azsli
@@ -122,7 +122,7 @@ partial ShaderResourceGroup ViewSrg
         uint m_cascadeCount;
         float m_shadowBias; 
         float m_normalShadowBias; 
-        uint m_filteringSampleCount;
+        uint m_filteringSampleCountMode;
         uint m_debugFlags;
         uint m_shadowFilterMethod;
         float m_far_minus_near;

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/FullscreenShadow.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/FullscreenShadow.azsl
@@ -53,6 +53,7 @@ ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
         float2 m_screenSize;
         int m_lightIndex;
         int m_filterMode;
+        int m_filteringSampleCount;
         int m_blendBetweenCascadesEnable;
         int m_receiverShadowPlaneBiasEnable;
         
@@ -163,11 +164,12 @@ void MainCS(uint3 thread_id : SV_GroupThreadID, uint3 group_id : SV_GroupID, uin
     calc.SetWorldNormal(normalWS);
     calc.SetReceiverShadowPlaneBiasEnable(PassSrg::m_constantData.m_receiverShadowPlaneBiasEnable);
     calc.SetFilterMode((ShadowFilterMethod)PassSrg::m_constantData.m_filterMode);
+    calc.SetFilteringSampleCount((ShadowFilterSampleCount)PassSrg::m_constantData.m_filteringSampleCount);
     calc.SetBlendBetweenCascadesEnable(PassSrg::m_constantData.m_blendBetweenCascadesEnable);
     calc.SetShadowmaps(PassSrg::m_directionalShadowmaps, PassSrg::m_directionalShadowmapsESM);
     calc.SetWorldPos(positionWS);
 
-   PassSrg::m_fullscreenShadowOutput[dispatch_id.xy] = calc.GetVisibility();
+    PassSrg::m_fullscreenShadowOutput[dispatch_id.xy] = calc.GetVisibility();
 }
 
 #else
@@ -183,6 +185,7 @@ PSOutput MainPS(VSOutput IN)
     calc.SetWorldNormal(normalWS);
     calc.SetReceiverShadowPlaneBiasEnable(PassSrg::m_constantData.m_receiverShadowPlaneBiasEnable);
     calc.SetFilterMode((ShadowFilterMethod)PassSrg::m_constantData.m_filterMode);
+    calc.SetFilteringSampleCount((ShadowFilterSampleCount)PassSrg::m_constantData.m_filteringSampleCount);
     calc.SetBlendBetweenCascadesEnable(PassSrg::m_constantData.m_blendBetweenCascadesEnable);
     calc.SetShadowmaps(PassSrg::m_directionalShadowmaps, PassSrg::m_directionalShadowmapsESM);
     calc.SetWorldPos(positionWS);

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/FullscreenShadow.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/FullscreenShadow.azsl
@@ -53,7 +53,7 @@ ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
         float2 m_screenSize;
         int m_lightIndex;
         int m_filterMode;
-        int m_filteringSampleCount;
+        int m_filteringSampleCountMode;
         int m_blendBetweenCascadesEnable;
         int m_receiverShadowPlaneBiasEnable;
         
@@ -164,7 +164,7 @@ void MainCS(uint3 thread_id : SV_GroupThreadID, uint3 group_id : SV_GroupID, uin
     calc.SetWorldNormal(normalWS);
     calc.SetReceiverShadowPlaneBiasEnable(PassSrg::m_constantData.m_receiverShadowPlaneBiasEnable);
     calc.SetFilterMode((ShadowFilterMethod)PassSrg::m_constantData.m_filterMode);
-    calc.SetFilteringSampleCount((ShadowFilterSampleCount)PassSrg::m_constantData.m_filteringSampleCount);
+    calc.SetFilteringSampleCount((ShadowFilterSampleCount)PassSrg::m_constantData.m_filteringSampleCountMode);
     calc.SetBlendBetweenCascadesEnable(PassSrg::m_constantData.m_blendBetweenCascadesEnable);
     calc.SetShadowmaps(PassSrg::m_directionalShadowmaps, PassSrg::m_directionalShadowmapsESM);
     calc.SetWorldPos(positionWS);
@@ -185,7 +185,7 @@ PSOutput MainPS(VSOutput IN)
     calc.SetWorldNormal(normalWS);
     calc.SetReceiverShadowPlaneBiasEnable(PassSrg::m_constantData.m_receiverShadowPlaneBiasEnable);
     calc.SetFilterMode((ShadowFilterMethod)PassSrg::m_constantData.m_filterMode);
-    calc.SetFilteringSampleCount((ShadowFilterSampleCount)PassSrg::m_constantData.m_filteringSampleCount);
+    calc.SetFilteringSampleCount((ShadowFilterSampleCount)PassSrg::m_constantData.m_filteringSampleCountMode);
     calc.SetBlendBetweenCascadesEnable(PassSrg::m_constantData.m_blendBetweenCascadesEnable);
     calc.SetShadowmaps(PassSrg::m_directionalShadowmaps, PassSrg::m_directionalShadowmapsESM);
     calc.SetWorldPos(positionWS);

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/ShadowConstants.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/ShadowConstants.h
@@ -27,7 +27,8 @@ namespace AZ
         static constexpr ShadowmapSize MinShadowmapImageSize = ShadowmapSize::Size256;
         static constexpr ShadowmapSize MaxShadowmapImageSize = ShadowmapSize::Size2048;
 
-        // This matches ShadowFilterMethod in CoreLights/ViewSrg.azsli
+        // This matches ShadowFilterMethod in DirectionalLightShadowCalculator.azsli
+        // and represents m_shadowFilterMethod in CoreLights/ViewSrg.azsli
         enum class ShadowFilterMethod : uint32_t
         {
             None = 0,
@@ -38,7 +39,8 @@ namespace AZ
             Count
         };
 
-        // This matches ShadowFilterSampleCount in CoreLights/ViewSrg.azsli
+        // This matches ShadowFilterSampleCount in DirectionalLightShadowCalculator.azsli
+        // and represents m_filteringSampleCountMode in CoreLights/ViewSrg.azsli
         enum class ShadowFilterSampleCount : uint32_t
         {
             Tap0 = 0,

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/ShadowConstants.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/ShadowConstants.h
@@ -43,10 +43,9 @@ namespace AZ
         // and represents m_filteringSampleCountMode in CoreLights/ViewSrg.azsli
         enum class ShadowFilterSampleCount : uint32_t
         {
-            Tap0 = 0,
-            Tap4,
-            Tap9,
-            Tap16,
+            PcfTap4 = 0,
+            PcfTap9,
+            PcfTap16,
 
             Count
         };

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/ShadowConstants.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/ShadowConstants.h
@@ -27,13 +27,24 @@ namespace AZ
         static constexpr ShadowmapSize MinShadowmapImageSize = ShadowmapSize::Size256;
         static constexpr ShadowmapSize MaxShadowmapImageSize = ShadowmapSize::Size2048;
 
-        // This matchs ShadowFilterMethod in CoreLights/ViewSrg.azsli
+        // This matches ShadowFilterMethod in CoreLights/ViewSrg.azsli
         enum class ShadowFilterMethod : uint32_t
         {
             None = 0,
             Pcf, // Percentage Closer Filtering
             Esm, // Exponential Shadow Maps
             EsmPcf, // ESM with PCF fallback
+
+            Count
+        };
+
+        // This matches ShadowFilterSampleCount in CoreLights/ViewSrg.azsli
+        enum class ShadowFilterSampleCount : uint32_t
+        {
+            Tap0 = 0,
+            Tap4,
+            Tap9,
+            Tap16,
 
             Count
         };

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
@@ -210,7 +210,7 @@ namespace AZ
                 const uint32_t shadowFilterMethod = m_shadowData.at(nullptr).GetData(m_shadowingLightHandle.GetIndex()).m_shadowFilterMethod;
                 RPI::ShaderSystemInterface::Get()->SetGlobalShaderOption(m_directionalShadowFilteringMethodName, AZ::RPI::ShaderOptionValue{shadowFilterMethod});
 
-                uint32_t shadowFilteringSampleCount = m_shadowData.at(nullptr).GetData(m_shadowingLightHandle.GetIndex()).m_filteringSampleCount;
+                uint32_t shadowFilteringSampleCount = m_shadowData.at(nullptr).GetData(m_shadowingLightHandle.GetIndex()).m_filteringSampleCountMode;
                 RPI::ShaderSystemInterface::Get()->SetGlobalShaderOption(
                     m_directionalShadowFilteringSamplecountName, AZ::RPI::ShaderOptionValue{ shadowFilteringSampleCount });
                 
@@ -590,23 +590,25 @@ namespace AZ
                 AZ_Warning(FeatureProcessorName, false, "Sampling count exceed the limit.");
                 count = Shadow::MaxPcfSamplingCount;
             }
-            ShadowFilterSampleCount samplingCount = ShadowFilterSampleCount::Tap0;
+
+            //Remap the count value to an enum value associated with that count.
+            ShadowFilterSampleCount samplingCountMode = ShadowFilterSampleCount::Tap0;
             if (count <= 4)
             {
-                samplingCount = ShadowFilterSampleCount::Tap4;
+                samplingCountMode = ShadowFilterSampleCount::Tap4;
             }
             else if (count <= 9)
             {
-                samplingCount = ShadowFilterSampleCount::Tap9;
+                samplingCountMode = ShadowFilterSampleCount::Tap9;
             }
             else
             {
-                samplingCount = ShadowFilterSampleCount::Tap16;
+                samplingCountMode = ShadowFilterSampleCount::Tap16;
             }
 
             for (auto& it : m_shadowData)
             {
-                it.second.GetData(handle.GetIndex()).m_filteringSampleCount = static_cast<uint32_t>(samplingCount);
+                it.second.GetData(handle.GetIndex()).m_filteringSampleCountMode = static_cast<uint32_t>(samplingCountMode);
             }
             m_shadowBufferNeedsUpdate = true;
         }
@@ -1778,12 +1780,12 @@ namespace AZ
             if (m_fullscreenShadowPass)
             {
                 const uint32_t shadowFilterMethod = m_shadowData.at(nullptr).GetData(m_shadowingLightHandle.GetIndex()).m_shadowFilterMethod;
-                const uint32_t filteringSampleCount = m_shadowData.at(nullptr).GetData(m_shadowingLightHandle.GetIndex()).m_filteringSampleCount;
+                const uint32_t filteringSampleCountMode = m_shadowData.at(nullptr).GetData(m_shadowingLightHandle.GetIndex()).m_filteringSampleCountMode;
                 const uint32_t cascadeCount = m_shadowData.at(nullptr).GetData(m_shadowingLightHandle.GetIndex()).m_cascadeCount;
                 m_fullscreenShadowPass->SetLightRawIndex(m_shadowProperties.GetRawIndex(m_shadowingLightHandle.GetIndex()));
                 m_fullscreenShadowPass->SetBlendBetweenCascadesEnable(cascadeCount > 1 && shadowProperty.m_blendBetweenCascades);
                 m_fullscreenShadowPass->SetFilterMethod(static_cast<ShadowFilterMethod>(shadowFilterMethod));
-                m_fullscreenShadowPass->SetFilteringSampleCount(static_cast<ShadowFilterSampleCount>(filteringSampleCount));
+                m_fullscreenShadowPass->SetFilteringSampleCountMode(static_cast<ShadowFilterSampleCount>(filteringSampleCountMode));
                 m_fullscreenShadowPass->SetReceiverShadowPlaneBiasEnable(shadowProperty.m_isReceiverPlaneBiasEnabled);
             }
 

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
@@ -592,18 +592,14 @@ namespace AZ
             }
 
             //Remap the count value to an enum value associated with that count.
-            ShadowFilterSampleCount samplingCountMode = ShadowFilterSampleCount::Tap0;
+            ShadowFilterSampleCount samplingCountMode = ShadowFilterSampleCount::PcfTap16;
             if (count <= 4)
             {
-                samplingCountMode = ShadowFilterSampleCount::Tap4;
+                samplingCountMode = ShadowFilterSampleCount::PcfTap4;
             }
             else if (count <= 9)
             {
-                samplingCountMode = ShadowFilterSampleCount::Tap9;
-            }
-            else
-            {
-                samplingCountMode = ShadowFilterSampleCount::Tap16;
+                samplingCountMode = ShadowFilterSampleCount::PcfTap9;
             }
 
             for (auto& it : m_shadowData)

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
@@ -209,6 +209,11 @@ namespace AZ
 
                 const uint32_t shadowFilterMethod = m_shadowData.at(nullptr).GetData(m_shadowingLightHandle.GetIndex()).m_shadowFilterMethod;
                 RPI::ShaderSystemInterface::Get()->SetGlobalShaderOption(m_directionalShadowFilteringMethodName, AZ::RPI::ShaderOptionValue{shadowFilterMethod});
+
+                uint32_t shadowFilteringSampleCount = m_shadowData.at(nullptr).GetData(m_shadowingLightHandle.GetIndex()).m_filteringSampleCount;
+                RPI::ShaderSystemInterface::Get()->SetGlobalShaderOption(
+                    m_directionalShadowFilteringSamplecountName, AZ::RPI::ShaderOptionValue{ shadowFilteringSampleCount });
+                
                 RPI::ShaderSystemInterface::Get()->SetGlobalShaderOption(m_directionalShadowReceiverPlaneBiasEnableName, AZ::RPI::ShaderOptionValue{ m_shadowProperties.GetData(m_shadowingLightHandle.GetIndex()).m_isReceiverPlaneBiasEnabled });
 
                 const uint32_t cascadeCount = m_shadowData.at(nullptr).GetData(m_shadowingLightHandle.GetIndex()).m_cascadeCount;
@@ -585,9 +590,23 @@ namespace AZ
                 AZ_Warning(FeatureProcessorName, false, "Sampling count exceed the limit.");
                 count = Shadow::MaxPcfSamplingCount;
             }
+            ShadowFilterSampleCount samplingCount = ShadowFilterSampleCount::Tap0;
+            if (count <= 4)
+            {
+                samplingCount = ShadowFilterSampleCount::Tap4;
+            }
+            else if (count <= 9)
+            {
+                samplingCount = ShadowFilterSampleCount::Tap9;
+            }
+            else
+            {
+                samplingCount = ShadowFilterSampleCount::Tap16;
+            }
+
             for (auto& it : m_shadowData)
             {
-                it.second.GetData(handle.GetIndex()).m_filteringSampleCount = count;
+                it.second.GetData(handle.GetIndex()).m_filteringSampleCount = static_cast<uint32_t>(samplingCount);
             }
             m_shadowBufferNeedsUpdate = true;
         }
@@ -1759,10 +1778,12 @@ namespace AZ
             if (m_fullscreenShadowPass)
             {
                 const uint32_t shadowFilterMethod = m_shadowData.at(nullptr).GetData(m_shadowingLightHandle.GetIndex()).m_shadowFilterMethod;
+                const uint32_t filteringSampleCount = m_shadowData.at(nullptr).GetData(m_shadowingLightHandle.GetIndex()).m_filteringSampleCount;
                 const uint32_t cascadeCount = m_shadowData.at(nullptr).GetData(m_shadowingLightHandle.GetIndex()).m_cascadeCount;
                 m_fullscreenShadowPass->SetLightRawIndex(m_shadowProperties.GetRawIndex(m_shadowingLightHandle.GetIndex()));
                 m_fullscreenShadowPass->SetBlendBetweenCascadesEnable(cascadeCount > 1 && shadowProperty.m_blendBetweenCascades);
                 m_fullscreenShadowPass->SetFilterMethod(static_cast<ShadowFilterMethod>(shadowFilterMethod));
+                m_fullscreenShadowPass->SetFilteringSampleCount(static_cast<ShadowFilterSampleCount>(filteringSampleCount));
                 m_fullscreenShadowPass->SetReceiverShadowPlaneBiasEnable(shadowProperty.m_isReceiverPlaneBiasEnabled);
             }
 

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.h
@@ -407,6 +407,7 @@ namespace AZ
 
             Name m_lightTypeName = Name("directional");
             Name m_directionalShadowFilteringMethodName = Name("o_directional_shadow_filtering_method");
+            Name m_directionalShadowFilteringSamplecountName = Name("o_directional_shadow_filtering_sample_count");
             Name m_directionalShadowReceiverPlaneBiasEnableName = Name("o_directional_shadow_receiver_plane_bias_enable");
             Name m_BlendBetweenCascadesEnableName = Name("o_blend_between_cascades_enable");
             static constexpr const char* FeatureProcessorName = "DirectionalLightFeatureProcessor";

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.h
@@ -106,7 +106,7 @@ namespace AZ
             float m_shadowBias = 0.0015f;
             // Reduces acne by biasing the shadowmap lookup along the geometric normal.
             float m_normalShadowBias = 2.5f;
-            uint32_t m_filteringSampleCount = 0;
+            uint32_t m_filteringSampleCountMode = 0;
             uint32_t m_debugFlags = 0;
             uint32_t m_shadowFilterMethod = 0; 
             float m_far_minus_near = 0;

--- a/Gems/Atom/Feature/Common/Code/Source/Shadows/FullscreenShadowPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Shadows/FullscreenShadowPass.cpp
@@ -77,6 +77,7 @@ namespace AZ
                 AZStd::array<float, 2> m_screenSize;
                 int m_lightIndex;
                 int m_filterMode;
+                int m_filteringSampleCount;
                 int m_blendBetweenCascadesEnable;
                 int m_receiverShadowPlaneBiasEnable;
 
@@ -86,6 +87,7 @@ namespace AZ
             constantData.m_lightIndex = m_lightIndex;
             constantData.m_screenSize = { static_cast<float>(resolution.m_width), static_cast<float>(resolution.m_height) };
             constantData.m_filterMode = static_cast<int>(m_filterMethod);
+            constantData.m_filteringSampleCount = static_cast<int>(m_filteringSampleCount);
             constantData.m_blendBetweenCascadesEnable = m_blendBetweenCascadesEnable ? 1 : 0;
             constantData.m_receiverShadowPlaneBiasEnable = m_receiverShadowPlaneBiasEnable ? 1 : 0;
 

--- a/Gems/Atom/Feature/Common/Code/Source/Shadows/FullscreenShadowPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Shadows/FullscreenShadowPass.cpp
@@ -77,7 +77,7 @@ namespace AZ
                 AZStd::array<float, 2> m_screenSize;
                 int m_lightIndex;
                 int m_filterMode;
-                int m_filteringSampleCount;
+                int m_filteringSampleCountMode;
                 int m_blendBetweenCascadesEnable;
                 int m_receiverShadowPlaneBiasEnable;
 
@@ -87,7 +87,7 @@ namespace AZ
             constantData.m_lightIndex = m_lightIndex;
             constantData.m_screenSize = { static_cast<float>(resolution.m_width), static_cast<float>(resolution.m_height) };
             constantData.m_filterMode = static_cast<int>(m_filterMethod);
-            constantData.m_filteringSampleCount = static_cast<int>(m_filteringSampleCount);
+            constantData.m_filteringSampleCountMode = static_cast<int>(m_filteringSampleCountMode);
             constantData.m_blendBetweenCascadesEnable = m_blendBetweenCascadesEnable ? 1 : 0;
             constantData.m_receiverShadowPlaneBiasEnable = m_receiverShadowPlaneBiasEnable ? 1 : 0;
 

--- a/Gems/Atom/Feature/Common/Code/Source/Shadows/FullscreenShadowPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Shadows/FullscreenShadowPass.h
@@ -47,6 +47,11 @@ namespace AZ
                 m_filterMethod = method;
             }
 
+            void SetFilteringSampleCount(AZ::Render::ShadowFilterSampleCount filteringSampleCount)
+            {
+                m_filteringSampleCount = filteringSampleCount;
+            }
+
             void SetReceiverShadowPlaneBiasEnable(bool enable)
             {
                 m_receiverShadowPlaneBiasEnable = enable;
@@ -63,6 +68,7 @@ namespace AZ
             bool m_blendBetweenCascadesEnable = false;
             bool m_receiverShadowPlaneBiasEnable = false;
             ShadowFilterMethod m_filterMethod = ShadowFilterMethod::None;
+            ShadowFilterSampleCount m_filteringSampleCount = ShadowFilterSampleCount::Tap0;
 
             FullscreenShadowPass(const RPI::PassDescriptor& descriptor);
 

--- a/Gems/Atom/Feature/Common/Code/Source/Shadows/FullscreenShadowPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Shadows/FullscreenShadowPass.h
@@ -47,9 +47,9 @@ namespace AZ
                 m_filterMethod = method;
             }
 
-            void SetFilteringSampleCount(AZ::Render::ShadowFilterSampleCount filteringSampleCount)
+            void SetFilteringSampleCountMode(AZ::Render::ShadowFilterSampleCount filteringSampleCount)
             {
-                m_filteringSampleCount = filteringSampleCount;
+                m_filteringSampleCountMode = filteringSampleCount;
             }
 
             void SetReceiverShadowPlaneBiasEnable(bool enable)
@@ -68,7 +68,7 @@ namespace AZ
             bool m_blendBetweenCascadesEnable = false;
             bool m_receiverShadowPlaneBiasEnable = false;
             ShadowFilterMethod m_filterMethod = ShadowFilterMethod::None;
-            ShadowFilterSampleCount m_filteringSampleCount = ShadowFilterSampleCount::Tap0;
+            ShadowFilterSampleCount m_filteringSampleCountMode = ShadowFilterSampleCount::Tap0;
 
             FullscreenShadowPass(const RPI::PassDescriptor& descriptor);
 

--- a/Gems/Atom/Feature/Common/Code/Source/Shadows/FullscreenShadowPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Shadows/FullscreenShadowPass.h
@@ -68,7 +68,7 @@ namespace AZ
             bool m_blendBetweenCascadesEnable = false;
             bool m_receiverShadowPlaneBiasEnable = false;
             ShadowFilterMethod m_filterMethod = ShadowFilterMethod::None;
-            ShadowFilterSampleCount m_filteringSampleCountMode = ShadowFilterSampleCount::Tap0;
+            ShadowFilterSampleCount m_filteringSampleCountMode = ShadowFilterSampleCount::PcfTap16;
 
             FullscreenShadowPass(const RPI::PassDescriptor& descriptor);
 


### PR DESCRIPTION
## What does this PR do?

This PR adds support for shader options for different PCF filtering modes. This will allow un-used filtering modes to be baked out and help with register usage for forward pass. We will need to build our variants for o_directional_shadow_filtering_sample_count in order to enable this optimization. The shader option support was only added for directional lights for this PR. Projected lights are still using ViewSrg to extract sample count

## How was this PR tested?

Tested Editor (DX12 and Vk) by adding directional light as well as projected light and ensuring that the PCF sample count still works as desired. 
