### PR TITLE
AssetBundlerBatch Updates: Permit empty assetlists & bundles, additional missing asset/dependency logs.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetBundler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetBundler.cpp
@@ -334,11 +334,6 @@ namespace AzToolsFramework
             }
         }
 
-        if (!assetFileInfoList.m_fileInfoList.size())
-        {
-            return AZ::Failure(AZStd::string::format("File ( %s ) does not contain any assets.\n", assetFileInfoPath.c_str()));
-        }
-
         return AZ::Success(assetFileInfoList);
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetBundler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetBundler.cpp
@@ -334,6 +334,14 @@ namespace AzToolsFramework
             }
         }
 
+#if defined(CARBONATED)
+        // Removed - don't fail on empty assets
+#else
+        if (!assetFileInfoList.m_fileInfoList.size())
+        {
+            return AZ::Failure(AZStd::string::format("File ( %s ) does not contain any assets.\n", assetFileInfoPath.c_str()));
+        }
+#endif
         return AZ::Success(assetFileInfoList);
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetDebugInfo.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetDebugInfo.cpp
@@ -282,7 +282,7 @@ namespace AzToolsFramework
                 // We are only reflecting the human readable string here because we do not plan on loading this file type
                 // into memory at this time, and this is the easiest way for our customers to read this info
                 ->Field("humanReadableString", &AssetFileDebugInfoList::m_humanReadableString)
-                ->Field("invalidAssetHumanReadableString", &AssetFileDebugInfoList::m_humanReadableString);
+                ->Field("invalidAssetHumanReadableString", &AssetFileDebugInfoList::m_invalidAssetHumanReadableString);
         }
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetDebugInfo.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetDebugInfo.cpp
@@ -238,7 +238,7 @@ namespace AzToolsFramework
                 root.m_assetId = assetDebugInfo->second.m_assetId;
                 BuildNodeTree(assetDebugInfo->second.m_assetId, &root);
                 root.BuildHumanReadableString("", *this, m_invalidAssetHumanReadableString, true);
-                m_invalidAssetHumanReadableString += AZStd::string("\n");
+                m_invalidAssetHumanReadableString += '\n';
             }
         }
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetDebugInfo.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetDebugInfo.cpp
@@ -79,7 +79,7 @@ namespace AzToolsFramework
                     m_assetId.ToString<AZStd::string>().c_str(),
                     sizeString.c_str());
 
-               AZ_Error("Dependency", false, errorText.c_str());
+               AZ_Error("Dependency", false, "%s", errorText.c_str());
             }
 
             for (AZStd::map<AZ::Data::AssetId, DependencyNode*>::iterator leaf = m_leaves.begin(); leaf != m_leaves.end(); ++leaf)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetDebugInfo.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetDebugInfo.h
@@ -65,14 +65,15 @@ namespace AzToolsFramework
         static const char* GetAssetListDebugFileExtension();
 
         void BuildHumanReadableString();
-        void BuildInvalidAssetHumanReadableString();
-
         void BuildNodeTree(AZ::Data::AssetId assetId, DependencyNode* parent);
 
         AZStd::map<AZ::Data::AssetId, AssetFileDebugInfo> m_fileDebugInfoList;
-        AZStd::vector<AZ::Data::AssetId> m_invalidFileDebugInfoList;
-
         AZStd::string m_humanReadableString;
+
+#if defined(CARBONATED)
+        void BuildInvalidAssetHumanReadableString();
+        AZStd::vector<AZ::Data::AssetId> m_invalidFileDebugInfoList;
         AZStd::string m_invalidAssetHumanReadableString;
+#endif
     };
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetDebugInfo.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetDebugInfo.h
@@ -65,9 +65,14 @@ namespace AzToolsFramework
         static const char* GetAssetListDebugFileExtension();
 
         void BuildHumanReadableString();
+        void BuildInvalidAssetHumanReadableString();
+
         void BuildNodeTree(AZ::Data::AssetId assetId, DependencyNode* parent);
 
         AZStd::map<AZ::Data::AssetId, AssetFileDebugInfo> m_fileDebugInfoList;
