### PR TITLE
Scriptedentitytweener lua fix, PR validator fixes

### DIFF
--- a/Code/Editor/GameEngine.cpp
+++ b/Code/Editor/GameEngine.cpp
@@ -775,7 +775,7 @@ void CGameEngine::Update()
         return;
     }
 
-#if defined(CARBONATED) && defined(AZ_PLATFORM_WINDOWS) // aefimov MAD-10299 assert modal dialog fix
+#if defined(CARBONATED) // aefimov MAD-10299 assert modal dialog fix
     if (gEnv->IsEditor())
     {
         bool result = false;

--- a/Code/Framework/AzCore/AzCore/Debug/EngineAnalyticsBus.h
+++ b/Code/Framework/AzCore/AzCore/Debug/EngineAnalyticsBus.h
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
 #pragma once
 
 #if defined(CARBONATED)

--- a/Code/Framework/AzCore/AzCore/NativeUI/NativeUIRequests.h
+++ b/Code/Framework/AzCore/AzCore/NativeUI/NativeUIRequests.h
@@ -42,7 +42,7 @@ namespace AZ::NativeUI
         {
             return {};
         }
-#if defined(CARBONATED) && defined(AZ_PLATFORM_WINDOWS) // aefimov MAD-10299 assert modal dialog fix
+#if defined(CARBONATED) // aefimov MAD-10299 assert modal dialog fix
             // returns true if a blocking dialog is displayed
             virtual bool IsDisplayingBlockingDialog() const { return false; }
 #endif

--- a/Code/Framework/AzCore/AzCore/NativeUI/NativeUISystemComponent.h
+++ b/Code/Framework/AzCore/AzCore/NativeUI/NativeUISystemComponent.h
@@ -26,7 +26,7 @@ namespace AZ::NativeUI
         ////////////////////////////////////////////////////////////////////////
         // NativeUIRequestBus interface implementation
         AZStd::string DisplayBlockingDialog(const AZStd::string& title, const AZStd::string& message, const AZStd::vector<AZStd::string>& options) const override;
-#if defined(CARBONATED) && defined(AZ_PLATFORM_WINDOWS) // aefimov MAD-10299 assert modal dialog fix
+#if defined(CARBONATED) // aefimov MAD-10299 assert modal dialog fix
         bool IsDisplayingBlockingDialog() const override;
 #endif        
         AZStd::string DisplayOkDialog(const AZStd::string& title, const AZStd::string& message, bool showCancel) const override;

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -82,7 +82,7 @@ set(FILES
     Debug/Budget.cpp
     Debug/BudgetTracker.h
     Debug/BudgetTracker.cpp
-	Debug/EngineAnalyticsBus.h	
+    Debug/EngineAnalyticsBus.h
     Debug/MemoryProfiler.h
     Debug/PerformanceCollector.h
     Debug/PerformanceCollector.cpp

--- a/Gems/ScriptedEntityTweener/Assets/Scripts/ScriptedEntityTweener/ScriptedEntityTweener.lua
+++ b/Gems/ScriptedEntityTweener/Assets/Scripts/ScriptedEntityTweener/ScriptedEntityTweener.lua
@@ -9,7 +9,10 @@
 --
 ----------------------------------------------------------------------------------------------------
 
-if g_timelineCounter == nil then
+-- Gruber patch begin : check if global variable exists 
+--if g_timelineCounter == nil then
+-- Gruber patch end
+if rawget(_G, "g_timelineCounter") == nil then
     g_timelineCounter = 0
     g_animationCallbackCounter = 0
     g_animationCallbacks = {}


### PR DESCRIPTION
## What does this PR do?

Fix for the error:

<11:44:04> [Warning] (Script) - Access to undeclared global variable 'g_timelineCounter'
 ---------- START STACK TRACE ----------
 =[C](-1): ?
 @scripts/scriptedentitytweener/scriptedentitytweener.lua(15): ?
 =[C](-1): ?

## How was this PR tested?

A proper check for the global variable
