### PR TITLE
Cherry pick Quality System changes

### DIFF
--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryVisitorUtils.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryVisitorUtils.h
@@ -71,15 +71,18 @@ namespace AZ::SettingsRegistryVisitorUtils
     //! If @path is not an array or object, then no elements are visited
     //! This function will not recurse into children of elements
     //! @visitCallback functor that is invoked for each array or object element found
+    //! @return Whether or not entries could be visited.
     bool VisitField(AZ::SettingsRegistryInterface& settingsRegistry, const VisitorCallback& visitCallback, AZStd::string_view path);
     //! Invokes the visitor callback for each element of the array at @path
     //! If @path is not an array, then no elements are visited
     //! This function will not recurse into children of elements
     //! @visitCallback functor that is invoked for each array element found
+    //! @return Whether or not entries could be visited.
     bool VisitArray(AZ::SettingsRegistryInterface& settingsRegistry, const VisitorCallback& visitCallback, AZStd::string_view path);
     //! Invokes the visitor callback for each element of the object at @path
     //! If @path is not an object, then no elements are visited
     //! This function will not recurse into children of elements
     //! @visitCallback functor that is invoked for each object element found
+    //! @return Whether or not entries could be visited.
     bool VisitObject(AZ::SettingsRegistryInterface& settingsRegistry, const VisitorCallback& visitCallback, AZStd::string_view path);
 }

--- a/Code/Framework/AzFramework/AzFramework/API/ApplicationAPI.h
+++ b/Code/Framework/AzFramework/AzFramework/API/ApplicationAPI.h
@@ -99,7 +99,7 @@ namespace AzFramework
         /// Calculate the branch token from the current application's engine root
         virtual void CalculateBranchTokenForEngineRoot(AZStd::string& token) const = 0;
 
-        /// Returns true if Prefab System is enabled, false if Legacy Slice System is enabled
+        /// Returns true if Editor Mode Feedback is enabled
         virtual bool IsEditorModeFeedbackEnabled() const { return false; }
 
         /// Returns true if Prefab System is enabled, false if Legacy Slice System is enabled

--- a/Code/Framework/AzFramework/AzFramework/Application/Application.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Application/Application.cpp
@@ -645,7 +645,7 @@ namespace AzFramework
         constexpr const char* userCachePathFilename{ "Cache" };
         AZ::IO::FixedMaxPath userCachePath = cacheUserPath / userCachePathFilename;
 #if AZ_TRAIT_OS_IS_HOST_OS_PLATFORM
-        // The number of max attempts ultimately dictates the number of Lumberyard instances that can run
+        // The number of max attempts ultimately dictates the number of application instances that can run
         // simultaneously.  This should be a reasonably high number so that it doesn't artificially limit
         // the number of instances (ex: parallel level exports via multiple Editor runs).  It also shouldn't
         // be set *infinitely* high - each cache folder is GBs in size, and finding a free directory is a

--- a/Code/Framework/AzFramework/AzFramework/AzFrameworkModule.cpp
+++ b/Code/Framework/AzFramework/AzFramework/AzFrameworkModule.cpp
@@ -14,6 +14,7 @@
 #include <AzFramework/Components/TransformComponent.h>
 #include <AzFramework/Components/NonUniformScaleComponent.h>
 #include <AzFramework/Components/AzFrameworkConfigurationSystemComponent.h>
+#include <AzFramework/Device/DeviceAttributesSystemComponent.h>
 #include <AzFramework/Entity/GameEntityContextComponent.h>
 #include <AzFramework/FileTag/FileTagComponent.h>
 #include <AzFramework/Input/Contexts/InputContextComponent.h>
@@ -57,6 +58,7 @@ namespace AzFramework
             AzFramework::StreamingInstall::StreamingInstallSystemComponent::CreateDescriptor(),
             AzFramework::AzFrameworkConfigurationSystemComponent::CreateDescriptor(),
             AzFramework::QualitySystemComponent::CreateDescriptor(),
+            AzFramework::DeviceAttributesSystemComponent::CreateDescriptor(),
 
             AzFramework::OctreeSystemComponent::CreateDescriptor(),
             AzFramework::SpawnableSystemComponent::CreateDescriptor(),
@@ -70,6 +72,7 @@ namespace AzFramework
         {
             azrtti_typeid<AzFramework::OctreeSystemComponent>(),
             azrtti_typeid<AzFramework::QualitySystemComponent>(),
+            azrtti_typeid<AzFramework::DeviceAttributesSystemComponent>(),
         };
     }
 }

--- a/Code/Framework/AzFramework/AzFramework/Device/DeviceAttributeDeviceModel.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Device/DeviceAttributeDeviceModel.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AzFramework/Device/DeviceAttributeDeviceModel.h>
+#include <AzCore/std/string/regex.h>
 
 namespace AzFramework
 {
@@ -28,9 +29,10 @@ namespace AzFramework
         return AZStd::any(m_value);
     }
 
-    bool DeviceAttributeDeviceModel::Evaluate([[maybe_unused]] AZStd::string_view rule) const
+    bool DeviceAttributeDeviceModel::Evaluate(AZStd::string_view rule) const
     {
-        return false;
+        auto regex = AZStd::regex(rule.data(), rule.size());
+        return AZStd::regex_match(m_value, regex);
     }
 } // namespace AzFramework
 

--- a/Code/Framework/AzFramework/AzFramework/Device/DeviceAttributeDeviceModel.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Device/DeviceAttributeDeviceModel.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzFramework/Device/DeviceAttributeDeviceModel.h>
+
+namespace AzFramework
+{
+    // Platform specific device model value retrieval can be found in the relevant platform's code folder
+    // e.g. Code/Framework/AzFramework/Platform/Windows/AzFramework/Device/DeviceAttributesCommon_Win.cpp
+
+    AZStd::string_view DeviceAttributeDeviceModel::GetName() const
+    {
+        return m_name;
+    }
+
+    AZStd::string_view DeviceAttributeDeviceModel::GetDescription() const
+    {
+        return m_description;
+    }
+
+    AZStd::any DeviceAttributeDeviceModel::GetValue() const
+    {
+        return AZStd::any(m_value);
+    }
+
+    bool DeviceAttributeDeviceModel::Evaluate([[maybe_unused]] AZStd::string_view rule) const
+    {
+        return false;
+    }
+} // namespace AzFramework
+

--- a/Code/Framework/AzFramework/AzFramework/Device/DeviceAttributeDeviceModel.h
+++ b/Code/Framework/AzFramework/AzFramework/Device/DeviceAttributeDeviceModel.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzFramework/Device/DeviceAttributeInterface.h>
+
+namespace AzFramework
+{
+    //! Device attribute for getting device model name e.g. "Pixel 3 XL" 
+    class DeviceAttributeDeviceModel : public DeviceAttribute
+    {
+    public:
+        DeviceAttributeDeviceModel();
+        AZStd::string_view GetName() const override;
+        AZStd::string_view GetDescription() const override;
+        AZStd::any GetValue() const override;
+        bool Evaluate(AZStd::string_view rule) const override;
+    protected:
+        AZStd::string m_name = "DeviceModel";
+        AZStd::string m_description = "Device Model";
+        AZStd::string m_value = "";
+    };
+} // namespace AzFramework

--- a/Code/Framework/AzFramework/AzFramework/Device/DeviceAttributeInterface.h
+++ b/Code/Framework/AzFramework/AzFramework/Device/DeviceAttributeInterface.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Interface/Interface.h>
+#include <AzCore/std/smart_ptr/shared_ptr.h>
+#include <AzCore/std/string/string.h>
+#include <AzCore/std/string/string_view.h>
+#include <AzCore/std/any.h>
+
+namespace AzFramework
+{
+    // DeviceAttribute provides an interface for requesting information about a
+    // single device attribute like model, GPU type, RAM amount etc.
+    class DeviceAttribute
+    {
+    public:
+        AZ_RTTI(DeviceAttribute, "{8B7AF778-DD8A-4AFA-8416-EA2D03080F29}");
+        virtual ~DeviceAttribute() = default;
+
+        //! Get the name of the device attribute e.g. gpuMemory, gpuVendor, customAttribute42
+        virtual AZStd::string_view GetName() const = 0;
+
+        //! Get a description of this device attribute, used for help text and eventual UI
+        virtual AZStd::string_view GetDescription() const = 0;
+
+        //! Evaluate a rule and return true if there is a match for this device attribute
+        virtual bool Evaluate(AZStd::string_view rule) const = 0;
+
+        //! Get the value of this attribute
+        virtual AZStd::any GetValue() const = 0;
+    };
+
+    // DeviceAttributeRegistrarInterface provides an interface for registering and accessing
+    // DeviceAttributes which describes a single device attribute.
+    class DeviceAttributeRegistrarInterface
+    {
+    public:
+        AZ_RTTI(DeviceAttributeRegistrarInterface, "{D6B65DF8-8275-42F8-B84D-4F9ACBECC7C2}");
+        virtual ~DeviceAttributeRegistrarInterface() = default;
+
+        //! Find a device attribute by name
+        virtual DeviceAttribute* FindDeviceAttribute(AZStd::string_view deviceAttribute) const = 0;
+
+        //! Register a device attribute interface, deviceAttribute must have a unique name, returns true on success
+        virtual bool RegisterDeviceAttribute(AZStd::shared_ptr<DeviceAttribute> deviceAttributeInterface) = 0;
+
+        //! Unregister an existing device attribute, returns true on success, false if not found
+        virtual bool UnregisterDeviceAttribute(AZStd::string_view deviceAttribute) = 0;
+
+        //! The callback function should return true to continue enumaration or false to stop
+        using VisitInterfaceCallback = AZStd::function<bool(DeviceAttribute&)>;
+
+        //! Visit device attribute interfaces with a callback function
+        //! The visiting callback can be useful to enumerate over multiple attributes
+        //! for display or rule evaluation.
+        virtual void VisitDeviceAttributes(const VisitInterfaceCallback&) const = 0;
+    };
+    using DeviceAttributeRegistrar = AZ::Interface<DeviceAttributeRegistrarInterface>;
+
+} // namespace AzFramework

