### PR TITLE
Implementing an Outside Released event for UiInteractableComponent

### DIFF
--- a/Gems/LyShine/Code/Include/LyShine/Bus/UiInteractableActionsBus.h
+++ b/Gems/LyShine/Code/Include/LyShine/Bus/UiInteractableActionsBus.h
@@ -54,7 +54,7 @@ public: // member functions
 
 // Gruber patch begin // (vlagutin/Ui_ReleaseOutsideEvent) // Fire an event when the press is release outside of the UI element
 #if defined(CARBONATED)
-    virtual const LyShine::ActionName& GetOutsideReleasedActionName() = 0;
+    virtual const LyShine::ActionName& GetOutsideReleasedActionName() const = 0;
     virtual void SetOutsideReleasedActionName(const LyShine::ActionName& actionName) = 0;
 #endif
 // Gruber patch end // (vlagutin/Ui_ReleaseOutsideEvent) // Fire an event when the press is release outside of the UI element

--- a/Gems/LyShine/Code/Include/LyShine/Bus/UiInteractableActionsBus.h
+++ b/Gems/LyShine/Code/Include/LyShine/Bus/UiInteractableActionsBus.h
@@ -52,6 +52,13 @@ public: // member functions
     //! Set the released action name
     virtual void SetReleasedActionName(const LyShine::ActionName& actionName) = 0;
 
+// Gruber patch begin // (vlagutin/Ui_ReleaseOutsideEvent) // Fire an event when the press is release outside of the UI element
+#if defined(CARBONATED)
+    virtual const LyShine::ActionName& GetOutsideReleasedActionName() = 0;
+    virtual void SetOutsideReleasedActionName(const LyShine::ActionName& actionName) = 0;
+#endif
+// Gruber patch end // (vlagutin/Ui_ReleaseOutsideEvent) // Fire an event when the press is release outside of the UI element
+
     //! Get the hover start callback
     virtual OnActionCallback GetHoverStartActionCallback() = 0;
 

