### PR TITLE
Add support to release BufferAssets owned by ModelAssets for some use cases

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
@@ -175,6 +175,7 @@ namespace AZ
                 bool m_hasForwardPassIblSpecularMaterial : 1;
                 bool m_needsSetRayTracingData : 1;
                 bool m_hasRayTracingReflectionProbe : 1;
+                bool m_keepBufferAssetsInMemory : 1;            // If true, we need to keep BufferAssets referenced by ModelAsset stay in memory. This is needed when editor use RayIntersection
             } m_flags;
         };
 

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
@@ -99,6 +99,7 @@ namespace AZ
             bool m_useForwardPassIblSpecular = false;
             bool m_isAlwaysDynamic = false;
             bool m_excludeFromReflectionCubeMaps = false;
+            bool m_supportRayIntersection = false;
         };
 
         //! MeshFeatureProcessorInterface provides an interface to acquire and release a MeshHandle from the underlying

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -949,6 +949,7 @@ namespace AZ
             meshDataHandle->m_objectId = m_transformService->ReserveObjectId();
             meshDataHandle->m_rayTracingUuid = AZ::Uuid::CreateRandom();
             meshDataHandle->m_originalModelAsset = descriptor.m_modelAsset;
+            meshDataHandle->m_flags.m_keepBufferAssetsInMemory = descriptor.m_supportRayIntersection; // Note: the MeshLoader may need to read this flag. so it needs to be assigned because meshloader is created
             meshDataHandle->m_meshLoader = AZStd::make_shared<ModelDataInstance::MeshLoader>(descriptor.m_modelAsset, &*meshDataHandle);
             meshDataHandle->m_flags.m_isAlwaysDynamic = descriptor.m_isAlwaysDynamic;
             meshDataHandle->m_flags.m_isDrawMotion = descriptor.m_isAlwaysDynamic;
@@ -1580,6 +1581,15 @@ namespace AZ
                 m_parent->RemoveRayTracingData(rayTracingFeatureProcessor);
                 m_parent->QueueInit(model);
                 m_modelChangedEvent.Signal(AZStd::move(model));
+
+                if (m_parent->m_flags.m_keepBufferAssetsInMemory)
+                {
+                    model->GetModelAsset()->AddRefBufferAssets();
+                }
+                else
+                {
+                    model->GetModelAsset()->ReleaseRefBufferAssets();
+                }
             }
             else
             {

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Buffer/BufferAssetView.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Buffer/BufferAssetView.h
@@ -32,6 +32,9 @@ namespace AZ
 
             const Data::Asset<BufferAsset>& GetBufferAsset() const;
 
+            void LoadBufferAsset();
+            void ReleaseBufferAsset();
+
         private:
             RHI::BufferViewDescriptor m_bufferViewDescriptor;
             Data::Asset<BufferAsset> m_bufferAsset;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelAsset.h
@@ -63,6 +63,20 @@ namespace AZ
 
             AZStd::span<const Data::Asset<ModelLodAsset>> GetLodAssets() const;
 
+            // These two functions are used for keep references for BufferAssets so we can release them when they are done using after RPI::Model was created
+            // Sometime they might need to be stay in memory for certain cpu operations such as ray intersection etc.
+
+            //! Increase reference for an overall reference count for all BufferAssets referenced by this ModelAsset
+            //! When the ref count was 0, increase ref count would trigger block loading for all the BufferAssets
+            void AddRefBufferAssets();
+
+            //! Reduce reference for an overall reference count for all BufferAssets referenced by this ModelAsset
+            //! When the ref count reaches 0 after the reduce, it would release all the BufferAssets from thos ModelAsset
+            void ReleaseRefBufferAssets();
+
+            //! Returns true if the ModelAsset contains data which requires by LocalRayIntersectionAgainstModel() function.
+            bool SupportLocalRayIntersection() const;
+
             //! Checks a ray for intersection against this model. The ray must be in the same coordinate space as the model.
             //! Important: only to be used in the Editor, it may kick off a job to calculate spatial information.
             //! [GFX TODO][ATOM-4343 Bake mesh spatial information during AP processing]
@@ -125,6 +139,10 @@ namespace AZ
                 float& distanceNormalized,
                 AZ::Vector3& normal) const;
 
+            // load/release all the BufferAsset references by this ModelAsset's ModelLodAssets.
+            void LoadBufferAssets();
+            void ReleaseBufferAssets();
+
             // Various model information used in raycasting
             AZ::Name m_positionName{ "POSITION" };
             // there is a tradeoff between memory use and performance but anywhere under a few thousand triangles or so remains under a few milliseconds per ray cast