--- a/Code/Framework/AzFramework/AzFramework/Device/DeviceAttributeRAM.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Device/DeviceAttributeRAM.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzFramework/Device/DeviceAttributeRAM.h>
+
+namespace AzFramework
+{
+    // Platform specific RAM value retrieval can be found in the relevant platform's code folder
+    // e.g. Code/Framework/AzFramework/Platform/Windows/AzFramework/Device/DeviceAttributesCommon_Win.cpp
+
+    AZStd::string_view DeviceAttributeRAM::GetName() const
+    {
+        return m_name;
+    }
+
+    AZStd::string_view DeviceAttributeRAM::GetDescription() const
+    {
+        return m_description;
+    }
+
+    AZStd::any DeviceAttributeRAM::GetValue() const
+    {
+        return AZStd::any(m_valueInGiB);
+    }
+
+    bool DeviceAttributeRAM::Evaluate([[maybe_unused]] AZStd::string_view rule) const
+    {
+        return false;
+    }
+} // namespace AzFramework
+

--- a/Code/Framework/AzFramework/AzFramework/Device/DeviceAttributeRAM.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Device/DeviceAttributeRAM.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AzFramework/Device/DeviceAttributeRAM.h>
+#include <AzCore/std/string/regex.h>
 
 namespace AzFramework
 {
@@ -28,9 +29,10 @@ namespace AzFramework
         return AZStd::any(m_valueInGiB);
     }
 
-    bool DeviceAttributeRAM::Evaluate([[maybe_unused]] AZStd::string_view rule) const
+    bool DeviceAttributeRAM::Evaluate(AZStd::string_view rule) const
     {
-        return false;
+        auto regex = AZStd::regex(rule.data(), rule.size());
+        return AZStd::regex_match(m_value, regex);
     }
 } // namespace AzFramework
 

--- a/Code/Framework/AzFramework/AzFramework/Device/DeviceAttributeRAM.h
+++ b/Code/Framework/AzFramework/AzFramework/Device/DeviceAttributeRAM.h
@@ -13,6 +13,14 @@ namespace AzFramework
 {
     //! Device attribute for getting RAM available to OS in GiB 
     //! which is usually less than the physically installed RAM
+    //! For this reason, instead of checking if a device has
+    //! e.g. 8GiB of RAM, it is better to check that the amount
+    //! of available RAM is equal to or greater than the actual
+    //! amount of RAM needed by your application e.g. 5.5GiB
+    //! plus some small margin.  Note: some mobile devices
+    //! set this value based on the amount physical RAM
+    //! installed which may be more than is actually
+    //! available for use.
     class DeviceAttributeRAM : public DeviceAttribute
     {
     public:
@@ -21,9 +29,11 @@ namespace AzFramework
         AZStd::string_view GetDescription() const override;
         AZStd::any GetValue() const override;
         bool Evaluate(AZStd::string_view rule) const override;
+
     protected:
         AZStd::string m_name = "RAM";
         AZStd::string m_description = "RAM available to OS in GiB, usually less than the physically installed RAM.";
         float m_valueInGiB = 0.f;
+        AZStd::string m_value; //! the string version of m_valueInGiB
     };
 } // namespace AzFramework

--- a/Code/Framework/AzFramework/AzFramework/Device/DeviceAttributeRAM.h
+++ b/Code/Framework/AzFramework/AzFramework/Device/DeviceAttributeRAM.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzFramework/Device/DeviceAttributeInterface.h>
+
+namespace AzFramework
+{
+    //! Device attribute for getting RAM available to OS in GiB 
+    //! which is usually less than the physically installed RAM
+    class DeviceAttributeRAM : public DeviceAttribute
+    {
+    public:
+        DeviceAttributeRAM();
+        AZStd::string_view GetName() const override;
+        AZStd::string_view GetDescription() const override;
+        AZStd::any GetValue() const override;
+        bool Evaluate(AZStd::string_view rule) const override;
+    protected:
+        AZStd::string m_name = "RAM";
+        AZStd::string m_description = "RAM available to OS in GiB, usually less than the physically installed RAM.";
+        float m_valueInGiB = 0.f;
+    };
+} // namespace AzFramework

--- a/Code/Framework/AzFramework/AzFramework/Device/DeviceAttributesSystemComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Device/DeviceAttributesSystemComponent.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzFramework/Device/DeviceAttributesSystemComponent.h>
+#include <AzFramework/Device/DeviceAttributeDeviceModel.h>
+#include <AzFramework/Device/DeviceAttributeRAM.h>
+
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/std/smart_ptr/make_shared.h>
+
+namespace AzFramework
+{
+    DeviceAttributesSystemComponent::DeviceAttributesSystemComponent() = default;
+    DeviceAttributesSystemComponent::~DeviceAttributesSystemComponent() = default;
+
+    void DeviceAttributesSystemComponent::Reflect(AZ::ReflectContext* context)
+    {
+        if (AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<DeviceAttributesSystemComponent, AZ::Component>();
+
+            if (AZ::EditContext* editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<DeviceAttributesSystemComponent>(
+                    "AzFramework Device Attributes Component", "System component responsible for handling device attribute registration")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::Category, "Editor")
+                    ;
+            }
+        }
+    }
+
+    void DeviceAttributesSystemComponent::Activate()
+    {
+        if (DeviceAttributeRegistrar::Get() == nullptr)
+        {
+            DeviceAttributeRegistrar::Register(this);
+        }
+
+        // register default attributes
+        RegisterDeviceAttribute(AZStd::make_shared<DeviceAttributeDeviceModel>());
+        RegisterDeviceAttribute(AZStd::make_shared<DeviceAttributeRAM>());
+    }
+
+    void DeviceAttributesSystemComponent::Deactivate()
+    {
+        if (DeviceAttributeRegistrar::Get() == this)
+        {
+            DeviceAttributeRegistrar::Unregister(this);
+        }
+
+        m_deviceAttributes.clear();
+    }
+
+    DeviceAttribute* DeviceAttributesSystemComponent::FindDeviceAttribute(AZStd::string_view deviceAttribute) const
+    {
+        auto itr = m_deviceAttributes.find(deviceAttribute);
+        return itr != m_deviceAttributes.end() ? itr->second.get() : nullptr;
+    }
+
+    bool DeviceAttributesSystemComponent::RegisterDeviceAttribute(AZStd::shared_ptr<DeviceAttribute> deviceAttribute)
+    {
+        const auto name = deviceAttribute->GetName();
+        if (m_deviceAttributes.contains(name))
+        {
+            AZ_Warning(
+                "DeviceAttributesSystemComponent", false,
+                "Device attribute '%.*s' is already registered, ignoring new registration request.",
+                AZ_STRING_ARG(name));
+            return false;
+        }
+
+        m_deviceAttributes.insert({ name, deviceAttribute });
+        return true;
+    }
+
+    bool DeviceAttributesSystemComponent::UnregisterDeviceAttribute(AZStd::string_view deviceAttribute)
+    {
+        return m_deviceAttributes.erase(deviceAttribute) > 0;
+    }
+
+    void DeviceAttributesSystemComponent::VisitDeviceAttributes(const VisitInterfaceCallback& callback) const
+    {
+        for ([[maybe_unused]] const auto& [deviceAttribute, deviceAttributeInterface] : m_deviceAttributes)
+        {
+            if (!deviceAttributeInterface)
+            {
+                continue;
+            }
+
+            if (!callback(*deviceAttributeInterface.get()))
+            {
+                return;
+            }
+        }
+    }
+
+    void DeviceAttributesSystemComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
+    {
+        provided.push_back(AZ_CRC_CE("DeviceAttributesSystemComponentService"));
+    }
+
+    void DeviceAttributesSystemComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
+    {
+        incompatible.push_back(AZ_CRC_CE("DeviceAttributesSystemComponentService"));
+    }
+
+    void DeviceAttributesSystemComponent::GetDependentServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& dependent)
+    {
+    }
+} // AzFramework
+

--- a/Code/Framework/AzFramework/AzFramework/Device/DeviceAttributesSystemComponent.h
+++ b/Code/Framework/AzFramework/AzFramework/Device/DeviceAttributesSystemComponent.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <AzCore/std/containers/unordered_map.h>
+#include <AzFramework/Device/DeviceAttributeInterface.h>
+
+namespace AzFramework
+{
+    class DeviceAttributeInterface;
+
+    //! System component responsible for managing device attributes
+    class DeviceAttributesSystemComponent final
+        : public AZ::Component
+        , public DeviceAttributeRegistrarInterface
+    {
+    public:
+        AZ_COMPONENT(DeviceAttributesSystemComponent, "{C5ACED7D-FE7B-43F4-9414-8B2CAB51F229}", AZ::Component);
+
+        DeviceAttributesSystemComponent();
+        ~DeviceAttributesSystemComponent() override;
+
+        // AZ::Component
+        void Activate() override;
+        void Deactivate() override;
+
+        // AzFramework::DeviceAttributeRegistrarInterface
+        DeviceAttribute* FindDeviceAttribute(AZStd::string_view deviceAttribute) const override;
+        bool RegisterDeviceAttribute(AZStd::shared_ptr<DeviceAttribute> deviceAttribute) override;
+        bool UnregisterDeviceAttribute(AZStd::string_view deviceAttribute) override;
+        void VisitDeviceAttributes(const VisitInterfaceCallback&) const override;
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
+        static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
+        static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
+
+    private:
+        AZ_DISABLE_COPY(DeviceAttributesSystemComponent);
+
+        AZStd::unordered_map<AZStd::string, AZStd::shared_ptr<DeviceAttribute>> m_deviceAttributes;
+    };
+} // AzFramework
+

--- a/Code/Framework/AzFramework/AzFramework/Quality/QualitySystemBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Quality/QualitySystemBus.h
@@ -26,6 +26,18 @@ namespace AzFramework
     AZ_DEFINE_ENUM_ARITHMETIC_OPERATORS(QualityLevel);
     AZ_DEFINE_ENUM_RELATIONAL_OPERATORS(QualityLevel);
 
