### PR TITLE
Add better assert for decal textures with different mips

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArray.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArray.cpp
@@ -298,6 +298,11 @@ namespace AZ
             {
                 return {};
             }
+            AZ_Assert(
+                mip < image->GetImageDescriptor().m_mipLevels,
+                "It is expected that all decals in a texture array must have the same number of mips which may not be the case here. "
+                "Please ensure that all the materials within m_materials are pointing to textures with same mips.");
+
             const auto srcData = image->GetSubImageData(mip, 0);
             return srcData;
         }


### PR DESCRIPTION
## What does this PR do?

Add an assert to better inform the developer if the mip sizes are not the same amongst decal textures

## How was this PR tested?

Tested by loading Central Plaza on PC and ios.