--- a/Gems/LyShine/Code/Source/UiButtonComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiButtonComponent.cpp
@@ -67,6 +67,15 @@ bool UiButtonComponent::HandleReleased(AZ::Vector2 point)
     }
     else
     {
+// Gruber patch begin // (vlagutin/Ui_ReleaseOutsideEvent) // Fire an event when the press is release outside of the UI element
+#if defined(CARBONATED)
+        if (m_isHandlingEvents)
+        {
+            UiInteractableComponent::TriggerReleasedAction(true);
+        }
+#endif
+// Gruber patch end // (vlagutin/Ui_ReleaseOutsideEvent) // Fire an event when the press is release outside of the UI element
+
         m_isPressed = false;
 
         return m_isHandlingEvents;

--- a/Gems/LyShine/Code/Source/UiInteractableComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiInteractableComponent.cpp
@@ -353,7 +353,7 @@ void UiInteractableComponent::SetOutsideReleasedActionName(const LyShine::Action
     m_outsideReleasedActionName = actionName;
 }
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-const LyShine::ActionName& UiInteractableComponent::GetOutsideReleasedActionName()
+const LyShine::ActionName& UiInteractableComponent::GetOutsideReleasedActionName() const
 {
     return m_outsideReleasedActionName;
 }

--- a/Gems/LyShine/Code/Source/UiInteractableComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiInteractableComponent.cpp
@@ -345,6 +345,21 @@ void UiInteractableComponent::SetReleasedActionName(const LyShine::ActionName& a
     m_releasedActionName = actionName;
 }
 
+// Gruber patch begin // (vlagutin/Ui_ReleaseOutsideEvent) // Fire an event when the press is release outside of the UI element
+#if defined(CARBONATED)
+////////////////////////////////////////////////////////////////////////////////////////////////////
+void UiInteractableComponent::SetOutsideReleasedActionName(const LyShine::ActionName& actionName)
+{
+    m_outsideReleasedActionName = actionName;
+}
+////////////////////////////////////////////////////////////////////////////////////////////////////
+const LyShine::ActionName& UiInteractableComponent::GetOutsideReleasedActionName()
+{
+    return m_outsideReleasedActionName;
+}
+#endif
+// Gruber patch end // (vlagutin/Ui_ReleaseOutsideEvent) // Fire an event when the press is release outside of the UI element
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 UiInteractableActionsInterface::OnActionCallback UiInteractableComponent::GetHoverStartActionCallback()
 {
@@ -462,6 +477,13 @@ void UiInteractableComponent::Reflect(AZ::ReflectContext* context)
 
             ->Field("HoverStartActionName", &UiInteractableComponent::m_hoverStartActionName)
             ->Field("HoverEndActionName", &UiInteractableComponent::m_hoverEndActionName)
+
+// Gruber patch begin // (vlagutin/Ui_ReleaseOutsideEvent) // Fire an event when the press is release outside of the UI element
+#if defined(CARBONATED)
+            ->Field("OutsideReleasedActionName", &UiInteractableComponent::m_outsideReleasedActionName)
+#endif
+// Gruber patch end // (vlagutin/Ui_ReleaseOutsideEvent) // Fire an event when the press is release outside of the UI element
+
             ->Field("PressedActionName", &UiInteractableComponent::m_pressedActionName)
             ->Field("ReleasedActionName", &UiInteractableComponent::m_releasedActionName);
 
@@ -517,6 +539,11 @@ void UiInteractableComponent::Reflect(AZ::ReflectContext* context)
                 editInfo->DataElement(0, &UiInteractableComponent::m_hoverEndActionName, "Hover end", "Action triggered on hover end");
                 editInfo->DataElement(0, &UiInteractableComponent::m_pressedActionName, "Pressed", "Action triggered on press");
                 editInfo->DataElement(0, &UiInteractableComponent::m_releasedActionName, "Released", "Action triggered on release");
+// Gruber patch begin // (vlagutin/Ui_ReleaseOutsideEvent) // Fire an event when the press is release outside of the UI element
+#if defined(CARBONATED)
+                editInfo->DataElement(0, &UiInteractableComponent::m_outsideReleasedActionName, "Outside Released", "Action triggered on release outside of element");
+#endif
+// Gruber patch end // (vlagutin/Ui_ReleaseOutsideEvent) // Fire an event when the press is release outside of the UI element
             }
         }
     }
@@ -740,7 +767,13 @@ void UiInteractableComponent::TriggerPressedAction()
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+// Gruber patch begin // (vlagutin/Ui_ReleaseOutsideEvent) // Fire an event when the press is release outside of the UI element
+#if defined(CARBONATED)
+void UiInteractableComponent::TriggerReleasedAction(bool releasedOutside)
+#else
 void UiInteractableComponent::TriggerReleasedAction()