+    // Device rule resolution 
+    AZ_ENUM_CLASS(DeviceRuleResolution,
+        (Invalid, -1),
+        (Min, 0), // use the lowest setting for all matching rules
+        (Max, 1), // use the maximum setting for all matching rules
+        (First, 2), // use the setting for the first rule that matches
+        (Last, 3)  // use the setting for the last rule that matches
+    );
+    AZ_TYPE_INFO_SPECIALIZE(DeviceRuleResolution, "{DB0E23FC-433A-4A95-BEFA-8E39E3A1E344}");
+    AZ_DEFINE_ENUM_ARITHMETIC_OPERATORS(DeviceRuleResolution);
+    AZ_DEFINE_ENUM_RELATIONAL_OPERATORS(DeviceRuleResolution);
+
     class QualitySystemEvents
         : public AZ::EBusTraits
     {

--- a/Code/Framework/AzFramework/AzFramework/Quality/QualitySystemComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Quality/QualitySystemComponent.cpp
@@ -8,6 +8,7 @@
 
 #include <AzFramework/Quality/QualitySystemComponent.h>
 #include <AzFramework/Quality/QualityCVarGroup.h>
+#include <AzFramework/Device/DeviceAttributeInterface.h>
 
 #include <AzCore/Console/IConsole.h>
 #include <AzCore/Preprocessor/EnumReflectUtils.h> 
@@ -15,12 +16,16 @@
 #include <AzCore/Settings/SettingsRegistry.h>
 #include <AzCore/Settings/SettingsRegistryVisitorUtils.h>
 #include <AzCore/StringFunc/StringFunc.h>
+#include <AzCore/std/containers/unordered_map.h>
+#include <AzCore/std/containers/list.h>
 
 
 namespace AzFramework
 {
     inline constexpr const char* QualitySettingsGroupsRootKey = "/O3DE/Quality/Groups";
     inline constexpr const char* QualitySettingsDefaultGroupKey = "/O3DE/Quality/DefaultGroup";
+    inline constexpr const char* QualitySettingsDevicesRootKey = "/O3DE/Quality/Devices";
+    inline constexpr const char* QualitySettingsDevicesRulesResolutionKey = "/O3DE/Quality/DeviceRulesResolution";
 
     // constructor and destructor defined here to prevent compiler errors
     // if default constructor/destructor is defined in header because of
@@ -28,12 +33,14 @@ namespace AzFramework
     QualitySystemComponent::QualitySystemComponent() = default;
     QualitySystemComponent::~QualitySystemComponent() = default;
 
+    AZ_ENUM_DEFINE_REFLECT_UTILITIES(DeviceRuleResolution);
     AZ_ENUM_DEFINE_REFLECT_UTILITIES(QualityLevel);
 
     void QualitySystemComponent::Reflect(AZ::ReflectContext* context)
     {
         if (AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
+            DeviceRuleResolutionReflect(*serializeContext);
             QualityLevelReflect(*serializeContext);
 
             serializeContext->Class<QualitySystemComponent, AZ::Component>();
@@ -83,6 +90,260 @@ namespace AzFramework
         {
             console->PerformCommand(AZStd::string_view(m_defaultGroupName),
                 { AZ::ConsoleTypeHelpers::ToString(qualityLevel) }, AZ::ConsoleSilentMode::Silent);
+        }
+
+        // evaluate device rules on demand so device attributes and rules can be added
+        // at runtime if needed
+        EvaluateDeviceRules();
+    }
+
+    namespace Internal
+    {
+        bool HasMatchingDeviceAttributeRule(DeviceAttributeRegistrarInterface* deviceRegistrar, AZ::SettingsRegistryInterface* registry, AZStd::string_view jsonPath)
+        {
+            bool hasMatchingRule = false;
+
+            auto callback = [&](const AZ::SettingsRegistryInterface::VisitArgs& visitArgs)
+            {
+                if (visitArgs.m_type != AZ::SettingsRegistryInterface::Type::String)
+                {
+                    // when Lua entries are supported, object entries will also be supported
+                    // but for now only strings are supported
+                    AZ_Warning(
+                        "QualitySystemComponent",
+                        false,
+                        "Skipping device attribute rule entry '%.*s' that is not a string.",
+                        AZ_STRING_ARG(visitArgs.m_fieldName));
+                    return AZ::SettingsRegistryInterface::VisitResponse::Skip;
+                }
+
+                // find the device attribute with this name and evaluate
+                if (auto device = deviceRegistrar->FindDeviceAttribute(visitArgs.m_fieldName); device != nullptr)
+                {
+                    AZ::SettingsRegistryInterface::FixedValueString rule;
+                    if (registry->Get(rule, visitArgs.m_jsonKeyPath))
+                    {
+                        hasMatchingRule = device->Evaluate(rule);
+
+                        // in order for a rule to apply, all device attribute rules must evaluate true
+                        if (!hasMatchingRule)
+                        {
+                            return AZ::SettingsRegistryInterface::VisitResponse::Done;
+                        }
+                    }
+                }
+
+                return AZ::SettingsRegistryInterface::VisitResponse::Continue;
+            };
+
+            AZ::SettingsRegistryVisitorUtils::VisitObject(*registry, callback, jsonPath);
+
+            return hasMatchingRule;
+        }
+
+        bool HasMatchingRule(DeviceAttributeRegistrarInterface* deviceRegistrar, AZ::SettingsRegistryInterface* registry, AZStd::string_view jsonPath)
+        {
+            bool hasMatchingRule = false;
+
+            auto callback = [&](const AZ::SettingsRegistryInterface::VisitArgs& visitArgs)
+            {
+                if (visitArgs.m_type != AZ::SettingsRegistryInterface::Type::Object)
+                {
+                    AZ_Warning(
+                        "QualitySystemComponent",
+                        false,
+                        "Skipping device rules entry '%.*s' that is not an object type.",
+                        AZ_STRING_ARG(visitArgs.m_fieldName));
+                    return AZ::SettingsRegistryInterface::VisitResponse::Skip;
+                }
+
+                if (HasMatchingDeviceAttributeRule(deviceRegistrar, registry, visitArgs.m_jsonKeyPath))
+                {
+                    // only one rule has to match
+                    hasMatchingRule = true;
+                    return AZ::SettingsRegistryInterface::VisitResponse::Done;
+                }
+
+                return AZ::SettingsRegistryInterface::VisitResponse::Continue;
+            };
+
+            AZ::SettingsRegistryVisitorUtils::VisitObject(*registry, callback, jsonPath);
+
+            return hasMatchingRule;
+        }
+
+        //! Stores the value for a console variable setting found in a matching device rule 
+        //! DeviceRuleResolution will be used to ensure only one console setting value is
+        //! actually executed after all rules have been evaluated.
+        struct RuleSetting
+        {
+            AZStd::string m_setting;
+            AZStd::string m_value;
+        };
+
+        // order matters with rules, the user may choose to use the first matching rule or the last (default)
+        // a list is used to maintain the order in which settings will be applied and a map is used to quickly
+        // check if settings are in the list and retrieve an iterator to the setting within the list
+        using RuleSettingList = AZStd::list<RuleSetting>;
+        using RuleIteratorMap = AZStd::unordered_map<AZStd::string, RuleSettingList::iterator>;
+
+        void UpdateRuleSettings(AZ::SettingsRegistryInterface* registry, RuleSettingList& settingsList, RuleIteratorMap& settingsMap, AZStd::string_view jsonPath, DeviceRuleResolution ruleResolution )
+        {
+            using Type = AZ::SettingsRegistryInterface::Type;
+            auto callback = [&](const AZ::SettingsRegistryInterface::VisitArgs& visitArgs)
+            {
+                // has another rule provided a value for this setting already?
+                auto iter = settingsMap.find(visitArgs.m_fieldName);
+                if (iter != settingsMap.end() && ruleResolution == DeviceRuleResolution::First)
+                {
+                    // when using "First" we ignore duplicate setting entries 
+                    return AZ::SettingsRegistryInterface::VisitResponse::Skip;
+                }
+
+                // convert the value to a string to pass to console for execution
+                AZStd::string stringValue;
+                switch (visitArgs.m_type)
+                {
+                case Type::FloatingPoint:
+                    if (double value; registry->Get(value, visitArgs.m_jsonKeyPath))
+                    {
+                        // handle Min/Max rule resolution for numbers
+                        if (iter != settingsMap.end() && ruleResolution != DeviceRuleResolution::Last)
+                        {
+                            double currentValue = 0;
+
+                            // When the user specifies they want to use the "Min" rule resolution
+                            // they want to apply the setting with the lowest value so we check if the
+                            // current value we have for a settings is already equal to or lower than the
+                            // new value, and if it is we skip this value - this is useful
+                            // when you want to take a conservative approach to apply settings
+                            // that should definitely work on a device.
+                            // Conversely, when "Max" rule resolution is selected, we want the highest
+                            // setting values so we skip any values that are not greater than the
+                            // current setting value.
+                            AZ::ConsoleTypeHelpers::StringToValue(currentValue, iter->second->m_value);
+                            if ((ruleResolution == DeviceRuleResolution::Min && currentValue <= value) ||
+                                (ruleResolution == DeviceRuleResolution::Max && currentValue >= value))
+                            {
+                                return AZ::SettingsRegistryInterface::VisitResponse::Skip;
+                            }
+                        }
+                        stringValue = AZ::ConsoleTypeHelpers::ToString(value);
+                    }
+                    break;
+                case Type::Boolean:
+                    if (bool value; registry->Get(value, visitArgs.m_jsonKeyPath))
+                    {
+                        stringValue = AZ::ConsoleTypeHelpers::ToString(value);
+                    }
+                    break;
+                case Type::Integer:
+                    if (AZ::s64 value; registry->Get(value, visitArgs.m_jsonKeyPath))
+                    {
+                        if (iter != settingsMap.end() && ruleResolution != DeviceRuleResolution::Last)
+                        {
+                            // see the comments above regarding "Min" and "Max" rule resolution,
+                            // we're following the same logic here 
+                            AZ::s64 currentValue = 0;
+                            AZ::ConsoleTypeHelpers::StringToValue(currentValue, iter->second->m_value);
+                            if ((ruleResolution == DeviceRuleResolution::Min && currentValue <= value) ||
+                                (ruleResolution == DeviceRuleResolution::Max && currentValue >= value))
+                            {
+                                return AZ::SettingsRegistryInterface::VisitResponse::Skip;
+                            }
+                        }
+                        stringValue = AZ::ConsoleTypeHelpers::ToString(value);
+                    }
+                    break;
+                case Type::String:
+                    {
+                        registry->Get(stringValue, visitArgs.m_jsonKeyPath);
+                    }
+                    break;
+                default:
+                    {
+                        AZ_Warning(
+                            "QualitySystemComponent",
+                            false,
+                            "Skipping settings entry '%.*s' that is not a string, number or bool type.",
+                            AZ_STRING_ARG(visitArgs.m_fieldName));
+                        return AZ::SettingsRegistryInterface::VisitResponse::Skip;
+                    }
+                }
+
+                // if this setting already exists then we are replacing the existing setting value 
+                // and should remove the old one from the ordered settings list
+                if (iter != settingsMap.end())
+                {
+                    settingsList.erase(iter->second);
+                }
+
+                // add the setting to the back of the list and update/store
+                // a mapping of "setting" -> list iterator in the settings map
+                settingsMap[visitArgs.m_fieldName] = settingsList.emplace(settingsList.end(),
+                    RuleSetting{ AZStd::string(visitArgs.m_fieldName), stringValue.c_str() });
+
+                return AZ::SettingsRegistryInterface::VisitResponse::Continue;
+            };
+
+            AZ::SettingsRegistryVisitorUtils::VisitObject(*registry, callback, jsonPath);
+        }
+    }
+
+    void QualitySystemComponent::EvaluateDeviceRules()
+    {
+        using Type = AZ::SettingsRegistryInterface::Type;
+        using VisitArgs = AZ::SettingsRegistryInterface::VisitArgs;
+        using VisitResponse = AZ::SettingsRegistryInterface::VisitResponse;
+        using FixedValueString = AZ::SettingsRegistryInterface::FixedValueString;
+
+        auto registry = AZ::SettingsRegistry::Get();
+        auto deviceRegistrar = DeviceAttributeRegistrar::Get();
+        auto console = AZ::Interface<AZ::IConsole>::Get();
+
+        // query the settings registry for the rule resolution setting here
+        // in case the value has changed since the last time device rules were evaluated
+        DeviceRuleResolution ruleResolution = DeviceRuleResolution::Last;
+        if (AZStd::string ruleValue; registry->Get(ruleValue, QualitySettingsDevicesRulesResolutionKey))
+        {
+            AZ::ConsoleTypeHelpers::StringToValue(ruleResolution, ruleValue);
+        }
+
+        Internal::RuleSettingList ruleSettings;
+        Internal::RuleIteratorMap ruleIterators;
+
+        // walk the devices in the settings registry and evaluate their rules 
+        auto callback = [&](const VisitArgs& visitArgs)
+        {
+            if (visitArgs.m_type != Type::Object)
+            {
+                AZ_Warning(
+                    "QualitySystemComponent",
+                    false,
+                    "Skipping device group entry '%.*s' that is not an object type.",
+                    AZ_STRING_ARG(visitArgs.m_fieldName));
+                return VisitResponse::Skip;
+            }
+
+            // iterate over all the device rules and see if any evaluate to true 
+            const auto rulesPath = FixedValueString(visitArgs.m_jsonKeyPath) + "/Rules";
+            if (Internal::HasMatchingRule(deviceRegistrar, registry, rulesPath))
+            {
+                // add all the valid settings found to the list of rule settings
+                const auto settingsPath = FixedValueString(visitArgs.m_jsonKeyPath) + "/Settings";
+                Internal::UpdateRuleSettings(registry, ruleSettings, ruleIterators, settingsPath, ruleResolution);
+            }
+
+            return VisitResponse::Continue;
+        };
+
+        AZ::SettingsRegistryVisitorUtils::VisitObject(*registry, callback, QualitySettingsDevicesRootKey);
+
+        // go through rule settings list and apply them in order
+        for (auto entry : ruleSettings)
+        {
+            console->PerformCommand(AZStd::string_view(entry.m_setting),
+                { entry.m_value }, AZ::ConsoleSilentMode::Silent);
         }
     }
 

--- a/Code/Framework/AzFramework/AzFramework/Quality/QualitySystemComponent.h
+++ b/Code/Framework/AzFramework/AzFramework/Quality/QualitySystemComponent.h
@@ -43,6 +43,7 @@ namespace AzFramework
         void LoadDefaultQualityGroup(QualityLevel qualityLevel = QualityLevel::LevelFromDeviceRules) override;
 
     private:
+        void EvaluateDeviceRules();
         void RegisterCvars();
 
         AZStd::string m_defaultGroupName;

--- a/Code/Framework/AzFramework/AzFramework/azframework_files.cmake
+++ b/Code/Framework/AzFramework/AzFramework/azframework_files.cmake
@@ -78,6 +78,13 @@ set(FILES
     Asset/Benchmark/BenchmarkSettingsAsset.h
     CommandLine/CommandLine.h
     CommandLine/CommandRegistrationBus.h
+    Device/DeviceAttributeDeviceModel.cpp
+    Device/DeviceAttributeDeviceModel.h
+    Device/DeviceAttributeInterface.h
+    Device/DeviceAttributeRAM.cpp
+    Device/DeviceAttributeRAM.h
+    Device/DeviceAttributesSystemComponent.cpp
+    Device/DeviceAttributesSystemComponent.h
     Viewport/ViewportBus.h
     Viewport/ViewportBus.cpp
     Viewport/ViewportColors.h

--- a/Code/Framework/AzFramework/Platform/Android/AzFramework/Device/DeviceAttributesCommon_Android.cpp
+++ b/Code/Framework/AzFramework/Platform/Android/AzFramework/Device/DeviceAttributesCommon_Android.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Android/JNI/JNI.h>
+#include <AzCore/Android/JNI/Object.h>
+#include <AzFramework/Device/DeviceAttributeDeviceModel.h>
+#include <AzFramework/Device/DeviceAttributeRAM.h>
+
+namespace AzFramework
+{
+    DeviceAttributeDeviceModel::DeviceAttributeDeviceModel()
+    {
+        static constexpr const char* JavaFieldName = "MODEL";
+        AZ::Android::JNI::Object obj("android/os/Build");
+        obj.RegisterStaticField(JavaFieldName, "Ljava/lang/String;");
+        m_value = obj.GetStaticStringField(JavaFieldName);
+    }
+
+    DeviceAttributeRAM::DeviceAttributeRAM()
+    {
+        static constexpr const char* JavaFuntionNameGetDeviceRamInGB = "GetDeviceRamInGB";
+        AZ::Android::JNI::Object obj("com/amazon/lumberyard/AndroidDeviceManager");
+        obj.RegisterStaticMethod(JavaFuntionNameGetDeviceRamInGB, "()F");
+        m_valueInGiB = obj.InvokeStaticFloatMethod(JavaFuntionNameGetDeviceRamInGB);
+    }
+} // AzFramework
+

--- a/Code/Framework/AzFramework/Platform/Android/AzFramework/Device/DeviceAttributesCommon_Android.cpp
+++ b/Code/Framework/AzFramework/Platform/Android/AzFramework/Device/DeviceAttributesCommon_Android.cpp
@@ -8,6 +8,7 @@
 
 #include <AzCore/Android/JNI/JNI.h>
 #include <AzCore/Android/JNI/Object.h>
+#include <AzCore/Console/ConsoleTypeHelpers.h>
 #include <AzFramework/Device/DeviceAttributeDeviceModel.h>
 #include <AzFramework/Device/DeviceAttributeRAM.h>
 
@@ -27,6 +28,7 @@ namespace AzFramework
         AZ::Android::JNI::Object obj("com/amazon/lumberyard/AndroidDeviceManager");
         obj.RegisterStaticMethod(JavaFuntionNameGetDeviceRamInGB, "()F");
         m_valueInGiB = obj.InvokeStaticFloatMethod(JavaFuntionNameGetDeviceRamInGB);
+        m_value = AZ::ConsoleTypeHelpers::ValueToString(m_valueInGiB);
     }
 } // AzFramework
 

--- a/Code/Framework/AzFramework/Platform/Android/platform_android_files.cmake
+++ b/Code/Framework/AzFramework/Platform/Android/platform_android_files.cmake
@@ -12,6 +12,7 @@ set(FILES
     AzFramework/API/ApplicationAPI_Platform.h
     AzFramework/API/ApplicationAPI_Android.h
     AzFramework/Application/Application_Android.cpp
+    AzFramework/Device/DeviceAttributesCommon_Android.cpp
     ../Common/Unimplemented/AzFramework/Asset/AssetSystemComponentHelper_Unimplemented.cpp
     AzFramework/IO/LocalFileIO_Android.cpp
     ../Common/Unimplemented/AzFramework/StreamingInstall/StreamingInstall_Unimplemented.cpp

--- a/Code/Framework/AzFramework/Platform/Common/Apple/AzFramework/Device/DeviceAttributesCommon_Apple.mm
+++ b/Code/Framework/AzFramework/Platform/Common/Apple/AzFramework/Device/DeviceAttributesCommon_Apple.mm
@@ -7,6 +7,7 @@
  */
 
 #include <sys/utsname.h>
+#include <AzCore/Console/ConsoleTypeHelpers.h>
 #include <AzFramework/Device/DeviceAttributeDeviceModel.h>
 #include <AzFramework/Device/DeviceAttributeRAM.h>
 #include <Foundation/NSProcessInfo.h>
@@ -30,5 +31,6 @@ namespace AzFramework
         constexpr double BytestoGiB = 1024.0 * 1024.0 * 1024.0;
         auto memInBytes = [[NSProcessInfo processInfo] physicalMemory];
         m_valueInGiB = aznumeric_cast<float>(static_cast<double>(memInBytes) / BytestoGiB);
+        m_value = AZ::ConsoleTypeHelpers::ValueToString(m_valueInGiB);
     }
 } // AzFramework

--- a/Code/Framework/AzFramework/Platform/Common/Apple/AzFramework/Device/DeviceAttributesCommon_Apple.mm
+++ b/Code/Framework/AzFramework/Platform/Common/Apple/AzFramework/Device/DeviceAttributesCommon_Apple.mm
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+*
+ */
+
+#include <sys/utsname.h>
+#include <AzFramework/Device/DeviceAttributeDeviceModel.h>
+#include <AzFramework/Device/DeviceAttributeRAM.h>
+#include <Foundation/NSProcessInfo.h>
+
+
+namespace AzFramework
+{
+    DeviceAttributeDeviceModel::DeviceAttributeDeviceModel()
+    {
+        utsname systemInfo;
+        if (uname(&systemInfo) != -1)
+        {
+            m_value = systemInfo.machine;
+        }
+    }
+
+    DeviceAttributeRAM::DeviceAttributeRAM()
+    {
+        // the actual RAM amount available to the OS may be less
+        // that the physical RAM available, but is not readily available
+        constexpr double BytestoGiB = 1024.0 * 1024.0 * 1024.0;
+        auto memInBytes = [[NSProcessInfo processInfo] physicalMemory];
+        m_valueInGiB = aznumeric_cast<float>(static_cast<double>(memInBytes) / BytestoGiB);
+    }
+} // AzFramework

--- a/Code/Framework/AzFramework/Platform/Common/UnixLike/AzFramework/Device/DeviceAttributesCommon_UnixLike.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/UnixLike/AzFramework/Device/DeviceAttributesCommon_UnixLike.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+*
+ */
+
+#include <sys/utsname.h>
+#include <AzCore/std/utility/charconv.h>
+#include <AzCore/std/string/string_view.h>
+#include <AzCore/std/string/conversions.h>
+#include <AzFramework/Device/DeviceAttributeDeviceModel.h>
+#include <AzFramework/Device/DeviceAttributeRAM.h>
+
+namespace AzFramework
+{
+    DeviceAttributeDeviceModel::DeviceAttributeDeviceModel()
+    {
+        utsname systemInfo;
+        if (uname(&systemInfo) != -1)
+        {
+            m_value = systemInfo.machine;
+        }
+    }
+
+    DeviceAttributeRAM::DeviceAttributeRAM()
+    {
+        FILE* f;
+        azfopen(&f, "/proc/meminfo", "r");
+        if (f)
+        {
+            char buffer[256] = { 0 };
+            AZ::u64 memTotalKiB = 0;
+            constexpr AZStd::string_view MemTotalKey = "MemTotal:";
+            while (fgets(buffer, sizeof(buffer), f))
+            {
+                const AZStd::string_view bufferView(buffer);
+                if(size_t offset = bufferView.find(MemTotalKey); offset != AZStd::string_view::npos)
+                {
+                    // skip spaces because from_chars does not support non numeric string prefixes 
+                    // non-numeric string postfixes are OK
+                    auto iter = bufferView.begin() + MemTotalKey.size();
+                    while(iter != bufferView.end() && AZStd::isspace(*iter))
+                    {
+                        iter++;
+                    }
+                    AZStd::from_chars_result result = AZStd::from_chars(iter, bufferView.end(), memTotalKiB);
+                    if(result.ec == AZStd::errc{})
+                    {
+                        constexpr double KiBtoGiB = 1024.f * 1024.f;
+                        m_valueInGiB = aznumeric_cast<float>(static_cast<double>(memTotalKiB) / KiBtoGiB);
+                    }
+                    break;
+                }
+            }
+            fclose(f);
+        }
+    }
+} // AzFramework
+

--- a/Code/Framework/AzFramework/Platform/Common/UnixLike/AzFramework/Device/DeviceAttributesCommon_UnixLike.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/UnixLike/AzFramework/Device/DeviceAttributesCommon_UnixLike.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <sys/utsname.h>
+#include <AzCore/Console/ConsoleTypeHelpers.h>
 #include <AzCore/std/utility/charconv.h>
 #include <AzCore/std/string/string_view.h>
 #include <AzCore/std/string/conversions.h>
@@ -50,6 +51,7 @@ namespace AzFramework
                     {
                         constexpr double KiBtoGiB = 1024.f * 1024.f;
                         m_valueInGiB = aznumeric_cast<float>(static_cast<double>(memTotalKiB) / KiBtoGiB);
+                        m_value = AZ::ConsoleTypeHelpers::ValueToString(m_valueInGiB);
                     }
                     break;
                 }

