### PR TITLE
[MADPORT-458] Make workaround for MipMap issues in O3DE/Atom/RPI sources for iPhone build

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArray.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArray.cpp
@@ -212,6 +212,16 @@ namespace AZ
                 }
 
                 const auto mipChainAsset = BuildPackedMipChainAsset(mapType, numTexturesToCreate);
+                
+                // Gruber patch begin // VMED // error for missing mipmap (MADPORT-459)
+                if (!mipChainAsset.GetData())
+                {
+                    AZ_Error("DecalTextureArray", false, "Missing decal texture mipmaps for %s. Please make sure all mipmaps of this type are present.\n", GetMapName(mapType).GetCStr());
+                    m_textureArrayPacked[i] = nullptr;
+                    continue;
+                }
+                // Gruber patch end // VMED
+                
                 RHI::ImageViewDescriptor imageViewDescriptor;
                 imageViewDescriptor.m_isArray = true;
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/ImageMipChainAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/ImageMipChainAsset.cpp
@@ -58,23 +58,10 @@ namespace AZ
         {
             // Gruber patch begin // VMED // error instead mipmap assert (MADPORT-459)
             // AZ_Assert(subImageIndex < m_subImageDataOffsets.size() && subImageIndex < m_subImageDatas.size(), "subImageIndex is out of range");
-            if (subImageIndex >= m_subImageDataOffsets.size() - 1 || subImageIndex >= m_subImageDatas.size())
+            if (subImageIndex + 1 >= m_subImageDataOffsets.size() || subImageIndex >= m_subImageDatas.size())
             {
                 AZ_Error("ImageMipChainAsset", false, "subImageIndex is out of range");
-                //verify valid sizes
-                if (m_subImageDatas.size() == 0 || m_subImageDataOffsets.size() <= 1)
-                {
-                    return AZStd::span<const uint8_t>();
-                }
-                // try to fallback to prev mipmap level
-                if (subImageIndex >= m_subImageDataOffsets.size() - 1) // size()-1, due to we use m_subImageDataOffsets[subImageIndex + 1] below
-                {
-                    subImageIndex = (uint32_t)(m_subImageDataOffsets.size() - 2);
-                }
-                if (subImageIndex >= m_subImageDatas.size())
-                {
-                    subImageIndex = (uint32_t)(m_subImageDatas.size() - 1);
-                }
+                return AZStd::span<const uint8_t>();
             }
             // Gruber patch end // VMED 
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/ImageMipChainAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/ImageMipChainAsset.cpp
@@ -58,21 +58,22 @@ namespace AZ
         {
             // Gruber patch begin // VMED // error instead mipmap assert (MADPORT-459)
             // AZ_Assert(subImageIndex < m_subImageDataOffsets.size() && subImageIndex < m_subImageDatas.size(), "subImageIndex is out of range");
-            if(subImageIndex >= m_subImageDataOffsets.size() - 1 || subImageIndex >= m_subImageDatas.size())
+            if (subImageIndex >= m_subImageDataOffsets.size() - 1 || subImageIndex >= m_subImageDatas.size())
             {
                 AZ_Error("ImageMipChainAsset", false, "subImageIndex is out of range");
-                // try to fallback to prev mipmap level
-                if(subImageIndex >= m_subImageDataOffsets.size() - 1) // size()-1, due to we use m_subImageDataOffsets[subImageIndex + 1] below
-                {
-                    subImageIndex = m_subImageDataOffsets.size() - 2;
-                }
-                if(subImageIndex >= m_subImageDatas.size())
-                {
-                    subImageIndex = m_subImageDatas.size() - 1;
-                }
-                if (subImageIndex < 0)
+                //verify valid sizes
+                if (m_subImageDatas.size() == 0 || m_subImageDataOffsets.size() <= 1)
                 {
                     return AZStd::span<const uint8_t>();
+                }
+                // try to fallback to prev mipmap level
+                if (subImageIndex >= m_subImageDataOffsets.size() - 1) // size()-1, due to we use m_subImageDataOffsets[subImageIndex + 1] below
+                {
+                    subImageIndex = (uint32_t)(m_subImageDataOffsets.size() - 2);
+                }
+                if (subImageIndex >= m_subImageDatas.size())
+                {
+                    subImageIndex = (uint32_t)(m_subImageDatas.size() - 1);
                 }
             }
             // Gruber patch end // VMED 

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/ImageMipChainAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/ImageMipChainAsset.cpp
@@ -56,7 +56,26 @@ namespace AZ
 
         AZStd::span<const uint8_t> ImageMipChainAsset::GetSubImageData(uint32_t subImageIndex) const
         {
-            AZ_Assert(subImageIndex < m_subImageDataOffsets.size() && subImageIndex < m_subImageDatas.size(), "subImageIndex is out of range");
+            // Gruber patch begin // VMED // error instead mipmap assert (MADPORT-459)
+            // AZ_Assert(subImageIndex < m_subImageDataOffsets.size() && subImageIndex < m_subImageDatas.size(), "subImageIndex is out of range");
+            if(subImageIndex >= m_subImageDataOffsets.size() - 1 || subImageIndex >= m_subImageDatas.size())
+            {
+                AZ_Error("ImageMipChainAsset", false, "subImageIndex is out of range");
+                // try to fallback to prev mipmap level
+                if(subImageIndex >= m_subImageDataOffsets.size() - 1) // size()-1, due to we use m_subImageDataOffsets[subImageIndex + 1] below
+                {
+                    subImageIndex = m_subImageDataOffsets.size() - 2;
+                }
+                if(subImageIndex >= m_subImageDatas.size())
+                {
+                    subImageIndex = m_subImageDatas.size() - 1;
+                }
+                if (subImageIndex < 0)
+                {
+                    return AZStd::span<const uint8_t>();
+                }
+            }
+            // Gruber patch end // VMED 
 
             // The offset vector contains an extra sentinel value.
             const size_t dataSize = m_subImageDataOffsets[subImageIndex + 1] - m_subImageDataOffsets[subImageIndex];

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/StreamingImageAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/StreamingImageAsset.cpp
@@ -61,7 +61,7 @@ namespace AZ
         {
             if (mipLevel >= m_imageDescriptor.m_mipLevels)
             {
-                AZ_Assert(false, "Input mipLevel doesn't exist");
+                AZ_Error("StreamingImageAsset", false, "Input mipLevel doesn't exist"); // Gruber patch begin // VMED // error instead mipmap assert (MADPORT-459)
                 mipLevel = m_imageDescriptor.m_mipLevels - 1;
             }
             return m_mipLevelToChainIndex[mipLevel];


### PR DESCRIPTION
## What does this PR do?

Ticket https://jira.carbonated.com:8443/browse/MADPORT-458

Changes: Made workaround for MipMap issues in O3DE/Atom/RPI sources for iPhone build

This PR covers the asserts:
-Input mipLevel doesn't exist
-subImageIndex is out of range
-AZStd::vector<>::at - position is out of range


Also: created the ticket https://jira.carbonated.com:8443/browse/MADPORT-459 for future revision of this issue 

## How was this PR tested?

Verified locally
