### PR TITLE
More Perf optimization work

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/ForwardPass_BaseLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/ForwardPass_BaseLighting.azsli
@@ -23,7 +23,6 @@
 #define ENABLE_SHADOWS 1
 #define ENABLE_FULLSCREEN_SHADOW 0
 #define ENABLE_LIGHT_CULLING 0
-#define ENABLE_SPHERE_LIGHTS 1   // Enabling this for mobile pipeline as point sphere lights support projected shadows.
 #define ENABLE_AREA_LIGHTS 0
 #define ENABLE_AREA_LIGHT_VALIDATION    0
 #define ENABLE_PHYSICAL_SKY 0

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/ForwardPass_StandardLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/ForwardPass_StandardLighting.azsli
@@ -24,7 +24,6 @@
 #define ENABLE_SHADOWS 1
 #define ENABLE_FULLSCREEN_SHADOW 0
 #define ENABLE_LIGHT_CULLING 0
-#define ENABLE_SPHERE_LIGHTS 1   // Enabling this for mobile pipeline as point sphere lights support projected shadows.
 #define ENABLE_AREA_LIGHTS 0
 #define ENABLE_AREA_LIGHT_VALIDATION    0
 #define ENABLE_PHYSICAL_SKY 0

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/ForwardPass_StandardLighting_CustomZ.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/ForwardPass_StandardLighting_CustomZ.azsli
@@ -24,7 +24,6 @@
 #define ENABLE_SHADOWS 1
 #define ENABLE_FULLSCREEN_SHADOW 0
 #define ENABLE_LIGHT_CULLING 0
-#define ENABLE_SPHERE_LIGHTS 1   // Enabling this for mobile pipeline as point sphere lights support projected shadows.
 #define ENABLE_AREA_LIGHTS 0
 #define ENABLE_AREA_LIGHT_VALIDATION    0
 #define ENABLE_PHYSICAL_SKY 0

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandList.h
@@ -145,8 +145,10 @@ namespace AZ
                 // Draw State
                 const RHI::PipelineState* m_pipelineState = nullptr;
                 const PipelineLayout* m_pipelineLayout = nullptr;
-                AZ::HashValue64 m_streamsHash = AZ::HashValue64{0};
-                AZ::HashValue64 m_indicesHash = AZ::HashValue64{0};
+                AZStd::array<AZ::HashValue64, RHI::Limits::Pipeline::StreamCountMax> m_streamsHashes = {AZ::HashValue64{0}};
+                
+                AZ::HashValue64 m_rasterizerStateHash = AZ::HashValue64{0};
+                uint64_t m_depthStencilStateHash = 0;
                 uint32_t m_stencilRef = static_cast<uint32_t>(-1);
                 RHI::CommandListScissorState m_scissorState;
                 RHI::CommandListViewportState m_viewportState;

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Conversions.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Conversions.cpp
@@ -908,6 +908,7 @@ namespace AZ
             rasterizerState.m_depthSlopeScale = raster.m_depthBiasSlopeScale;
             rasterizerState.m_triangleFillMode = ConvertFillMode(raster.m_fillMode);
             rasterizerState.m_depthClipMode = raster.m_depthClipEnable ? MTLDepthClipModeClip:MTLDepthClipModeClamp;
+            rasterizerState.UpdateHash();
         }
         
         bool IsDepthStencilMerged(RHI::Format format)

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineState.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineState.cpp
@@ -21,6 +21,19 @@ namespace AZ
 {
     namespace Metal
     {
+        void RasterizerState::UpdateHash()
+        {
+            HashValue64 seed = HashValue64{ 0 };
+            seed = TypeHash64(m_cullMode, seed);
+            seed = TypeHash64(m_depthBias, seed);
+            seed = TypeHash64(m_depthSlopeScale, seed);
+            seed = TypeHash64(m_depthBiasClamp, seed);
+            seed = TypeHash64(m_frontFaceWinding, seed);
+            seed = TypeHash64(m_triangleFillMode, seed);
+            seed = TypeHash64(m_depthClipMode, seed);
+            m_hash = seed;
+        }
+    
         RHI::Ptr<PipelineState> PipelineState::Create()
         {
             return aznew PipelineState;

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineState.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineState.h
@@ -18,13 +18,16 @@ namespace AZ
         class ShaderStageFunction;
         struct RasterizerState
         {
-            MTLCullMode         m_cullMode;
-            float               m_depthBias;
-            float               m_depthSlopeScale;
-            float               m_depthBiasClamp;
-            MTLWinding          m_frontFaceWinding;
-            MTLTriangleFillMode m_triangleFillMode;
-            MTLDepthClipMode    m_depthClipMode;
+            MTLCullMode         m_cullMode = MTLCullModeNone;
+            float               m_depthBias = 0.0f;
+            float               m_depthSlopeScale = 0.0f;
+            float               m_depthBiasClamp = 0.0f;
+            MTLWinding          m_frontFaceWinding = MTLWindingClockwise;
+            MTLTriangleFillMode m_triangleFillMode = MTLTriangleFillModeFill;
+            MTLDepthClipMode    m_depthClipMode = MTLDepthClipModeClip;
+            HashValue64         m_hash = HashValue64{ 0 };
+            
+            void UpdateHash();
         };
 
         class PipelineState final


### PR DESCRIPTION
## What does this PR do?

- Disabled Point Sphere lights from mobile pipeline as simple spot lights can now support shadows as per https://github.com/carbonated-dev/o3de/pull/104. 
- Added support to not bind rasterizer or depth stencil state if unchanged from previous Submit command.

## How was this PR tested?

Tested by running centralplaza_flythrough_stripped.spawnable
