### PR TITLE
Mobile pipeline related GPU optimization related for projected shadow light

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/ForwardPass_BaseLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/ForwardPass_BaseLighting.azsli
@@ -23,7 +23,7 @@
 #define ENABLE_SHADOWS 1
 #define ENABLE_FULLSCREEN_SHADOW 0
 #define ENABLE_LIGHT_CULLING 0
-#define ENABLE_DISK_LIGHTS 1
+#define ENABLE_SPHERE_LIGHTS 1   // Enabling this for mobile pipeline as point sphere lights support projected shadows.
 #define ENABLE_AREA_LIGHTS 0
 #define ENABLE_AREA_LIGHT_VALIDATION    0
 #define ENABLE_PHYSICAL_SKY 0

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/ForwardPass_StandardLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/ForwardPass_StandardLighting.azsli
@@ -24,7 +24,7 @@
 #define ENABLE_SHADOWS 1
 #define ENABLE_FULLSCREEN_SHADOW 0
 #define ENABLE_LIGHT_CULLING 0
-#define ENABLE_DISK_LIGHTS 1
+#define ENABLE_SPHERE_LIGHTS 1   // Enabling this for mobile pipeline as point sphere lights support projected shadows.
 #define ENABLE_AREA_LIGHTS 0
 #define ENABLE_AREA_LIGHT_VALIDATION    0
 #define ENABLE_PHYSICAL_SKY 0


### PR DESCRIPTION
## What does this PR do?

Disable Disk lights for mobile pipeline and instead enable point sphere (cheaper) light to help support projected shadows.

## How was this PR tested?

Tested with Editor
