### PR TITLE
Using one BehaviorContext for all the lua material functors

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/MaterialSystem.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/MaterialSystem.h
@@ -15,6 +15,8 @@ namespace AZ
 
     namespace RPI
     {
+        class LuaMaterialBehaviorContext;
+
         //! Manages system-wide initialization and support for material classes
         class MaterialSystem
         {
@@ -24,6 +26,9 @@ namespace AZ
 
             void Init();
             void Shutdown();
+
+        private:
+            LuaMaterialBehaviorContext* m_luaMaterialBehaviorContext = nullptr;
         };
 
     } // namespace RPI

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/LuaMaterialFunctor.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/LuaMaterialFunctor.h
@@ -25,6 +25,22 @@ namespace AZ
 
     namespace RPI
     {
+        class LuaMaterialBehaviorContext
+        {
+        public:
+            static LuaMaterialBehaviorContext* GetInstance();
+            static void SetInstance(LuaMaterialBehaviorContext* instance);
+
+            LuaMaterialBehaviorContext();
+
+            AZ::BehaviorContext* GetBehaviorContext();
+
+        private:
+            void ReflectScriptContext(AZ::BehaviorContext* behaviorContext);
+
+            AZStd::unique_ptr<AZ::BehaviorContext> m_sriptBehaviorContext;
+        };
+
         namespace LuaMaterialFunctorAPI
         {
             class CommonRuntimeConfiguration
@@ -418,9 +434,6 @@ namespace AZ
 
         private:
 
-            // Registers functions in a BehaviorContext so they can be exposed to Lua scripts.
-            static void ReflectScriptContext(AZ::BehaviorContext* context);
-
             void InitScriptContext();
 
             // Utility function that returns either m_scriptBuffer or the content of m_scriptAsset, depending on which as the data
@@ -432,7 +445,6 @@ namespace AZ
             Data::Asset<ScriptAsset> m_scriptAsset;
             AZStd::vector<char> m_scriptBuffer;
 
-            AZStd::unique_ptr<AZ::BehaviorContext> m_sriptBehaviorContext;
             AZStd::unique_ptr<AZ::ScriptContext> m_scriptContext;
             
             MaterialNameContext m_materialNameContext;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Material/MaterialSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Material/MaterialSystem.cpp
@@ -40,6 +40,9 @@ namespace AZ
 
         void MaterialSystem::Init()
         {
+            m_luaMaterialBehaviorContext = aznew LuaMaterialBehaviorContext();
+            LuaMaterialBehaviorContext::SetInstance(m_luaMaterialBehaviorContext);
+
             AZ::Data::InstanceHandler<Material> handler;
             handler.m_createFunction = [](Data::AssetData* materialAsset)
             {
@@ -51,6 +54,10 @@ namespace AZ
         void MaterialSystem::Shutdown()
         {
             Data::InstanceDatabase<Material>::Destroy();
+
+            LuaMaterialBehaviorContext::SetInstance(nullptr);
+            delete m_luaMaterialBehaviorContext;
+            m_luaMaterialBehaviorContext = nullptr;
         }
 
     } // namespace RPI


### PR DESCRIPTION
## What does this PR do?

Using one BehaviorContext for all the lua material functors. This could save a lot of memory when loading all the MaterialTypeAssets.

Note, the ScriptContext can't be shared by all the functors. It may cause script execution issue if you do so.

## How was this PR tested?

MadWorld PC launcher, load centralplaza level
Editor, opened centralplaza level