--- a/Code/Framework/AzFramework/Platform/Linux/platform_linux_files.cmake
+++ b/Code/Framework/AzFramework/Platform/Linux/platform_linux_files.cmake
@@ -17,6 +17,7 @@ set(FILES
     AzFramework/Process/ProcessWatcher_Linux.cpp
     AzFramework/Process/ProcessCommon.h
     AzFramework/Process/ProcessCommunicator_Linux.cpp
+    ../Common/UnixLike/AzFramework/Device/DeviceAttributesCommon_UnixLike.cpp
     ../Common/UnixLike/AzFramework/IO/LocalFileIO_UnixLike.cpp
     ../Common/Unimplemented/AzFramework/StreamingInstall/StreamingInstall_Unimplemented.cpp
     ../Common/Default/AzFramework/TargetManagement/TargetManagementComponent_Default.cpp

--- a/Code/Framework/AzFramework/Platform/Mac/platform_mac_files.cmake
+++ b/Code/Framework/AzFramework/Platform/Mac/platform_mac_files.cmake
@@ -17,6 +17,7 @@ set(FILES
     AzFramework/Process/ProcessWatcher_Mac.cpp
     AzFramework/Process/ProcessCommon.h
     AzFramework/Process/ProcessCommunicator_Mac.cpp
+    ../Common/Apple/AzFramework/Device/DeviceAttributesCommon_Apple.mm
     ../Common/UnixLike/AzFramework/IO/LocalFileIO_UnixLike.cpp
     ../Common/Unimplemented/AzFramework/StreamingInstall/StreamingInstall_Unimplemented.cpp
     AzFramework/TargetManagement/TargetManagementComponent_Mac.cpp

--- a/Code/Framework/AzFramework/Platform/Windows/AzFramework/Device/DeviceAttributesCommon_Win.cpp
+++ b/Code/Framework/AzFramework/Platform/Windows/AzFramework/Device/DeviceAttributesCommon_Win.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/PlatformIncl.h>
+#include <AzCore/std/string/conversions.h>
+#include <AzFramework/Device/DeviceAttributeDeviceModel.h>
+#include <AzFramework/Device/DeviceAttributeRAM.h>
+
+#include <Wbemidl.h>
+#pragma comment(lib, "wbemuuid.lib")
+
+namespace AzFramework
+{
+    AZStd::string QueryWMIProperty(IWbemServices* services, AZStd::string_view propertyName)
+    {
+        AZStd::string result;
+        IEnumWbemClassObject* classObjectEnumerator = nullptr;
+
+        // prepare a query to obtain the property value from Win32_ComputerSystem
+        // https://learn.microsoft.com/en-us/windows/win32/cimwin32prov/win32-computersystem
+        auto propertyQuery = AZStd::wstring::format(TEXT("SELECT %.*S FROM Win32_ComputerSystem"),
+            AZ_STRING_ARG(propertyName));
+
+        // ExecQuery expects BSTR types
+        auto query = SysAllocString(propertyQuery.c_str());
+        auto language = SysAllocString(TEXT("WQL"));
+        auto hResult = services->ExecQuery(language, query,
+            WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY,
+            nullptr,
+            &classObjectEnumerator);
+        SysFreeString(language);
+        SysFreeString(query);
+
+        if (!FAILED(hResult))
+        {
+            // prepare to enumerate the object, blocking until the objects are ready
+            IWbemClassObject* classObject = nullptr;
+            ULONG numResults = 0;
+            hResult = classObjectEnumerator->Next(WBEM_INFINITE, 1, &classObject, &numResults);
+
+            if (!FAILED(hResult) && classObject && numResults != 0)
+            {
+                // get the class object's property value
+                VARIANT propertyValue;
+                AZStd::wstring classObjectPropertyName;
+                AZStd::to_wstring(classObjectPropertyName, propertyName);
+                if (!FAILED(classObject->Get(classObjectPropertyName.c_str(), 0, &propertyValue, 0, 0)))
+                {
+                    if (propertyValue.vt != VT_NULL &&
+                        propertyValue.vt != VT_EMPTY &&
+                        !(propertyValue.vt & VT_ARRAY))
+                    {
+                        AZStd::to_string(result, propertyValue.bstrVal);
+                    }
+                }
+                VariantClear(&propertyValue);
+            }
+
+            if (classObject)
+            {
+                classObject->Release();
+            }
+        }
+
+        if (classObjectEnumerator)
+        {
+            classObjectEnumerator->Release();
+        }
+
+        return result;
+    }
+
+    AZStd::string GetWMIPropertyValue(AZStd::string_view propertyName)
+    {
+        AZStd::string propertyValue;
+
+        // NOTE: this query functionality is not optimized for querying multiple values
+        // If it becomes necessary to add more device attributes that must also query WMI
+        // an optimization can be to query all the WMI properties for all attributes in a
+        // single query, store in a static cache so they are available as the other device
+        // attributes are created so they can pull the values from the cache.
+
+        CoInitialize(nullptr);
+
+        // Obtain the initial locator to Windows Management on a particular host computer.
+        IWbemLocator* locator = nullptr;
+        auto hResult = CoCreateInstance(CLSID_WbemLocator, 0, CLSCTX_INPROC_SERVER, IID_IWbemLocator, (LPVOID*)&locator);
+        if (!FAILED(hResult))
+        {
+            // Connect to the root\cimv2 namespace with the current user and obtain pointer pSvc to make IWbemServices calls.
+            IWbemServices* services = nullptr;
+            auto serverPath = SysAllocString(TEXT(R"(ROOT\CIMV2)"));
+            hResult = locator->ConnectServer(serverPath, nullptr, nullptr, 0, NULL, 0, 0, &services);
+            SysFreeString(serverPath);
+
+            if (!FAILED(hResult))
+            {
+                // Set the IWbemServices proxy so that impersonation of the user (client) occurs.
+                hResult = CoSetProxyBlanket( services,
+                    RPC_C_AUTHN_WINNT,
+                    RPC_C_AUTHZ_NONE,
+                    nullptr,
+                    RPC_C_AUTHN_LEVEL_CALL,
+                    RPC_C_IMP_LEVEL_IMPERSONATE,
+                    nullptr,
+                    EOAC_NONE);
+
+                if (!FAILED(hResult))
+                {
+                    propertyValue = QueryWMIProperty(services, propertyName);
+                }
+            }
+
+            if (services)
+            {
+                services->Release();
+            }
+        }
+
+        if (locator)
+        {
+            locator->Release();
+        }
+
+        CoUninitialize();
+
+        return propertyValue;
+    }
+
+    DeviceAttributeDeviceModel::DeviceAttributeDeviceModel()
+    {
+        // Use WMI because the registry HARDWARE\DESCRIPTION\System\BIOS\SystemProductName is not
+        // always available or non-empty and the name does not match what WMI returns for the Model
+        m_value = GetWMIPropertyValue("Model");
+    }
+
+    DeviceAttributeRAM::DeviceAttributeRAM()
+    {
+        HMODULE kernel32Handle = ::GetModuleHandleW(L"Kernel32.dll");
+        if (kernel32Handle)
+        {
+            using Func = BOOL(WINAPI*)(_Out_ LPMEMORYSTATUSEX lpMemStatus);
+            auto globalMemoryStatusExFunc = reinterpret_cast<Func>(::GetProcAddress(kernel32Handle, "GlobalMemoryStatusEx"));
+            if (globalMemoryStatusExFunc)
+            {
+                // OS RAM amount is returned in Bytes
+                constexpr double bytesToGiB = 1024.0 * 1024.0 * 1024.0;
+                MEMORYSTATUSEX memStats;
+                memStats.dwLength = sizeof(memStats);
+                if (globalMemoryStatusExFunc(&memStats))
+                {
+                    m_valueInGiB = aznumeric_cast<float>(static_cast<double>(memStats.ullTotalPhys) / bytesToGiB);
+                }
+            }
+
+            // fall back to oldest available method 
+            if (m_valueInGiB == 0)
+            {
+                // OS RAM amount is returned in Bytes
+                constexpr double bytesToGiB = 1024.0 * 1024.0 * 1024.0;
+                MEMORYSTATUS memStats;
+                memStats.dwLength = sizeof(memStats);
+                ::GlobalMemoryStatus(&memStats);
+                m_valueInGiB = aznumeric_cast<float>(static_cast<double>(memStats.dwTotalPhys) / bytesToGiB);
+            }
+        }
+    }
+} // AzFramework
+

--- a/Code/Framework/AzFramework/Platform/Windows/AzFramework/Device/DeviceAttributesCommon_Win.cpp
+++ b/Code/Framework/AzFramework/Platform/Windows/AzFramework/Device/DeviceAttributesCommon_Win.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AzCore/PlatformIncl.h>
+#include <AzCore/Console/ConsoleTypeHelpers.h>
 #include <AzCore/std/string/conversions.h>
 #include <AzFramework/Device/DeviceAttributeDeviceModel.h>
 #include <AzFramework/Device/DeviceAttributeRAM.h>
@@ -155,6 +156,7 @@ namespace AzFramework
                 if (globalMemoryStatusExFunc(&memStats))
                 {
                     m_valueInGiB = aznumeric_cast<float>(static_cast<double>(memStats.ullTotalPhys) / bytesToGiB);
+                    m_value = AZ::ConsoleTypeHelpers::ValueToString(m_valueInGiB);
                 }
             }
 
@@ -167,6 +169,7 @@ namespace AzFramework
                 memStats.dwLength = sizeof(memStats);
                 ::GlobalMemoryStatus(&memStats);
                 m_valueInGiB = aznumeric_cast<float>(static_cast<double>(memStats.dwTotalPhys) / bytesToGiB);
+                m_value = AZ::ConsoleTypeHelpers::ValueToString(m_valueInGiB);
             }
         }
     }