+#endif
+// Gruber patch end // (vlagutin/Ui_ReleaseOutsideEvent) // Fire an event when the press is release outside of the UI element
 {
     // if a C++ callback is registered for released then call it
     if (m_releasedActionCallback)
@@ -750,6 +783,21 @@ void UiInteractableComponent::TriggerReleasedAction()
 
     // Queue the event to prevent deletions during the input event
     UiInteractableNotificationBus::QueueEvent(GetEntityId(), &UiInteractableNotificationBus::Events::OnReleased);
+
+// Gruber patch begin // (vlagutin/Ui_ReleaseOutsideEvent) // Fire an event when the press is release outside of the UI element
+#if defined(CARBONATED)
+    if (releasedOutside && !m_outsideReleasedActionName.empty())
+    {
+        AZ::EntityId canvasEntityId;
+        UiElementBus::EventResult(canvasEntityId, GetEntityId(), &UiElementBus::Events::GetCanvasEntityId);
+        // Queue the event to prevent deletions during the input event
+
+        UiCanvasNotificationBus::QueueEvent(canvasEntityId, &UiCanvasNotificationBus::Events::OnAction, GetEntityId(), m_outsideReleasedActionName);
+        UiCanvasNotificationBus::QueueEvent(canvasEntityId, &UiCanvasNotificationBus::Events::OnActionMultitouch, GetEntityId(), m_outsideReleasedActionName, m_pressedPoint, m_pressedMultiTouchIndex);
+        return;
+    }
+#endif
+// Gruber patch end // (vlagutin/Ui_ReleaseOutsideEvent) // Fire an event when the press is release outside of the UI element
 
     // Tell any action listeners about the event
     if (!m_releasedActionName.empty())

--- a/Gems/LyShine/Code/Source/UiInteractableComponent.h
+++ b/Gems/LyShine/Code/Source/UiInteractableComponent.h
@@ -85,7 +85,7 @@ public: // member functions
 
 // Gruber patch begin // (vlagutin/Ui_ReleaseOutsideEvent) // Fire an event when the press is release outside of the UI element
 #if defined(CARBONATED)
-    const LyShine::ActionName& GetOutsideReleasedActionName() override;
+    const LyShine::ActionName& GetOutsideReleasedActionName() const override;
     void SetOutsideReleasedActionName(const LyShine::ActionName& actionName) override;
 #endif
 // Gruber patch end // (vlagutin/Ui_ReleaseOutsideEvent) // Fire an event when the press is release outside of the UI element

--- a/Gems/LyShine/Code/Source/UiInteractableComponent.h
+++ b/Gems/LyShine/Code/Source/UiInteractableComponent.h
@@ -82,6 +82,14 @@ public: // member functions
     void SetPressedActionName(const LyShine::ActionName& actionName) override;
     const LyShine::ActionName& GetReleasedActionName() override;
     void SetReleasedActionName(const LyShine::ActionName& actionName) override;
+
+// Gruber patch begin // (vlagutin/Ui_ReleaseOutsideEvent) // Fire an event when the press is release outside of the UI element
+#if defined(CARBONATED)
+    const LyShine::ActionName& GetOutsideReleasedActionName() override;
+    void SetOutsideReleasedActionName(const LyShine::ActionName& actionName) override;
+#endif
+// Gruber patch end // (vlagutin/Ui_ReleaseOutsideEvent) // Fire an event when the press is release outside of the UI element
+
     OnActionCallback GetHoverStartActionCallback() override;
     void SetHoverStartActionCallback(OnActionCallback onActionCallback) override;
     OnActionCallback GetHoverEndActionCallback() override;
@@ -118,7 +126,14 @@ protected: // member functions
     void TriggerHoverStartAction();
     void TriggerHoverEndAction();
     void TriggerPressedAction();
+// Gruber patch begin // (vlagutin/Ui_ReleaseOutsideEvent) // Fire an event when the press is release outside of the UI element
+#if defined(CARBONATED)
+    void TriggerReleasedAction(bool releasedOutside = false);
+#else
     void TriggerReleasedAction();
+#endif
+// Gruber patch end // (vlagutin/Ui_ReleaseOutsideEvent) // Fire an event when the press is release outside of the UI element
+
     void TriggerReceivedHoverByNavigatingFromDescendantAction(AZ::EntityId descendantEntityId);
 
     virtual bool IsAutoActivationSupported();
@@ -148,6 +163,13 @@ protected: // data members
 
     //! Action triggered on release
     LyShine::ActionName m_releasedActionName;
+
+// Gruber patch begin // (vlagutin/Ui_ReleaseOutsideEvent) // Fire an event when the press is release outside of the UI element
+#if defined(CARBONATED)
+    //! Action triggered on release outside
+    LyShine::ActionName m_outsideReleasedActionName;
+#endif
+// Gruber patch end // (vlagutin/Ui_ReleaseOutsideEvent) // Fire an event when the press is release outside of the UI element
 
     //! If true, the interactable automatically becomes active when navigated to via gamepad/keyboard.
     //! Otherwise, a key press is needed to put the interactable in an active state 


### PR DESCRIPTION
## What does this PR do?

When the UI element is touched/mouse pressed then a finger/mouse is moved outside of the UI element and then released then no any event is fired that leads to sticky action

## How was this PR tested?

In the Editor for an UI element in a new field "Outside Released Action Name" a new special event is added and a LUA script receives that event when we touch UI element->move outside it->release.