@@ -133,6 +151,11 @@ namespace AZ
             volatile mutable bool m_isKdTreeCalculationRunning = false;
             mutable AZStd::mutex m_kdTreeLock;
             mutable AZStd::optional<AZStd::size_t> m_modelTriangleCount;
+
+            // An overall reference count for all BufferAssets referenced by this ModelAsset
+            // Set defaul to 1 since the ModelAsset would load all its BufferAssets by default.
+            // ModelAsset would release these BufferAssets if this ref count reach 0 to save memory
+            AZStd::atomic<size_t> m_bufferAssetsRef = 1;
             
             // Lists all of the material slots that are used by this LOD.
             // Note the same slot can appear in multiple LODs in the model, so that LODs don't have to refer back to the model asset.

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelAsset.h
@@ -63,7 +63,7 @@ namespace AZ
 
             AZStd::span<const Data::Asset<ModelLodAsset>> GetLodAssets() const;
 
-            // These two functions are used for keep references for BufferAssets so we can release them when they are done using after RPI::Model was created
+            // These two functions are used to keep references for BufferAssets so we can release them when they are done using after RPI::Model was created
             // Sometime they might need to be stay in memory for certain cpu operations such as ray intersection etc.
 
             //! Increase reference for an overall reference count for all BufferAssets referenced by this ModelAsset
@@ -71,10 +71,10 @@ namespace AZ
             void AddRefBufferAssets();
 
             //! Reduce reference for an overall reference count for all BufferAssets referenced by this ModelAsset
-            //! When the ref count reaches 0 after the reduce, it would release all the BufferAssets from thos ModelAsset
+            //! When the ref count reaches 0 after the reduce, it would release all the BufferAssets from the ModelAsset
             void ReleaseRefBufferAssets();
 
-            //! Returns true if the ModelAsset contains data which requires by LocalRayIntersectionAgainstModel() function.
+            //! Returns true if the ModelAsset contains data which is required by LocalRayIntersectionAgainstModel() function.
             bool SupportLocalRayIntersection() const;
 
             //! Checks a ray for intersection against this model. The ray must be in the same coordinate space as the model.
@@ -153,7 +153,7 @@ namespace AZ
             mutable AZStd::optional<AZStd::size_t> m_modelTriangleCount;
 
             // An overall reference count for all BufferAssets referenced by this ModelAsset
