### PR TITLE
Fixed two crashes when start game launcher (with mobile render pipeline)

### DIFF
--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -602,8 +602,10 @@ namespace AZ
 
                 // Switch render pipeline
                 viewportContext->GetRenderScene()->RemoveRenderPipeline(oldRenderPipeline->GetId());
+                auto view = oldRenderPipeline->GetDefaultView();
+                oldRenderPipeline = nullptr;
                 viewportContext->GetRenderScene()->AddRenderPipeline(newRenderPipeline);
-                newRenderPipeline->SetDefaultView(oldRenderPipeline->GetDefaultView());
+                newRenderPipeline->SetDefaultView(view);
 
                 AZ::RPI::RPISystemInterface::Get()->SetApplicationMultisampleState(newRenderPipeline->GetRenderSettings().m_multisampleState);
             }

--- a/Gems/Atom/Feature/Common/Code/Source/Silhouette/SilhouetteFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Silhouette/SilhouetteFeatureProcessor.cpp
@@ -76,7 +76,6 @@ namespace AZ::Render
         {
             m_compositePass->SetEnabled(enabled);
             m_rasterPass->SetEnabled(enabled);
-
         }
     }
 
@@ -115,7 +114,13 @@ namespace AZ::Render
         {
             return;
         }
-        // update our render pass members in case they were added as part of a pipeline 
+
+        // the silhouette passes are alrady added in another render pipeline
+        if (m_renderPipeline)
+        {
+            return;
+        }
+
         UpdatePasses(renderPipeline);
 
         // if we already have valid render pass members then we don't need to dynamically
@@ -124,6 +129,9 @@ namespace AZ::Render
         {
             return;
         }
+
+        // unset the render pipeline untill we added the passes successfully 
+        m_renderPipeline = nullptr;
 
         const auto mergeTemplateName = Name("SilhouettePassTemplate");
         const auto gatherTemplateName = Name("SilhouetteGatherPassTemplate");
@@ -176,20 +184,29 @@ namespace AZ::Render
 
     void SilhouetteFeatureProcessor::OnRenderPipelineChanged(AZ::RPI::RenderPipeline* pipeline, [[maybe_unused]] AZ::RPI::SceneNotification::RenderPipelineChangeType changeType)
     {
-        // update our render pass members in case the pipeline was removed
-        UpdatePasses(pipeline);
+        // Only need to recache silhouette passes if the pipeline had them
+        if (pipeline == m_renderPipeline)
+        {
+            if (changeType == AZ::RPI::SceneNotification::RenderPipelineChangeType::Removed)
+            {
+                UpdatePasses(nullptr);
+            }
+            else
+            {
+                UpdatePasses(pipeline);
+            }
+        }
     }
-
     void SilhouetteFeatureProcessor::UpdatePasses(AZ::RPI::RenderPipeline* renderPipeline)
     {
-        // if we assigned passes to a render pipeline already (m_renderPipeline) then ignore
-        // all other render pipelines
-        if (m_renderPipeline && renderPipeline != m_renderPipeline)
+        m_compositePass = nullptr;
+        m_rasterPass = nullptr;
+
+        if (renderPipeline == nullptr)
         {
+            m_renderPipeline = nullptr;
             return;
         }
-
-        m_compositePass = nullptr;
 
         const auto mergeTemplateName = Name("SilhouettePassTemplate");
         auto compositePassFilter = AZ::RPI::PassFilter::CreateWithTemplateName(mergeTemplateName, renderPipeline);
@@ -197,8 +214,6 @@ namespace AZ::Render
         {
             m_compositePass = foundPass;
         }
-
-        m_rasterPass = nullptr;
 
         const auto gatherTemplateName = Name("SilhouetteGatherPassTemplate");
         auto gatherPassFilter = AZ::RPI::PassFilter::CreateWithTemplateName(gatherTemplateName, renderPipeline);

--- a/Gems/Atom/Feature/Common/Code/Source/Silhouette/SilhouetteFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Silhouette/SilhouetteFeatureProcessor.cpp
@@ -115,7 +115,7 @@ namespace AZ::Render
             return;
         }
 
-        // the silhouette passes are alrady added in another render pipeline
+        // the silhouette passes are already added in another render pipeline
         if (m_renderPipeline)
         {
             return;
@@ -130,7 +130,7 @@ namespace AZ::Render
             return;
         }
 
-        // unset the render pipeline untill we added the passes successfully 
+        // unset the render pipeline until we add the passes successfully 
         m_renderPipeline = nullptr;
 
         const auto mergeTemplateName = Name("SilhouettePassTemplate");

--- a/Gems/Atom/Feature/Common/Code/Source/Silhouette/SilhouetteFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Silhouette/SilhouetteFeatureProcessor.cpp
@@ -182,7 +182,7 @@ namespace AZ::Render
         m_renderPipeline = renderPipeline;
     }
 
-    void SilhouetteFeatureProcessor::OnRenderPipelineChanged(AZ::RPI::RenderPipeline* pipeline, [[maybe_unused]] AZ::RPI::SceneNotification::RenderPipelineChangeType changeType)
+    void SilhouetteFeatureProcessor::OnRenderPipelineChanged(AZ::RPI::RenderPipeline* pipeline, AZ::RPI::SceneNotification::RenderPipelineChangeType changeType)
     {
         // Only need to recache silhouette passes if the pipeline had them
         if (pipeline == m_renderPipeline)


### PR DESCRIPTION
## What does this PR do?

Fixed two crashes when start MadWorld game launcher with MobileRenderPipeline
One crash is with lyShine when there are two passes connected to LyShinePassRequestBus with same ebus id. 
The second crash happened with SilhouetteFeatureProcessor which failed to update m_compositePass and m_rasterPass correctly. The two passes may get re-created with same render pipeline, so we need to always re-find the two passes when render pipeline is changed.

## How was this PR tested?

MadWorld game launcher
