### PR TITLE
Attach support for Metal shader debug symbols when explicitly asked

### DIFF
--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/AzslShaderBuilderSystemComponent.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/AzslShaderBuilderSystemComponent.cpp
@@ -83,7 +83,7 @@ namespace AZ
             // Register Shader Asset Builder
             AssetBuilderSDK::AssetBuilderDesc shaderAssetBuilderDescriptor;
             shaderAssetBuilderDescriptor.m_name = "Shader Asset Builder";
-            shaderAssetBuilderDescriptor.m_version = 122; // Fix the handling of typed buffers for metal shader related dummy entries
+            shaderAssetBuilderDescriptor.m_version = 123; // Metal shader debug symbols controlled via settings registry or shader build arguments
             shaderAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern( AZStd::string::format("*.%s", RPI::ShaderSourceData::Extension), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
             shaderAssetBuilderDescriptor.m_busId = azrtti_typeid<ShaderAssetBuilder>();
             shaderAssetBuilderDescriptor.m_createJobFunction = AZStd::bind(&ShaderAssetBuilder::CreateJobs, &m_shaderAssetBuilder, AZStd::placeholders::_1, AZStd::placeholders::_2);
@@ -108,7 +108,7 @@ namespace AZ
                 shaderVariantAssetBuilderDescriptor.m_name = "Shader Variant Asset Builder";
                 // Both "Shader Variant Asset Builder" and "Shader Asset Builder" produce ShaderVariantAsset products. If you update
                 // ShaderVariantAsset you will need to update BOTH version numbers, not just "Shader Variant Asset Builder".
-                shaderVariantAssetBuilderDescriptor.m_version = 39; // // Fix the handling of typed buffers for metal shader related dummy entries
+                shaderVariantAssetBuilderDescriptor.m_version = 40; // Metal shader debug symbols controlled via settings registry or shader build arguments
                 shaderVariantAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern(AZStd::string::format("*.%s", HashedVariantListSourceData::Extension), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
                 shaderVariantAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern(AZStd::string::format("*.%s", HashedVariantInfoSourceData::Extension), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
                 shaderVariantAssetBuilderDescriptor.m_busId = azrtti_typeid<ShaderVariantAssetBuilder>();

--- a/Gems/Atom/Asset/Shader/Config/Platform/Mac/shader_build_options.json
+++ b/Gems/Atom/Asset/Shader/Config/Platform/Mac/shader_build_options.json
@@ -13,7 +13,6 @@
         ],
         "spirv-cross": [],
         "metalair": ["-sdk", "macosx", "metal" // For xcrun
-                   , "-gline-tables-only", "-MO" //Debug symbols are always enabled at the moment. Need to turn them off for optimized shader assets.
                    , "-fpreserve-invariance"
                    , "-c"
         ],

--- a/Gems/Atom/Asset/Shader/Config/Platform/iOS/shader_build_options.json
+++ b/Gems/Atom/Asset/Shader/Config/Platform/iOS/shader_build_options.json
@@ -13,7 +13,6 @@
         ],
         "spirv-cross": [],
         "metalair": ["-sdk", "iphoneos", "metal", "-std=ios-metal2.2", "-target air64-apple-ios14.0" // For xcrun
-                   , "-gline-tables-only", "-MO" //Debug symbols are always enabled at the moment. Need to turn them off for optimized shader assets.
                    , "-fpreserve-invariance"
                    , "-c"
         ],

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
@@ -13,6 +13,7 @@
 #include <Atom/RHI.Reflect/Metal/Base.h>
 #include <Atom/RHI.Reflect/Metal/PipelineLayoutDescriptor.h>
 #include <Atom/RHI.Reflect/Metal/ShaderStageFunction.h>
+#include <Atom/RHI/RHIUtils.h>
 #include <AzFramework/StringFunc/StringFunc.h>
 
 namespace AZ
@@ -119,10 +120,11 @@ namespace AZ
 
             const Metal::ShaderSourceCode& sourceCode = stageDescriptor.m_sourceCode;
 
-            //Metal sourceCode is great for debugging but it is not needed as we are also packing the bytecode. This
-            //can be removed for more optimized shader assets
-            newShaderStageFunction->SetSourceCode(sourceCode);
-
+            if (!sourceCode.empty())
+            {
+                newShaderStageFunction->SetSourceCode(sourceCode);
+            }
+            
             const Metal::ShaderByteCode& byteCode = stageDescriptor.m_byteCode;
             const AZStd::string& entryFunctionName = stageDescriptor.m_entryFunctionName;
             newShaderStageFunction->SetByteCode(byteCode);
@@ -181,6 +183,9 @@ namespace AZ
             AZStd::vector<char> shaderSourceCode;
             AZStd::vector<uint8_t> shaderByteCode;
 
+            bool isGraphicsDevModeEnabled = RHI::IsGraphicsDevModeEnabled();
+            isGraphicsDevModeEnabled |= BuildHasDebugInfo(shaderBuildArguments);
+                
             // Compile HLSL shader to METAL source code
             bool compiledSucessfully = CompileHLSLShader(
                 shaderSourcePath,                // shader source filename
@@ -191,6 +196,7 @@ namespace AZ
                 shaderSourceCode,                // cross-compiled shader output
                 shaderByteCode,                  // compiled byte code
                 platform,                        // target platform
+                isGraphicsDevModeEnabled,        //Embed debug symbols
                 outputDescriptor.m_byProducts);  // debug objects
 
             if (!compiledSucessfully)
@@ -202,9 +208,14 @@ namespace AZ
             if (shaderSourceCode.size() > 0)
             {
                 outputDescriptor.m_stageType = shaderStage;
-                outputDescriptor.m_sourceCode = AZStd::move(shaderSourceCode);
                 outputDescriptor.m_byteCode = AZStd::move(shaderByteCode);
                 outputDescriptor.m_entryFunctionName = AZStd::move(functionName);
+
+                if (isGraphicsDevModeEnabled)
+                {
+                    //Metal sourceCode is great for debugging at runtime but it is not needed as we are also packing the bytecode.
+                    outputDescriptor.m_sourceCode = AZStd::move(shaderSourceCode);
+                }
             }
             else
             {
@@ -227,6 +238,7 @@ namespace AZ
             AZStd::vector<char>& sourceMetalShader,
             AZStd::vector<uint8_t>& compiledByteCode,
             const AssetBuilderSDK::PlatformInfo& platform,
+            const bool isGraphicsDevModeEnabled,
             ByProducts& byProducts) const
         {
             // Shader compiler executable
@@ -336,7 +348,7 @@ namespace AZ
                 byProducts.m_intermediatePaths.emplace(AZStd::move(shaderMSLOutputFile));   // .msl metal out of sv-cross
             }
 
-            bool compileMetalSL = CreateMetalLib(MetalShaderPlatformName, shaderSourceFile, tempFolder, compiledByteCode, sourceMetalShader, platform, shaderBuildArguments);
+            bool compileMetalSL = CreateMetalLib(MetalShaderPlatformName, shaderSourceFile, tempFolder, compiledByteCode, sourceMetalShader, platform, shaderBuildArguments, isGraphicsDevModeEnabled);
             if (!compileMetalSL)
             {
                 AZ_Error(MetalShaderPlatformName, false, "Failed to create bytecode");
@@ -375,7 +387,8 @@ namespace AZ
                                                      AZStd::vector<uint8_t>& compiledByteCode,
                                                      AZStd::vector<char>& sourceMetalShader,
                                                      const AssetBuilderSDK::PlatformInfo& platform,
-                                                     const RHI::ShaderBuildArguments& shaderBuildArguments) const
+                                                     const RHI::ShaderBuildArguments& shaderBuildArguments,
+                                                     const bool isGraphicsDevModeEnabled) const
         {
             AZStd::string inputMetalFile = RHI::BuildFileNameWithExtension(shaderSourceFile, tempFolder, "metal");
 
@@ -394,7 +407,14 @@ namespace AZ
             AZStd::string outMetalLibFile = RHI::BuildFileNameWithExtension(shaderSourceFile, tempFolder, "metallib");
 
             //Convert to air file
-            const auto metalAirArgumentsStr = RHI::ShaderBuildArguments::ListAsString(shaderBuildArguments.m_metalAirArguments);
+            auto metalAirArguments = shaderBuildArguments.m_metalAirArguments;
+            if (isGraphicsDevModeEnabled)
+            {
+                //Embed debug symbols into the bytecode
+                RHI::ShaderBuildArguments::AppendArguments(metalAirArguments, { "-gline-tables-only", "-MO" });
+            }
+            
+            const auto metalAirArgumentsStr = RHI::ShaderBuildArguments::ListAsString(metalAirArguments);
             const auto mslToAirCommandOptions = AZStd::string::format("%s \"%s\" -o \"%s\"", metalAirArgumentsStr.c_str(), inputMetalFile.c_str(), outputAirFile.c_str());
             if (!RHI::ExecuteShaderCompiler("/usr/bin/xcrun", mslToAirCommandOptions, inputMetalFile, "MslToAir"))
             {

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI.Builders/ShaderPlatformInterface.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI.Builders/ShaderPlatformInterface.h
@@ -67,6 +67,7 @@ namespace AZ
                 AZStd::vector<char>& compiledShader,
                 AZStd::vector<uint8_t>& compiledByteCode,
                 const AssetBuilderSDK::PlatformInfo& platform,
+                const bool isGraphicsDevModeEnabled,
                 ByProducts& byproducts) const;
 
             bool UpdateCompiledShader(AZ::IO::FileIOStream& fileStream,
@@ -80,7 +81,8 @@ namespace AZ
                                 AZStd::vector<uint8_t>& compiledByteCode,
                                 AZStd::vector<char>& sourceMetalShader,
                                 const AssetBuilderSDK::PlatformInfo& platform,
-                                const RHI::ShaderBuildArguments& shaderBuildArguments) const;
+                                const RHI::ShaderBuildArguments& shaderBuildArguments,
+                                const bool isGraphicsDevModeEnabled) const;
             
             using ArgBufferEntries = AZStd::pair<AZStd::string, uint32_t>;
             struct compareByRegisterId {

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI.Reflect/ShaderStageFunction.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI.Reflect/ShaderStageFunction.cpp
@@ -74,14 +74,22 @@ namespace AZ
 
         RHI::ResultCode ShaderStageFunction::FinalizeInternal()
         {
-            if (m_sourceCode.empty())
+            if (m_byteCode.empty())
             {
-                AZ_Error("ShaderStageFunction", false, "Finalizing shader stage function with empty sourcecode.");
+                AZ_Error("ShaderStageFunction", false, "Finalizing shader stage function with empty bytecodes.");
                 return RHI::ResultCode::InvalidArgument;
             }
 
             HashValue64 hash = HashValue64{ 0 };
-            hash = TypeHash64(reinterpret_cast<const uint8_t*>(m_sourceCode.data()), m_sourceCode.size(), hash);
+            if (!m_byteCode.empty())
+            {
+                hash = TypeHash64(m_byteCode.data(), m_byteCode.size(), hash);
+            }
+            
+            if(!m_sourceCode.empty())
+            {
+                hash = TypeHash64(reinterpret_cast<const uint8_t*>(m_sourceCode.data()), m_sourceCode.size(), hash);
+            }
             SetHash(hash);
 
             return RHI::ResultCode::Success;

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI.Reflect/ShaderStageFunction.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI.Reflect/ShaderStageFunction.cpp
@@ -81,10 +81,7 @@ namespace AZ
             }
 
             HashValue64 hash = HashValue64{ 0 };
-            if (!m_byteCode.empty())
-            {
-                hash = TypeHash64(m_byteCode.data(), m_byteCode.size(), hash);
-            }
+            hash = TypeHash64(m_byteCode.data(), m_byteCode.size(), hash);
             
             if(!m_sourceCode.empty())
             {

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineState.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineState.cpp
@@ -83,14 +83,21 @@ namespace AZ
             }
             else
             {
-                //In case byte code was not generated try to create the lib with source code
-                MTLCompileOptions* compileOptions = [MTLCompileOptions alloc];
-                compileOptions.fastMathEnabled = YES;
-                compileOptions.languageVersion = MTLLanguageVersion2_2;
-                lib = [mtlDevice newLibraryWithSource:source
-                                               options:compileOptions
-                                                 error:&error];
-                [compileOptions release];
+                if(!sourceStr.empty())
+                {
+                    //In case byte code was not generated try to create the lib with source code
+                    MTLCompileOptions* compileOptions = [MTLCompileOptions alloc];
+                    compileOptions.fastMathEnabled = YES;
+                    compileOptions.languageVersion = MTLLanguageVersion2_2;
+                    lib = [mtlDevice newLibraryWithSource:source
+                                                  options:compileOptions
+                                                    error:&error];
+                    [compileOptions release];
+                }
+                else
+                {
+                    AZ_Assert(false, "Sahder source is not added by default. It can be added by enabling /O3DE/Atom/RHI/GraphicsDevMode via settings registry and re-building the shader.");
+                }
             }
             
             if (error)

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineState.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineState.cpp
@@ -96,7 +96,7 @@ namespace AZ
                 }
                 else
                 {
-                    AZ_Assert(false, "Sahder source is not added by default. It can be added by enabling /O3DE/Atom/RHI/GraphicsDevMode via settings registry and re-building the shader.");
+                    AZ_Assert(false, "Shader source is not added by default. It can be added by enabling /O3DE/Atom/RHI/GraphicsDevMode via settings registry and re-building the shader.");
                 }
             }
             


### PR DESCRIPTION
## What does this PR do?

- Disables metal shader debug symbols by default. Saves ~25MB within centralplaza_flythrough_stripped level.
- Debug symbols can be requested by either setting the following settings registry 
```
// Atom.setreg
{
    "O3DE": { 
        "Atom": {
            "RHI": {
                "GraphicsDevMode": true
            }
        }
    }
}
```
or by adding this compiler option to the .shader file.
```
{
    "AddBuildArguments" :
    {
        "debug": true
    }
}
```

## How was this PR tested?

Tested centralplaza_flythrough_stripped level on iOS.
