### PR TITLE
Fix mac build break

### DIFF
--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/SystemComponent.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/SystemComponent.cpp
@@ -15,7 +15,6 @@
 #include <Atom/RHI/RayTracingAccelerationStructure.h>
 #include <Atom/RHI/RayTracingPipelineState.h>
 #include <Atom/RHI/RayTracingShaderTable.h>
-#include <Atom/RHI/DispatchRaysIndirectBuffer.h>
 #include <Atom/RHI.Reflect/Metal/Base.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <RHI/BufferPool.h>


### PR DESCRIPTION
## What does this PR do?

Reverts a change on Mac for an include that doesn't exist in 23.10 (only exists in o3de/development)

## How was this PR tested?

n/a