--- a/Code/Framework/AzFramework/Platform/Windows/platform_windows_files.cmake
+++ b/Code/Framework/AzFramework/Platform/Windows/platform_windows_files.cmake
@@ -13,6 +13,7 @@ set(FILES
     AzFramework/API/ApplicationAPI_Windows.h
     AzFramework/Application/Application_Windows.cpp
     AzFramework/Asset/AssetSystemComponentHelper_Windows.cpp
+    AzFramework/Device/DeviceAttributesCommon_Win.cpp
     AzFramework/Process/ProcessWatcher_Win.cpp
     AzFramework/Process/ProcessCommon.h
     AzFramework/Process/ProcessCommunicator_Win.cpp

--- a/Code/Framework/AzFramework/Platform/iOS/platform_ios_files.cmake
+++ b/Code/Framework/AzFramework/Platform/iOS/platform_ios_files.cmake
@@ -12,6 +12,7 @@ set(FILES
     AzFramework/API/ApplicationAPI_Platform.h
     AzFramework/API/ApplicationAPI_iOS.h
     AzFramework/Application/Application_iOS.mm
+    ../Common/Apple/AzFramework/Device/DeviceAttributesCommon_Apple.mm
     ../Common/Unimplemented/AzFramework/Asset/AssetSystemComponentHelper_Unimplemented.cpp
     ../Common/UnixLike/AzFramework/IO/LocalFileIO_UnixLike.cpp
     ../Common/Unimplemented/AzFramework/StreamingInstall/StreamingInstall_Unimplemented.cpp

--- a/Code/Framework/AzFramework/Tests/DeviceAttribute/TestDeviceAttribute.cpp
+++ b/Code/Framework/AzFramework/Tests/DeviceAttribute/TestDeviceAttribute.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "TestDeviceAttribute.h"
+
+namespace UnitTest
+{
+    TestDeviceAttribute::TestDeviceAttribute(AZStd::string_view name, AZStd::string_view description, AZStd::any value, EvalFunc eval)
+        : m_name(name)
+        , m_description(description)
+        , m_eval(eval)
+        , m_value(value)
+    {
+    }
+
+    AZStd::string_view TestDeviceAttribute::GetName() const
+    {
+        return m_name;
+    }
+
+    AZStd::string_view TestDeviceAttribute::GetDescription() const
+    {
+        return m_description;
+    }
+
+    bool TestDeviceAttribute::Evaluate(AZStd::string_view rule) const
+    {
+        return m_eval(rule);
+    }
+
+    AZStd::any TestDeviceAttribute::GetValue() const
+    {
+        return m_value; 
+    }
+
+} // namespace UnitTest
+

--- a/Code/Framework/AzFramework/Tests/DeviceAttribute/TestDeviceAttribute.h
+++ b/Code/Framework/AzFramework/Tests/DeviceAttribute/TestDeviceAttribute.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzFramework/Device/DeviceAttributesSystemComponent.h>
+
+namespace UnitTest
+{
+    class TestDeviceAttribute
+        : public AzFramework::DeviceAttribute
+    {
+    public:
+        using EvalFunc = AZStd::function<bool(AZStd::string_view)>;
+
+        TestDeviceAttribute(AZStd::string_view name, AZStd::string_view description, AZStd::any value, EvalFunc eval);
+        ~TestDeviceAttribute() = default;
+
+        AZStd::string_view GetName() const override;
+        AZStd::string_view GetDescription() const override;
+        bool Evaluate(AZStd::string_view rule) const override;
+        AZStd::any GetValue() const override;
+
+    private:
+        AZStd::string m_name;
+        AZStd::string m_description;
+        EvalFunc m_eval;
+        AZStd::any m_value;
+    };
+
+} // namespace UnitTest
+

--- a/Code/Framework/AzFramework/Tests/DeviceAttributeSystemComponentTests.cpp
+++ b/Code/Framework/AzFramework/Tests/DeviceAttributeSystemComponentTests.cpp
@@ -15,6 +15,7 @@
 #include <AzCore/Settings/SettingsRegistry.h>
 #include <AzCore/Settings/SettingsRegistryImpl.h>
 #include <AzFramework/Device/DeviceAttributesSystemComponent.h>
+#include "DeviceAttribute/TestDeviceAttribute.h" 
 
 namespace UnitTest
 {
@@ -49,50 +50,6 @@ namespace UnitTest
 
         AZStd::unique_ptr<AzFramework::DeviceAttributesSystemComponent> m_deviceAttributesSystemComponent;
         AZStd::unique_ptr<AZ::SettingsRegistryInterface> m_settingsRegistry;
-    };
-
-    class TestDeviceAttribute
-        : public AzFramework::DeviceAttribute
-    {
-    public:
-        using EvalFunc = AZStd::function<bool(AZStd::string_view)>;
-
-        TestDeviceAttribute(AZStd::string_view name, AZStd::string_view description,
-            AZStd::any value, EvalFunc eval)
-            : m_name(name)
-            , m_description(description)
-            , m_eval(eval)
-            , m_value(value)
-        {
-
-        }
-        ~TestDeviceAttribute() = default;
-
-        AZStd::string_view GetName() const override
-        {
-            return m_name;
-        }
-
-        AZStd::string_view GetDescription() const override
-        {
-            return m_description;
-        }
-
-        bool Evaluate(AZStd::string_view rule) const override
-        {
-            return m_eval(rule);
-        }
-
-        AZStd::any GetValue() const override
-        {
-            return m_value; 
-        }
-
-    private:
-        AZStd::string m_name;
-        AZStd::string m_description;
-        EvalFunc m_eval;
-        AZStd::any m_value;
     };
 
 

--- a/Code/Framework/AzFramework/Tests/DeviceAttributeSystemComponentTests.cpp
+++ b/Code/Framework/AzFramework/Tests/DeviceAttributeSystemComponentTests.cpp
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/UnitTest/TestTypes.h>
+#include <AzCore/std/any.h>
+#include <AzCore/std/smart_ptr/make_shared.h>
+#include <AzCore/std/smart_ptr/shared_ptr.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
+#include <AzCore/std/string/string.h>
+#include <AzCore/Settings/SettingsRegistry.h>
+#include <AzCore/Settings/SettingsRegistryImpl.h>
+#include <AzFramework/Device/DeviceAttributesSystemComponent.h>
+
+namespace UnitTest
+{
+    class DeviceAttributesSystemComponentTestFixture
+        : public LeakDetectionFixture
+    {
+    public:
+        DeviceAttributesSystemComponentTestFixture()
+            : LeakDetectionFixture()
+        {
+        }
+
+    protected:
+        void SetUp() override
+        {
+            m_settingsRegistry = AZStd::make_unique<AZ::SettingsRegistryImpl>();
+            AZ::SettingsRegistry::Register(m_settingsRegistry.get());
+
+            m_deviceAttributesSystemComponent = AZStd::make_unique<AzFramework::DeviceAttributesSystemComponent>();
+            m_deviceAttributesSystemComponent->Activate();
+        }
+
+        void TearDown() override
+        {
+            m_deviceAttributesSystemComponent->Deactivate();
+            m_deviceAttributesSystemComponent.reset();
+
+
+            AZ::SettingsRegistry::Unregister(m_settingsRegistry.get());
+            m_settingsRegistry.reset();
+        }
+
+        AZStd::unique_ptr<AzFramework::DeviceAttributesSystemComponent> m_deviceAttributesSystemComponent;
+        AZStd::unique_ptr<AZ::SettingsRegistryInterface> m_settingsRegistry;
+    };
+
+    class TestDeviceAttribute
+        : public AzFramework::DeviceAttribute
+    {
+    public:
+        using EvalFunc = AZStd::function<bool(AZStd::string_view)>;
+
+        TestDeviceAttribute(AZStd::string_view name, AZStd::string_view description,
+            AZStd::any value, EvalFunc eval)
+            : m_name(name)
+            , m_description(description)
+            , m_eval(eval)
+            , m_value(value)
+        {
+
+        }
+        ~TestDeviceAttribute() = default;
+
+        AZStd::string_view GetName() const override
+        {
+            return m_name;
+        }
+
+        AZStd::string_view GetDescription() const override
+        {
+            return m_description;
+        }
+
+        bool Evaluate(AZStd::string_view rule) const override
+        {
+            return m_eval(rule);
+        }
+
+        AZStd::any GetValue() const override
+        {
+            return m_value; 
+        }
+
+    private:
+        AZStd::string m_name;
+        AZStd::string m_description;
+        EvalFunc m_eval;
+        AZStd::any m_value;
+    };
+
+
+    TEST_F(DeviceAttributesSystemComponentTestFixture, DeviceAttributesSystem_Can_Register_Device_Attributes)
+    {
+        AZStd::string name { "TestAttribute" };
+        AZStd::string description { "Description" };
+        AZStd::string valueString{ "ABC123" };
+        AZStd::any value{ valueString };
+        TestDeviceAttribute::EvalFunc eval = [](AZStd::string_view rule)
+        {
+            // simple string comparison evaluator
+            return rule == "True";
+        };
+        auto deviceAttribute = AZStd::make_shared<TestDeviceAttribute>(name, description, value, eval);
+
+        // when the device attribute registrar exists
+        auto registrar = AzFramework::DeviceAttributeRegistrar::Get();
+        ASSERT_NE(nullptr, registrar);
+
+        // expect a device attribute can be registered
+        EXPECT_TRUE(registrar->RegisterDeviceAttribute(deviceAttribute));
+
+        // expect the registered attribute can be found
+        auto foundAttribute = registrar->FindDeviceAttribute(name);
+        EXPECT_NE(nullptr, foundAttribute);
+        auto foundValue = foundAttribute->GetValue();
+        EXPECT_EQ(azrtti_typeid<AZStd::string>(), foundValue.type());
+        EXPECT_EQ(valueString, AZStd::any_cast<AZStd::string>(foundValue));
+        EXPECT_EQ(description, foundAttribute->GetDescription());
+        EXPECT_EQ(name, foundAttribute->GetName());
+        EXPECT_TRUE(foundAttribute->Evaluate("True"));
+        EXPECT_FALSE(foundAttribute->Evaluate("Not true"));
+
+        // when another device attribute with the same attribute name is registered
+        auto deviceAttributeDuplicate = AZStd::make_shared<TestDeviceAttribute>(name, description, value, eval);
+
+        // expect failure because attribute names must be unique
+        EXPECT_FALSE(registrar->RegisterDeviceAttribute(deviceAttributeDuplicate));
+
+        // expect device attribute can be removed
+        EXPECT_TRUE(registrar->UnregisterDeviceAttribute(deviceAttribute->GetName()));
+
+        // expect the alternate device attribute can be registered now
+        EXPECT_TRUE(registrar->RegisterDeviceAttribute(deviceAttributeDuplicate));
+
+        // expect alternate device attribute can be removed
+        EXPECT_TRUE(registrar->UnregisterDeviceAttribute(deviceAttributeDuplicate->GetName()));
+
+        // expect alternate attribute is not found after removal
+        EXPECT_EQ(nullptr, registrar->FindDeviceAttribute(deviceAttributeDuplicate->GetName()));
+    }
+
+    TEST_F(DeviceAttributesSystemComponentTestFixture, DeviceAttributesSystem_Registers_Common_Device_Attributes)
+    {
+        // when the device attributes system component is activated
+
+        // expect a device attribute registrar exists
+        auto registrar = AzFramework::DeviceAttributeRegistrar::Get();
+        ASSERT_NE(registrar, nullptr);
+
+        // expect common attributes are registered
+        auto deviceModel = registrar->FindDeviceAttribute("DeviceModel");
+        EXPECT_NE(nullptr, deviceModel);
+        auto deviceModelValue = deviceModel->GetValue();
+        ASSERT_TRUE(deviceModelValue.is<AZStd::string>());
+        EXPECT_FALSE(AZStd::any_cast<AZStd::string>(deviceModelValue).empty());
+
+        auto ram = registrar->FindDeviceAttribute("RAM");
+        EXPECT_NE(nullptr, ram);
+        auto ramValue = ram->GetValue();
+        ASSERT_TRUE(ramValue.is<float>());
+        EXPECT_GT(AZStd::any_cast<float>(ramValue), 0);
+    }
+
+} // namespace UnitTest
+

--- a/Code/Framework/AzFramework/Tests/QualitySystemComponentTests.cpp
+++ b/Code/Framework/AzFramework/Tests/QualitySystemComponentTests.cpp
@@ -12,10 +12,12 @@
 #include <AzCore/Settings/SettingsRegistryImpl.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/std/string/regex.h>
 #include <AzCore/UserSettings/UserSettingsComponent.h>
 #include <AzFramework/Application/Application.h>
 #include <AzFramework/Quality/QualitySystemComponent.h>
 #include <AzFramework/Quality/QualityCVarGroup.h>
+#include "DeviceAttribute/TestDeviceAttribute.h" 
 
 namespace UnitTest
 {
@@ -75,11 +77,27 @@ namespace UnitTest
             // shared across the whole engine, if multiple tests are run in parallel, the saving could cause a crash
             // in the unit tests.
             AZ::UserSettingsComponentRequestBus::Broadcast(&AZ::UserSettingsComponentRequests::DisableSaveOnFinalize);
+
+            // Create and register a test device attribute for evaluating rules
+            AZStd::string name { "TestAttribute" };
+            AZStd::string description { "Description" };
+            AZStd::string valueString{ "ValidAttribute" };
+            AZStd::any value{ valueString };
+            TestDeviceAttribute::EvalFunc eval = [valueString](AZStd::string_view rule)
+            {
+                auto regex = AZStd::regex(rule.data(), rule.size());
+                return AZStd::regex_match(valueString, regex);
+            };
+            m_testDeviceAttribute = AZStd::make_shared<TestDeviceAttribute>(AZStd::move(name), AZStd::move(description), AZStd::move(value), AZStd::move(eval));
+            auto registrar = AzFramework::DeviceAttributeRegistrar::Get();
+            ASSERT_NE(nullptr, registrar);
+            EXPECT_TRUE(registrar->RegisterDeviceAttribute(m_testDeviceAttribute));
         }
 
         AZ::IConsole* m_console;
         AZStd::unique_ptr<AzFramework::Application> m_application;
         AZStd::unique_ptr<AZ::SettingsRegistryInterface> m_settingsRegistry;
+        AZStd::shared_ptr<TestDeviceAttribute> m_testDeviceAttribute;
     };
 
     TEST_F(QualitySystemComponentTestFixture, QualitySystem_Registers_Group_CVars)
@@ -124,7 +142,7 @@ namespace UnitTest
     AZ_CVAR(int32_t, a_setting, 0, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Example integer setting 1");
     AZ_CVAR(AZ::CVarFixedString, b_setting, "default", nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Example string setting 2");
     AZ_CVAR(int32_t, c_setting, -1, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Example integer setting 3");
-    AZ_CVAR(int32_t, d_setting, -2, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Example integer setting 4");
+    AZ_CVAR(double, d_setting, -2.0, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Example double setting");
 
     TEST_F(QualitySystemComponentTestFixture, QualitySystem_Loads_Group_Level)
     {
@@ -151,7 +169,7 @@ namespace UnitTest
                                 "Description": "q_test_sub quality group",
                                 "Settings": {
                                     "c_setting": [123,234],
-                                    "d_setting": [42] // test missing high level setting
+                                    "d_setting": [42.0] // test missing high level setting
                                 }
                             }
                         }
@@ -162,6 +180,7 @@ namespace UnitTest
 
         auto value = AzFramework::QualityLevel::LevelFromDeviceRules;
         int32_t intValue = -42;
+        double doubleValue = -42.0;
         AZ::CVarFixedString stringValue;
 
         // expect the value defaults
@@ -171,8 +190,8 @@ namespace UnitTest
         EXPECT_EQ(stringValue, "default");
         EXPECT_EQ(m_console->GetCvarValue("c_setting", intValue), AZ::GetValueResult::Success);
         EXPECT_EQ(intValue, -1);
-        EXPECT_EQ(m_console->GetCvarValue("d_setting", intValue), AZ::GetValueResult::Success);
-        EXPECT_EQ(intValue, -2);
+        EXPECT_EQ(m_console->GetCvarValue("d_setting", doubleValue), AZ::GetValueResult::Success);
+        EXPECT_EQ(doubleValue, -2.0);
 
         // when the default group is loaded
         AzFramework::QualitySystemEvents::Bus::Broadcast(
@@ -195,8 +214,8 @@ namespace UnitTest
         EXPECT_EQ(m_console->GetCvarValue("c_setting", intValue), AZ::GetValueResult::Success);
         EXPECT_EQ(intValue, 234);
 
-        EXPECT_EQ(m_console->GetCvarValue("d_setting", intValue), AZ::GetValueResult::Success);
-        EXPECT_EQ(intValue, 42);
+        EXPECT_EQ(m_console->GetCvarValue("d_setting", doubleValue), AZ::GetValueResult::Success);
+        EXPECT_EQ(doubleValue, 42.0);
 
         // when the group level 1 is loaded ("medium" which is "high" for q_test_sub)
         m_console->PerformCommand("q_test", { "1" });
@@ -216,8 +235,8 @@ namespace UnitTest
 
         // d_settings doesn't specify a value for "high" so it should use highest available setting
         // which is "low" -> 42
-        EXPECT_EQ(m_console->GetCvarValue("d_setting", intValue), AZ::GetValueResult::Success);
-        EXPECT_EQ(intValue, 42);
+        EXPECT_EQ(m_console->GetCvarValue("d_setting", doubleValue), AZ::GetValueResult::Success);
+        EXPECT_EQ(doubleValue, 42.0);
 
         // when the group level 0 is loaded (low) using mixed-case name 
         m_console->PerformCommand("q_test", { "LoW" });
@@ -235,8 +254,150 @@ namespace UnitTest
         EXPECT_EQ(m_console->GetCvarValue("c_setting", intValue), AZ::GetValueResult::Success);
         EXPECT_EQ(intValue, 123);
 
-        EXPECT_EQ(m_console->GetCvarValue("d_setting", intValue), AZ::GetValueResult::Success);
-        EXPECT_EQ(intValue, 42);
+        EXPECT_EQ(m_console->GetCvarValue("d_setting", doubleValue), AZ::GetValueResult::Success);
+        EXPECT_EQ(doubleValue, 42.0);
     }
+
+    TEST_F(QualitySystemComponentTestFixture, QualitySystem_Evaluates_Device_Rules)
+    {
+        // when the quality system component registers group cvars
+        StartApplicationWithSettings(R"(
+            {
+                "O3DE": {
+                    "Quality": {
+                        "DefaultGroup":"q_test",
+                        "Groups": {
+                            "q_test": {
+                                "Levels": [ "low", "medium", "high", "veryhigh"],
+                                "Default": 2,
+                                "Description": "q_test quality group",
+                                "Settings": {
+                                    "d_setting": [0.0,1.0,4.0,8.0],
+                                    "q_test_sub": [0,1,1,1]
+                                }
+                            },
+                            "q_test_sub": {
+                                "Levels": [ "low", "high" ],
+                                "Default": "DefaultQualityLevel",
+                                "Description": "q_test_sub quality group",
+                                "Settings": {
+                                    "c_setting": [123,234],
+                                    "d_setting": [42.0]
+                                }
+                            }
+                        },
+                        "Devices": {
+                            // settings from these rule sections will be applied
+                            // based on device rule resolution
+                            "Rule Group 1": {
+                                "Rules": {
+                                    "Test Device": { "TestAttribute": "ValidAttribute" }
+                                },
+                                "Settings": {
+                                    "q_test": 1,
+                                    "c_setting": 4,
+                                    "d_setting": 1.0
+                                }
+                            },
+                            "Rule Group 2": {
+                                "Rules": {
+                                    "Test Device": { "TestAttribute": "ValidAttribute" }
+                                },
+                                "Settings": {
+                                    "q_test": 3,
+                                    "c_setting": 1,
+                                    "d_setting": 2.0
+                                }
+                            },
+                            // this group should not match
+                            "Invalid Rule Group": {
+                                "Rules": {
+                                    "Test Device": { "TestAttribute": "InvalidAttribute" }
+                                },
+                                "Settings": {
+                                    "q_test": 0,
+                                    "c_setting": 0,
+                                    "d_setting": 0.0
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            )");
+
+        // when the default group is loaded
+        AzFramework::QualitySystemEvents::Bus::Broadcast(
+            &AzFramework::QualitySystemEvents::LoadDefaultQualityGroup,
+            AzFramework::QualityLevel::LevelFromDeviceRules);
+
+        // expect the values are set based on the device rules and the default resolution order of "Last"
+        auto cvarValue = AzFramework::QualityLevel::LevelFromDeviceRules;
+        EXPECT_EQ(m_console->GetCvarValue("q_test", cvarValue), AZ::GetValueResult::Success);
+        EXPECT_EQ(cvarValue, AzFramework::QualityLevel{3});
+
+        int32_t intValue = -42;
+        EXPECT_EQ(m_console->GetCvarValue("c_setting", intValue), AZ::GetValueResult::Success);
+        EXPECT_EQ(intValue, 1);
+
+        double doubleValue = -2.0;
+        EXPECT_EQ(m_console->GetCvarValue("d_setting", doubleValue), AZ::GetValueResult::Success);
+        EXPECT_EQ(doubleValue, 2.0);
+
+        // when the rule resolution order is changed to First and default groups are loaded
+        m_settingsRegistry.get()->SetObject("/O3DE/Quality/DeviceRulesResolution", AzFramework::DeviceRuleResolution::First);
+        AzFramework::QualitySystemEvents::Bus::Broadcast(
+            &AzFramework::QualitySystemEvents::LoadDefaultQualityGroup,
+            AzFramework::QualityLevel::LevelFromDeviceRules);
+
+        // expect the values are set based on the device rules and the resolution order of "First"
+        EXPECT_EQ(m_console->GetCvarValue("q_test", cvarValue), AZ::GetValueResult::Success);
+        EXPECT_EQ(cvarValue, AzFramework::QualityLevel{1});
+
+        EXPECT_EQ(m_console->GetCvarValue("c_setting", intValue), AZ::GetValueResult::Success);
+        EXPECT_EQ(intValue, 4);
+
+        EXPECT_EQ(m_console->GetCvarValue("d_setting", doubleValue), AZ::GetValueResult::Success);
+        EXPECT_EQ(doubleValue, 1.0);
+
+        // when the rule resolution order is changed to Min and default groups are loaded
+        m_settingsRegistry.get()->SetObject("/O3DE/Quality/DeviceRulesResolution", AzFramework::DeviceRuleResolution::Min);
+        AzFramework::QualitySystemEvents::Bus::Broadcast(
+            &AzFramework::QualitySystemEvents::LoadDefaultQualityGroup,
+            AzFramework::QualityLevel::LevelFromDeviceRules);
+
+        // expect the values are set based on the device rules and the default resolution rule of "Min"
+        EXPECT_EQ(m_console->GetCvarValue("q_test", cvarValue), AZ::GetValueResult::Success);
+        EXPECT_EQ(cvarValue, AzFramework::QualityLevel{1});
+
+        EXPECT_EQ(m_console->GetCvarValue("c_setting", intValue), AZ::GetValueResult::Success);
+        EXPECT_EQ(intValue, 1);
+
+        EXPECT_EQ(m_console->GetCvarValue("d_setting", doubleValue), AZ::GetValueResult::Success);
+        EXPECT_EQ(doubleValue, 1.0);
+
+        // when the rule resolution order is changed to Max and default groups are loaded
+        m_settingsRegistry.get()->SetObject("/O3DE/Quality/DeviceRulesResolution", AzFramework::DeviceRuleResolution::Max);
+        AzFramework::QualitySystemEvents::Bus::Broadcast(
+            &AzFramework::QualitySystemEvents::LoadDefaultQualityGroup,
+            AzFramework::QualityLevel::LevelFromDeviceRules);
+
+        // expect the values are set based on the device rules and the default resolution rule of "Max"
+        EXPECT_EQ(m_console->GetCvarValue("q_test", cvarValue), AZ::GetValueResult::Success);
+        EXPECT_EQ(cvarValue, AzFramework::QualityLevel{3});
+
+        // IMPORTANT the value for c_setting in the second group is lower than the value for
+        // c_setting in the first rule group so it is ignored and would have been 4 but
+        // the value for q_test is higher in the second group and it is a group cvar which
+        // will set c_setting to 234
+        EXPECT_EQ(m_console->GetCvarValue("c_setting", intValue), AZ::GetValueResult::Success);
+        EXPECT_EQ(intValue, 234);
+
+        // d_setting will be 2.0 because the value in the second group is higher than the
+        // value in the first group
+        EXPECT_EQ(m_console->GetCvarValue("d_setting", doubleValue), AZ::GetValueResult::Success);
+        EXPECT_EQ(doubleValue, 2.0);
+    }
+
 } // namespace UnitTest
 

--- a/Code/Framework/AzFramework/Tests/framework_shared_tests_files.cmake
+++ b/Code/Framework/AzFramework/Tests/framework_shared_tests_files.cmake
@@ -9,11 +9,12 @@
 set(FILES
     DocumentPropertyEditor/DocumentPropertyEditorFixture.h
     DocumentPropertyEditor/DocumentPropertyEditorFixture.cpp
+    DeviceAttribute/TestDeviceAttribute.h
+    DeviceAttribute/TestDeviceAttribute.cpp
     Mocks/MockSpawnableEntitiesInterface.h
     Mocks/MockWindowRequests.h
     Mocks/MockViewportRequests.h
     Utils/Utils.h
-
     Utils/Printers.h
     Utils/Printers.cpp
     FrameworkApplicationFixture.h

--- a/Code/Framework/AzFramework/Tests/frameworktests_files.cmake
+++ b/Code/Framework/AzFramework/Tests/frameworktests_files.cmake
@@ -45,4 +45,5 @@ set(FILES
     PaintBrush/PaintBrushPaintSettingsTests.cpp
     PaintBrush/PaintBrushSmoothLocationTests.cpp
     QualitySystemComponentTests.cpp
+    DeviceAttributeSystemComponentTests.cpp
 )

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.inl
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.inl
@@ -76,7 +76,7 @@ namespace AzNetworking
     {
         static bool SerializeObject(ISerializer& serializer, TYPE& value)
         {
-            return value.Serialize(serializer);
+            return SerializeType<TYPE>::Serialize(serializer, value);
         }
     };
 

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/SystemComponent.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/SystemComponent.cpp
@@ -15,6 +15,7 @@
 #include <Atom/RHI/RayTracingAccelerationStructure.h>
 #include <Atom/RHI/RayTracingPipelineState.h>
 #include <Atom/RHI/RayTracingShaderTable.h>
+#include <Atom/RHI/DispatchRaysIndirectBuffer.h>
 #include <Atom/RHI.Reflect/Metal/Base.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <RHI/BufferPool.h>


### PR DESCRIPTION
## What does this PR do?

Cherry picks the following changes from `o3de/development` to support using device rules to set quality settings based on device attributes like `DeviceModel` and `RAM`
1. Device Attributes https://github.com/o3de/o3de/pull/16725 
2. Quality Settings Device Rules https://github.com/o3de/o3de/pull/16839

## How was this PR tested?

- configured and built on Windows
- refer to the listed PR for details, but device attributes and rules were tested on Windows, Linux, Mac, Android and iOS