+        AZStd::vector<AZ::Data::AssetId> m_invalidFileDebugInfoList;
+
         AZStd::string m_humanReadableString;
+        AZStd::string m_invalidAssetHumanReadableString;
     };
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetSeedManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetSeedManager.cpp
@@ -649,7 +649,7 @@ namespace AzToolsFramework
         if (useDebugInfoList)
         {
             debugInfo.BuildHumanReadableString();
-            if (debugInfo.m_invalidFileDebugInfoList.size() > 0)
+            if (!debugInfo.m_invalidFileDebugInfoList.empty())
             {
                 debugInfo.BuildInvalidAssetHumanReadableString();
             }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetSeedManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetSeedManager.cpp
@@ -535,7 +535,6 @@ namespace AzToolsFramework
                     if (productDependency.m_assetId.IsValid() && assetIdSet.find(productDependency.m_assetId) == assetIdSet.end())
                     {
                         assetIdSet.insert(productDependency.m_assetId);
-                       
                         AZ::Data::AssetInfo assetInfo = GetAssetInfoById(productDependency.m_assetId, platformIndex, "", m_assetSeedList[idx].m_assetRelativePath);
                         assetsInfoList.emplace_back(AZStd::move(assetInfo));
                     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetSeedManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetSeedManager.cpp
@@ -347,7 +347,11 @@ namespace AzToolsFramework
     }
 
     // Returns the asset info if it exists and is the same for the platform specified by platformIndex
+#if defined(CARBONATED)
     AZ::Data::AssetInfo AssetSeedManager::GetAssetInfoById(const AZ::Data::AssetId& assetId, const AzFramework::PlatformId& platformIndex, const AZStd::string& seedListfilePath, const AZStd::string& assetHintPath, AssetFileDebugInfoList* optionalDebugList)
+#else
+    AZ::Data::AssetInfo AssetSeedManager::GetAssetInfoById(const AZ::Data::AssetId& assetId, const AzFramework::PlatformId& platformIndex, const AZStd::string& seedListfilePath, const AZStd::string& assetHintPath)
+#endif
     {
         using namespace AzToolsFramework::AssetCatalog;
         AZ::Data::AssetInfo assetInfo;
@@ -362,11 +366,12 @@ namespace AzToolsFramework
             }
 
             AZ_Error("AssetSeedManager", false, errorMessage.c_str());
-
+#if defined(CARBONATED)
             if (optionalDebugList)
             {
                 optionalDebugList->m_invalidFileDebugInfoList.push_back(assetId);
             }
+#endif
         }
         return assetInfo;
     }
@@ -535,7 +540,11 @@ namespace AzToolsFramework
                     if (productDependency.m_assetId.IsValid() && assetIdSet.find(productDependency.m_assetId) == assetIdSet.end())
                     {
                         assetIdSet.insert(productDependency.m_assetId);
+#if defined(CARBONATED)
                         AZ::Data::AssetInfo assetInfo = GetAssetInfoById(productDependency.m_assetId, platformIndex, "", m_assetSeedList[idx].m_assetRelativePath);
+#else
+                        AZ::Data::AssetInfo assetInfo = GetAssetInfoById(productDependency.m_assetId, platformIndex, m_assetSeedList[idx].m_seedListFilePath);
+#endif
                         assetsInfoList.emplace_back(AZStd::move(assetInfo));
                     }
                 }
@@ -649,10 +658,12 @@ namespace AzToolsFramework
         if (useDebugInfoList)
         {
             debugInfo.BuildHumanReadableString();
+#if defined(CARBONATED)
             if (!debugInfo.m_invalidFileDebugInfoList.empty())
             {
                 debugInfo.BuildInvalidAssetHumanReadableString();
             }
+#endif
             return AZ::Utils::SaveObjectToFile(debugFilePath, AZ::DataStream::StreamType::ST_XML, &debugInfo);
         }
 
