### PR TITLE
Fix Vulkan validation error on Mobile render pipeline

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/Mobile/SkyBox.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/Mobile/SkyBox.pass
@@ -23,7 +23,15 @@
                 "ShaderAsset": {
                     "FilePath": "Shaders/SkyBox/SkyBox.shader"
                 },
-                "BindViewSrg": true
+                "BindViewSrg": true,
+                "ShaderDataMappings": {
+                    "FloatMappings": [
+                        {
+                            "Name": "m_sunIntensityMultiplier",
+                            "Value": 1.0
+                        }
+                    ]
+                }
             }
         }
     }


### PR DESCRIPTION
## What does this PR do?

Add ShaderDataMappings for SkyBox shader that was causing the following validation error:

`Validation Error: [ VUID-vkCmdDraw-None-02699 ] Object 0: handle = 0x7eee00000003c2, name = SkyBox_PassSrg, type = VK_OBJECT_TYPE_DESCRIPTOR_SET; | MessageID = 0x1608dec0 | Descriptor set VkDescriptorSet 0x7eee00000003c2[SkyBox_PassSrg] encountered the following validation error at vkCmdDraw time: Descriptor in binding #1 index 0 is being used in draw but has never been updated via vkUpdateDescriptorSets() or a similar call. The Vulkan spec states: Descriptors in each bound descriptor set, specified via vkCmdBindDescriptorSets, must be valid as described by descriptor validity if they are statically used by a bound shader (https://vulkan.lunarg.com/doc/view/1.3.250.0/windows/1.3-extensions/vkspec.html#VUID-vkCmdDraw-None-02699)`

## How was this PR tested?

Run Mobile pipeline on Vulkan