-            // Set defaul to 1 since the ModelAsset would load all its BufferAssets by default.
+            // Set default to 1 since the ModelAsset would load all its BufferAssets by default.
             // ModelAsset would release these BufferAssets if this ref count reach 0 to save memory
             AZStd::atomic<size_t> m_bufferAssetsRef = 1;
             

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelLodAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelLodAsset.h
@@ -33,6 +33,7 @@ namespace AZ
             : public Data::AssetData
         {
             friend class ModelLodAssetCreator;
+            friend class ModelAsset;
 
         public:
             static constexpr size_t LodCountMax = 10;
@@ -54,6 +55,8 @@ namespace AZ
             class Mesh final
             {
                 friend class ModelLodAssetCreator;
+                friend class ModelLodAsset;
+
             public:
                 AZ_TYPE_INFO(Mesh, "{55A91F9A-2F71-4B75-B2F7-565087DD2DBD}");
                 AZ_CLASS_ALLOCATOR(Mesh, AZ::SystemAllocator);
@@ -122,6 +125,10 @@ namespace AZ
             private:
                 template<class T>
                 AZStd::span<const T> GetBufferTyped(const BufferAssetView& bufferAssetView) const;
+                                
+                // Load/Release all the buffer assets referenced by this mesh
+                void LoadBufferAssets();
+                void ReleaseBufferAssets();
 
                 AZ::Name m_name;
                 AZ::Aabb m_aabb = AZ::Aabb::CreateNull();
@@ -164,6 +171,10 @@ namespace AZ
                 // to by using MeshFeatureProcessor::ConnectModelChangeEventHandler().
                 return false;
             }
+
+            // Load/release all BufferAssets used by this ModelLodAsset
+            void LoadBufferAssets();
+            void ReleaseBufferAssets();
             
             AZStd::vector<Mesh> m_meshes;
             AZ::Aabb m_aabb = AZ::Aabb::CreateNull();

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/Buffer.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/Buffer.cpp
@@ -150,6 +150,7 @@ namespace AZ
                         m_streamFence->WaitOnCpuAsync(
                             [this]()
                             {
+                                // Once the uploading to gpu process is done, we shouldn't need to keep the reference of the m_bufferAsset
                                 this->m_pendingUploadMutex.lock();
                                 this->m_bufferAsset.Reset();
                                 this->m_pendingUploadMutex.unlock();

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/Buffer.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/Buffer.cpp
@@ -136,16 +136,24 @@ namespace AZ
 
             if (resultCode == RHI::ResultCode::Success)
             {
-                m_bufferAsset = { &bufferAsset, AZ::Data::AssetLoadBehavior::PreLoad };
                 InitBufferView();
                 
                 if (bufferAsset.GetBuffer().size() > 0 && !initWithData)
                 {
+                    m_bufferAsset = { &bufferAsset, AZ::Data::AssetLoadBehavior::PreLoad };
+
                     AZ_PROFILE_SCOPE(RPI, "Stream Upload");
                     m_streamFence = RHI::Factory::Get().CreateFence();
                     if (m_streamFence)
                     {
                         m_streamFence->Init(m_rhiBufferPool->GetDevice(), RHI::FenceState::Reset);
+                        m_streamFence->WaitOnCpuAsync(
+                            [this]()
+                            {
+                                this->m_pendingUploadMutex.lock();
+                                this->m_bufferAsset.Reset();
+                                this->m_pendingUploadMutex.unlock();
+                            });
                     }
 
                     RHI::BufferDescriptor bufferDescriptor = bufferAsset.GetBufferDescriptor();

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Model/Model.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Model/Model.cpp
@@ -164,7 +164,8 @@ namespace AZ
             const int result = Intersect::IntersectRayAABB2(rayStart, rayDir.GetReciprocal(), GetModelAsset()->GetAabb(), start, end);
             if (Intersect::ISECT_RAY_AABB_NONE != result)
             {
-                if (ModelAsset* modelAssetPtr = m_modelAsset.Get())
+                ModelAsset* modelAssetPtr = m_modelAsset.Get();
+                if (modelAssetPtr && modelAssetPtr->SupportLocalRayIntersection())
                 {
 #if defined(AZ_RPI_PROFILE_RAYCASTING_AGAINST_MODELS)
                     AZ::Debug::Timer timer;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Model/ModelLod.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Model/ModelLod.cpp
@@ -59,7 +59,7 @@ namespace AZ
 
                 const BufferAssetView& indexBufferAssetView = mesh.GetIndexBufferAssetView();
                 const Data::Asset<BufferAsset>& indexBufferAsset = indexBufferAssetView.GetBufferAsset();
-                if (indexBufferAsset)
+                if (indexBufferAsset.GetId().IsValid())
                 {
                     Data::Instance<Buffer> indexBuffer = Buffer::FindOrCreate(indexBufferAsset);
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Buffer/BufferAssetView.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Buffer/BufferAssetView.cpp
@@ -41,5 +41,19 @@ namespace AZ
         {
             return m_bufferViewDescriptor;
         }
+
+        void BufferAssetView::LoadBufferAsset()
+        {
+            if (m_bufferAsset.QueueLoad())
+            {
+                m_bufferAsset.BlockUntilLoadComplete();
+            }
+        }
+
+        void BufferAssetView::ReleaseBufferAsset()
+        {
+            m_bufferAsset.Release();
+        }
+
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/ModelAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/ModelAsset.cpp
@@ -101,6 +101,48 @@ namespace AZ
             return AZStd::span<const Data::Asset<ModelLodAsset>>(m_lodAssets);
         }
 
+        void ModelAsset::LoadBufferAssets()
+        {
+            for (auto& lodAsset : m_lodAssets)
+            {
+                lodAsset->LoadBufferAssets();
+            }
+        }
+
+        void ModelAsset::ReleaseBufferAssets()
+        {
+            for (auto& lodAsset : m_lodAssets)
+            {
+                lodAsset->ReleaseBufferAssets();
+            }
+        }
+
+        void ModelAsset::AddRefBufferAssets()
+        {
+            if (m_bufferAssetsRef == 0)
+            {
+                LoadBufferAssets();
+            }
+            m_bufferAssetsRef++;
+        }
+
+        void ModelAsset::ReleaseRefBufferAssets()
+        {
+            if (m_bufferAssetsRef > 0)
+            {
+                m_bufferAssetsRef--;
+                if (m_bufferAssetsRef == 0)
+                {
+                    ReleaseBufferAssets();
+                }
+            }
+        }
+
+        bool ModelAsset::SupportLocalRayIntersection() const
+        {
+            return m_bufferAssetsRef > 0;
+        }
+
         void ModelAsset::SetReady()
         {
             m_status = Data::AssetData::AssetStatus::Ready;

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/ModelLodAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/ModelLodAsset.cpp
@@ -126,7 +126,64 @@ namespace AZ
             AZ_Assert(meshIndex < m_meshes.size(), "Mesh index out of range");
             return m_meshes[meshIndex].GetSemanticBufferAssetView(semantic);
         }
+
+        void ModelLodAsset::LoadBufferAssets()
+        {
+            m_indexBuffer.QueueLoad();
+
+            for (auto& streamBuffer : m_streamBuffers)
+            {
+                streamBuffer.QueueLoad();
+            }
+
+            m_indexBuffer.BlockUntilLoadComplete();
+            for (auto& streamBuffer : m_streamBuffers)
+            {
+                streamBuffer.BlockUntilLoadComplete();
+            }
+
+            // update buffer asset references in meshes
+            for (auto& mesh : m_meshes)
+            {
+                mesh.LoadBufferAssets();
+            }
+        }
+
+        void ModelLodAsset::ReleaseBufferAssets()
+        {
+            m_indexBuffer.Release();
+
+            for (auto& streamBuffer : m_streamBuffers)
+            {
+                streamBuffer.Release();
+            }
+             
+            for (auto& mesh : m_meshes)
+            {
+                mesh.ReleaseBufferAssets();
+            }
+        }
+
+        void ModelLodAsset::Mesh::LoadBufferAssets()
+        {
+            m_indexBufferAssetView.LoadBufferAsset();
+
+            for (auto& bufferInfo : m_streamBufferInfo)
+            {
+                bufferInfo.m_bufferAssetView.LoadBufferAsset();
+            }
+        }
         
+        void ModelLodAsset::Mesh::ReleaseBufferAssets()
+        {
+            m_indexBufferAssetView.ReleaseBufferAsset();
+
+            for (auto& bufferInfo : m_streamBufferInfo)
+            {
+                bufferInfo.m_bufferAssetView.ReleaseBufferAsset();
+            }
+        }
+
         const BufferAssetView* ModelLodAsset::Mesh::GetSemanticBufferAssetView(const AZ::Name& semantic) const
         {
             const AZStd::span<const ModelLodAsset::Mesh::StreamBufferInfo>& streamBufferList = GetStreamBufferInfoList();

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshComponent.cpp
@@ -82,6 +82,9 @@ namespace AZ
                             ->DataElement(AZ::Edit::UIHandlers::CheckBox, &MeshComponentConfig::m_isRayTracingEnabled, "Use ray tracing",
                                 "Includes this mesh in ray tracing calculations.")
                                 ->Attribute(AZ::Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
+                            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &MeshComponentConfig::m_enableRayIntersection, "Support ray intersection",
+                                "Set to true when the entity has UiCanvasOnMeshComponent")
+                                ->Attribute(AZ::Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
                             ->DataElement(AZ::Edit::UIHandlers::CheckBox, &MeshComponentConfig::m_isAlwaysDynamic, "Always Moving", "Forces this mesh to be considered to always be moving, even if the transform didn't update. Useful for meshes with vertex shader animation.")
                             ->DataElement(AZ::Edit::UIHandlers::ComboBox, &MeshComponentConfig::m_lodType, "Lod Type", "Determines how level of detail (LOD) will be selected during rendering.")
                                 ->Attribute(AZ::Edit::Attributes::NameLabelOverride, "LOD Type")
@@ -128,6 +131,7 @@ namespace AZ
 
         void EditorMeshComponent::Activate()
         {
+            m_controller.m_configuration.m_editorRayIntersection = true;
             BaseClass::Activate();
             AzToolsFramework::EditorComponentSelectionRequestsBus::Handler::BusConnect(GetEntityId());
             AzFramework::EntityDebugDisplayEventBus::Handler::BusConnect(GetEntityId());

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
@@ -82,6 +82,7 @@ namespace AZ
                     ->Field("UseForwardPassIBLSpecular", &MeshComponentConfig::m_useForwardPassIblSpecular)
                     ->Field("IsRayTracingEnabled", &MeshComponentConfig::m_isRayTracingEnabled)
                     ->Field("IsAlwaysDynamic", &MeshComponentConfig::m_isAlwaysDynamic)
+                    ->Field("SupportRayIntersection", &MeshComponentConfig::m_enableRayIntersection)
                     ->Field("LodType", &MeshComponentConfig::m_lodType)
                     ->Field("LodOverride", &MeshComponentConfig::m_lodOverride)
                     ->Field("MinimumScreenCoverage", &MeshComponentConfig::m_minimumScreenCoverage)
@@ -432,6 +433,7 @@ namespace AZ
                 meshDescriptor.m_isRayTracingEnabled = m_configuration.m_isRayTracingEnabled;
                 meshDescriptor.m_excludeFromReflectionCubeMaps = m_configuration.m_excludeFromReflectionCubeMaps;
                 meshDescriptor.m_isAlwaysDynamic = m_configuration.m_isAlwaysDynamic;
+                meshDescriptor.m_supportRayIntersection = m_configuration.m_enableRayIntersection || m_configuration.m_editorRayIntersection;
                 m_meshHandle = m_meshFeatureProcessor->AcquireMesh(meshDescriptor, ConvertToCustomMaterialMap(materials));
                 m_meshFeatureProcessor->ConnectModelChangeEventHandler(m_meshHandle, m_changeEventHandler);
                 m_meshFeatureProcessor->ConnectObjectSrgCreatedEventHandler(m_meshHandle, m_objectSrgCreatedHandler);

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
@@ -50,6 +50,9 @@ namespace AZ
             bool m_isAlwaysDynamic = false;
             bool m_useForwardPassIblSpecular = false;
             bool m_isRayTracingEnabled = true;
+            // the ModelAsset should support ray intersection if any one of the two flags are enabled.
+            bool m_editorRayIntersection = false;       // Set to true if the config is for EditorMeshComponent so the ModelAsset always support ray intersection 
+            bool m_enableRayIntersection = false;       // Set to true if a mesh need ray intersection support at runtime. 
             RPI::Cullable::LodType m_lodType = RPI::Cullable::LodType::Default;
             RPI::Cullable::LodOverride m_lodOverride = aznumeric_cast<RPI::Cullable::LodOverride>(0);
             float m_minimumScreenCoverage = 1.0f / 1080.0f;

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
@@ -678,7 +678,7 @@ namespace AZ::Render
             meshDescriptor.m_isAlwaysDynamic = true;
             meshDescriptor.m_excludeFromReflectionCubeMaps = true;
 
-            meshDescriptor.m_supportRayIntersection = true; // we need keep the buffer data for initialize actor. 
+            meshDescriptor.m_supportRayIntersection = true; // we need to keep the buffer data in order to initialize the actor.
 
             m_meshHandle = AZStd::make_shared<MeshFeatureProcessorInterface::MeshHandle>(
                 m_meshFeatureProcessor->AcquireMesh(meshDescriptor, ConvertToCustomMaterialMap(materials)));

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
@@ -678,6 +678,8 @@ namespace AZ::Render
             meshDescriptor.m_isAlwaysDynamic = true;
             meshDescriptor.m_excludeFromReflectionCubeMaps = true;
 
+            meshDescriptor.m_supportRayIntersection = true; // we need keep the buffer data for initialize actor. 
+
             m_meshHandle = AZStd::make_shared<MeshFeatureProcessorInterface::MeshHandle>(
                 m_meshFeatureProcessor->AcquireMesh(meshDescriptor, ConvertToCustomMaterialMap(materials)));
             m_meshFeatureProcessor->ConnectObjectSrgCreatedEventHandler(*m_meshHandle, m_objectSrgCreatedHandler);


### PR DESCRIPTION
## What does this PR do?
In most of use cases, the BufferAssets referenced by ModelAssets don't need be staying in memory after the RPI::Buffers are created. This could save us a lot of the cpu memory. 
This PR has the change that some BufferAssets would be removed when the RPI::Model was created. 

There are few special use cases which requires the BufferAssets stay in memory.
- The mesh components need to have the BufferAsset to support ray intersection function in Editor's editing mode.
- If the mesh component's owner entity has a UICanvasOnMeshComponent. 
- Actor component which need to create its own mesh from the BufferAsset data. 

This PR includes these changes:
- Change RPI::Buffer so it always release its BufferAsset when buffer was uploaded to GPU.
- Add functions to ModelAsset so it can load/release its BufferAssets based on references.
- Add configuration to MeshDescriptor which can pass the usage of BufferAssets for each mesh instance.

## How was this PR tested?
Editor
GameLauncher