@@ -859,8 +870,14 @@ namespace AzToolsFramework
     {
         if (assetFileInfoList.m_fileInfoList.empty())
         {
+#if defined(CARBONATED)
             // Warn if the asset list is empty, but allow the save
             AZ_Warning("AssetFileInfoList", false, "(%s): list is empty.\n", destinationFilePath.c_str());
+#else
+            // Don't save an empty list
+            AZ_Warning("AssetFileInfoList", false, "Unable to save Asset List file (%s): list is empty.\n", destinationFilePath.c_str());
+            return false;
+#endif
         }
 
         auto fileExtensionOutcome = ValidateAssetListFileExtension(destinationFilePath);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetSeedManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetSeedManager.h
@@ -149,7 +149,11 @@ namespace AzToolsFramework
         AZ::Data::AssetId FindAssetIdByPathHint(const AZStd::string& pathHint) const;
         AZ::Data::AssetId GetAssetIdByPath(const AZStd::string& assetPath, const AzFramework::PlatformFlags& platformFlags) const;
         AZ::Data::AssetId GetAssetIdByAssetKey(const AZStd::string& assetKey, const AzFramework::PlatformFlags& platformFlags) const;
+#if defined(CARBONATED)
         static AZ::Data::AssetInfo GetAssetInfoById(const AZ::Data::AssetId& assetId, const AzFramework::PlatformId& platformIndex, const AZStd::string& seedListfilePath = AZStd::string(), const AZStd::string& asetHintPath = AZStd::string(), AssetFileDebugInfoList* optionalDebugList = nullptr);
+#else
+        static AZ::Data::AssetInfo GetAssetInfoById(const AZ::Data::AssetId& assetId, const AzFramework::PlatformId& platformIndex, const AZStd::string& seedListfilePath = AZStd::string(), const AZStd::string& asetHintPath = AZStd::string());
+#endif
     private:
         AZ::Outcome<AZStd::vector<AZ::Data::ProductDependency>, AZStd::string> GetAllProductDependencies(
             const AZ::Data::AssetId& assetId,

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetSeedManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetSeedManager.h
@@ -149,7 +149,7 @@ namespace AzToolsFramework
         AZ::Data::AssetId FindAssetIdByPathHint(const AZStd::string& pathHint) const;
         AZ::Data::AssetId GetAssetIdByPath(const AZStd::string& assetPath, const AzFramework::PlatformFlags& platformFlags) const;
         AZ::Data::AssetId GetAssetIdByAssetKey(const AZStd::string& assetKey, const AzFramework::PlatformFlags& platformFlags) const;
-        static AZ::Data::AssetInfo GetAssetInfoById(const AZ::Data::AssetId& assetId, const AzFramework::PlatformId& platformIndex, const AZStd::string& seedListfilePath = AZStd::string(), const AZStd::string& asetHintPath = AZStd::string());
+        static AZ::Data::AssetInfo GetAssetInfoById(const AZ::Data::AssetId& assetId, const AzFramework::PlatformId& platformIndex, const AZStd::string& seedListfilePath = AZStd::string(), const AZStd::string& asetHintPath = AZStd::string(), AssetFileDebugInfoList* optionalDebugList = nullptr);
     private:
         AZ::Outcome<AZStd::vector<AZ::Data::ProductDependency>, AZStd::string> GetAllProductDependencies(
             const AZ::Data::AssetId& assetId,


### PR DESCRIPTION
## What does this PR do?

Removes the failure case for empty assetlists & bundles.  Also prints out human-readable logs when missing assets / dependencies are found.

## How was this PR tested?

By running AssetBundlerBatch's compare (complement) function to generating assetlists containing no assets, and generating bundles (pak files) that contain no assets.

Additionally, these changes were pulled from our changes in LY 1.28.

## Reasoning

Users of the AssetBundlerBatch should be permitted to generate assetlists & bundles without any actual assets, along with appropriate warnings.
