### PR TITLE
Make outline size range 0..100 independent of view

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/SilhouettePropertyGroup.json
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/SilhouettePropertyGroup.json
@@ -59,7 +59,7 @@
             "type": "float",
             "defaultValue": 0.0,
             "min":0.0,
-            "max":3.0,
+            "max":100.0,
             "connection": {
                 "type": "ShaderInput",
                 "name": "m_outlineSize"

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Silhouette/SilhouetteGather.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Silhouette/SilhouetteGather.azsl
@@ -28,10 +28,9 @@ VsOutput MainVS(VsInput IN, uint instanceId : SV_InstanceID)
     real distanceScale = 1.0 - OUT.position.z / OUT.position.w;
     OUT.position.z += MaterialSrg::m_depthBias * distanceScale;
 
-    if(MaterialSrg::m_outlineSize > 0.0)
+    if(MaterialSrg::m_outlineSize > EPSILON)
     {
-        real3 unitNormal = normalize(IN.normal);
-        real3 worldNormal = normalize(mul(GetObjectToWorldMatrixInverseTranspose(instanceId), unitNormal));
+        real3 worldNormal = normalize(mul(GetObjectToWorldMatrixInverseTranspose(instanceId), IN.normal));
         real4 screenSpaceNormal = mul(ViewSrg::m_viewProjectionMatrix, real4(worldNormal, 0.0));
 
         // use a size scale so input m_outlineSize can be in range 0..100

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Silhouette/SilhouetteGather.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Silhouette/SilhouetteGather.azsl
@@ -21,15 +21,23 @@ VsOutput MainVS(VsInput IN, uint instanceId : SV_InstanceID)
     VsSystemValues SV;
     SV.m_instanceId = instanceId;
 
-    // assumes IN.normal is already normalized and pointing in direction the silhouette should expand in
-    IN.position += MaterialSrg::m_outlineSize * IN.normal;
-
     VsOutput OUT = EvaluateVertexGeometry(IN, SV);
 
     // this depth bias helps prevent silhouettes appearing where there are small intersections
     // like the player feet with the ground
-    float distance = 1.0 - OUT.position.z / OUT.position.w;
-    OUT.position.z += MaterialSrg::m_depthBias * distance;
+    real distanceScale = 1.0 - OUT.position.z / OUT.position.w;
+    OUT.position.z += MaterialSrg::m_depthBias * distanceScale;
+
+    if(MaterialSrg::m_outlineSize > 0.0)
+    {
+        real3 unitNormal = normalize(IN.normal);
+        real3 worldNormal = normalize(mul(GetObjectToWorldMatrixInverseTranspose(instanceId), unitNormal));
+        real4 screenSpaceNormal = mul(ViewSrg::m_viewProjectionMatrix, real4(worldNormal, 0.0));
+
+        // use a size scale so input m_outlineSize can be in range 0..100
+        const real sizeScale = 1.0 / 400.0;
+        OUT.position.xy += screenSpaceNormal.xy * (MaterialSrg::m_outlineSize * OUT.position.w * sizeScale) * distanceScale;
+    }
 
     return OUT;
 }


### PR DESCRIPTION
## What does this PR do?

- Updates the way the outline size offset is calculated so it is consistent no matter how close the camera is to the object.
- Updates the outline range to be 0..100 to match the size used in previous versions based on the LY code:
```
  OUT.HPosition = Pos_VS_General(PerView_ViewProjZeroMatr, vertPassPos);

  //// IF CARBONATED ////
  //Computation needs to happen AFTER Pos_VS_General(...) as it changes Input Tangent QUATERNION ROTATION to Tangent VECTOR
  //Get Screen Space Normals
  float3x3 instInvScaleMat = InverseScaleMatrixFast((const float3x3)vertPassPos.InstMatrix);
  float3 worldNormal = normalize(mul(instInvScaleMat, vertPassPos.ObjToTangentSpace[2]));
  float4 worldSpaceNormal = float4(worldNormal.x, worldNormal.y, worldNormal.z, 1.0);
  float4 screenSpaceNormal = mul(PerView_ViewProjZeroMatr, worldSpaceNormal);

  //Compute View Independent offset factor
  const float distance = OUT.HPosition.z / OUT.HPosition.w;

  // aefimov this is the original formula
  //Divide by 100.0f because OutlineSize is sensical for very small values, but in Editor it is easier to work with larger values 
  //OUT.HPosition.xy += OutlineSize / 100.0f * screenSpaceNormal.xy * (1.0f - distance) * (1.0f - distance);
  // aefimov the new one is perspective agnostic, the same outline thickness for all objects
  // divided by 400 to match the old look when it was divided by 100
  OUT.HPosition.xy += (OutlineSize * OUT.HPosition.w / 400.0f) * screenSpaceNormal.xy
```

## How was this PR tested?

Tested in Editor 
