### PR TITLE
Android Project Generation & Build Fixes

### DIFF
--- a/cmake/Tools/Platform/Android/android_support.py
+++ b/cmake/Tools/Platform/Android/android_support.py
@@ -821,9 +821,10 @@ class AndroidProjectGenerator(object):
 
         gradle_build_env = dict()
 
-        engine_root_as_path= pathlib.Path(self.engine_root)
+        engine_root_as_path = pathlib.Path(self.engine_root)
+        project_path_as_path = pathlib.Path(self.project_path)
 
-        absolute_cmakelist_path = (engine_root_as_path / 'CMakeLists.txt').resolve().as_posix()
+        absolute_cmakelist_path = (project_path_as_path / 'CMakeLists.txt').resolve().as_posix()
         absolute_azandroid_path = (engine_root_as_path / 'Code/Framework/AzAndroid/java').resolve().as_posix()
 
         gradle_build_env['TARGET_TYPE'] = 'application'
@@ -843,7 +844,7 @@ class AndroidProjectGenerator(object):
             # Prepare the cmake argument list based on the collected android settings and each build config
             cmake_argument_list = [
                 '"-GNinja"',
-                f'"-S{template_engine_root}"',
+                f'"-S{project_path_as_path.as_posix()}"',
                 f'"-DCMAKE_BUILD_TYPE={native_config_lower}"',
                 f'"-DCMAKE_TOOLCHAIN_FILE={template_engine_root}/cmake/Platform/Android/Toolchain_android.cmake"',
                 f'"-DLY_3RDPARTY_PATH={template_third_party_path}"',
@@ -853,7 +854,7 @@ class AndroidProjectGenerator(object):
                 cmake_argument_list.append(f'"-DLY_ANDROID_VULKAN_VALIDATION_PATH={pathlib.PurePath(self.vulkan_validation_path).as_posix()}"')
 
             if not self.is_test_project:
-                cmake_argument_list.append(f'"-DLY_PROJECTS={pathlib.PurePath(self.project_path).as_posix()}"')
+                cmake_argument_list.append(f'"-DLY_PROJECTS={project_path_as_path.as_posix()}"')
             else:
                 cmake_argument_list.append('"-DLY_TEST_PROJECT=1"')
 

--- a/cmake/Tools/Platform/Android/generate_android_project.py
+++ b/cmake/Tools/Platform/Android/generate_android_project.py
@@ -33,7 +33,7 @@ from o3de import manifest
 
 GRADLE_ARGUMENT_NAME = '--gradle-install-path'
 GRADLE_MIN_VERSION = Version('6.5')
-GRADLE_MAX_VERSION = Version('8.4.0')
+GRADLE_MAX_VERSION = Version('7.6.3')
 GRADLE_VERSION_REGEX = re.compile(r"Gradle\s(\d+.\d+.?\d*)")
 GRADLE_EXECUTABLE = 'gradle.bat' if platform.system() == 'Windows' else 'gradle'
 

--- a/cmake/Tools/Platform/Android/generate_android_project.py
+++ b/cmake/Tools/Platform/Android/generate_android_project.py
@@ -33,7 +33,7 @@ from o3de import manifest
 
 GRADLE_ARGUMENT_NAME = '--gradle-install-path'
 GRADLE_MIN_VERSION = Version('6.5')
-GRADLE_MAX_VERSION = Version('7.5.1')
+GRADLE_MAX_VERSION = Version('8.4.0')
 GRADLE_VERSION_REGEX = re.compile(r"Gradle\s(\d+.\d+.?\d*)")
 GRADLE_EXECUTABLE = 'gradle.bat' if platform.system() == 'Windows' else 'gradle'
 

--- a/cmake/Tools/layout_tool.py
+++ b/cmake/Tools/layout_tool.py
@@ -447,13 +447,12 @@ def sync_layout_non_vfs(mode, target_platform, project_path, asset_type, warning
                                target_platform=target_platform,
                                layout_target=layout_target)
 
-    # Reset the 'gems' junction if any in the layout (only in loose mode).
-    layout_gems_folder_src = os.path.join(project_asset_folder, 'gems')
-
-    # The gems link only is valid in LOOSE mode. If in PAK, then dont re-link
-    if mode == ASSET_MODE_LOOSE and os.path.isdir(layout_gems_folder_src):
-        if os.path.isdir(layout_gems_folder_src):
-            create_link(layout_gems_folder_src, layout_gems_folder_target, copy)
+    # # Reset the 'gems' junction if any in the layout (only in loose mode).
+    # layout_gems_folder_src = os.path.join(project_asset_folder, 'gems')
+    # # The gems link only is valid in LOOSE mode. If in PAK, then dont re-link
+    # if mode == ASSET_MODE_LOOSE and os.path.isdir(layout_gems_folder_src):
+    #     if os.path.isdir(layout_gems_folder_src):
+    #         create_link(layout_gems_folder_src, layout_gems_folder_target, copy)
 
 
 def sync_layout_pak(target_platform, project_path, asset_type, warning_on_missing_assets, layout_target,

--- a/cmake/Tools/layout_tool.py
+++ b/cmake/Tools/layout_tool.py
@@ -375,12 +375,12 @@ def sync_layout_vfs(target_platform, project_path, asset_type, warning_on_missin
         shutil.copy2(os.path.join(project_asset_folder, root_asset), layout_target)
 
     # Reset the 'gems' junction if any in the layout
-    layout_gems_folder_src = os.path.join(project_asset_folder, 'gems')
-    layout_gems_folder_target = os.path.join(layout_target, 'gems')
-    if os.path.isdir(layout_gems_folder_target):
-        remove_link(layout_gems_folder_target)
-    if os.path.isdir(layout_gems_folder_src):
-        create_link(layout_gems_folder_src, layout_gems_folder_target, copy)
+#    layout_gems_folder_src = os.path.join(project_asset_folder, 'gems')
+#    layout_gems_folder_target = os.path.join(layout_target, 'gems')
+#    if os.path.isdir(layout_gems_folder_target):
+#        remove_link(layout_gems_folder_target)
+#    if os.path.isdir(layout_gems_folder_src):
+#        create_link(layout_gems_folder_src, layout_gems_folder_target, copy)
 
 
 

--- a/cmake/Tools/layout_tool.py
+++ b/cmake/Tools/layout_tool.py
@@ -374,14 +374,6 @@ def sync_layout_vfs(target_platform, project_path, asset_type, warning_on_missin
         logging.debug("Copying %s -> %s",  os.path.join(project_asset_folder, root_asset), layout_target)
         shutil.copy2(os.path.join(project_asset_folder, root_asset), layout_target)
 
-    # Reset the 'gems' junction if any in the layout
-#    layout_gems_folder_src = os.path.join(project_asset_folder, 'gems')
-#    layout_gems_folder_target = os.path.join(layout_target, 'gems')
-#    if os.path.isdir(layout_gems_folder_target):
-#        remove_link(layout_gems_folder_target)
-#    if os.path.isdir(layout_gems_folder_src):
-#        create_link(layout_gems_folder_src, layout_gems_folder_target, copy)
-
 
 
 def sync_layout_non_vfs(mode, target_platform, project_path, asset_type, warning_on_missing_assets, layout_target, override_pak_folder, copy):
@@ -446,13 +438,6 @@ def sync_layout_non_vfs(mode, target_platform, project_path, asset_type, warning
     copy_asset_files_to_layout(project_asset_folder=project_asset_folder,
                                target_platform=target_platform,
                                layout_target=layout_target)
-
-    # # Reset the 'gems' junction if any in the layout (only in loose mode).
-    # layout_gems_folder_src = os.path.join(project_asset_folder, 'gems')
-    # # The gems link only is valid in LOOSE mode. If in PAK, then dont re-link
-    # if mode == ASSET_MODE_LOOSE and os.path.isdir(layout_gems_folder_src):
-    #     if os.path.isdir(layout_gems_folder_src):
-    #         create_link(layout_gems_folder_src, layout_gems_folder_target, copy)
 
 
 def sync_layout_pak(target_platform, project_path, asset_type, warning_on_missing_assets, layout_target,


### PR DESCRIPTION
## What does this PR do?

Fixed android project generation & assembly. Running cmake from the project folder, instead of engine folder. Removing creation of nested junctions (courtesy @alexeykostin )

## How was this PR tested?

Locally and through jenkins (mac) builds. Built iOS, Android, PC, mac. Android fails at the apk generation due to massive APK size (15GB vs 4GB limit), but the code compilation etc succeeds.