### PR TITLE
Add support for Decal color and decal color factor to help modulate final decal color

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Decals.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Decals.azsli
@@ -14,6 +14,8 @@
 // ---------------------------------------------------------------------------------
 
 #include <Atom/Features/MatrixUtility.azsli>
+#include <Atom/Features/BlendUtility.azsli>
+#include <Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/BaseColorInput.azsli>
 #include <Atom/Features/Decals/DecalTextureUtil.azsli>
 #include <Atom/Features/LightCulling/LightCullingTileIterator.azsli>
 #include <Atom/RPI/TangentSpace.azsli>
@@ -115,7 +117,10 @@ void ApplyDecal(uint currDecalIndex, inout Surface surface)
         
         const real decalAttenuation = GetDecalAttenuation(surface.normal, decalRot[2], real(decal.m_angleAttenuation));
         const real albedoOpacity = real(baseMap.a) * real(decal.m_opacity) * decalAttenuation;
-        surface.albedo = lerp(surface.albedo, real3(baseMap.rgb), albedoOpacity);
+
+        bool useTexture = true;
+        real3 blendedBaseColor = BlendBaseColor(real3(baseMap.rgb), real3(decal.m_decalColor), real(decal.m_decalColorFactor), TextureBlendMode::Multiply, useTexture);
+        surface.albedo = lerp(surface.albedo, real3(blendedBaseColor.rgb), albedoOpacity);
 
         const real normalOpacity = real(baseMap.a) * real(decal.m_normalMapOpacity) * decalAttenuation;
         const real3 normalMapWS = GetWorldSpaceNormal(real2(normalMap), decalRot[2], decalRot[0], decalRot[1], 1.0);

--- a/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/Decals/ViewSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/Decals/ViewSrg.azsli
@@ -24,6 +24,9 @@ partial ShaderResourceGroup ViewSrg
         uint m_sortKeyPacked;
         uint m_textureArrayIndex;
         uint m_textureIndex;
+        float3 m_decalColor;
+        float m_decalColorFactor;
+        [[pad_to(16)]]
     };
 
     StructuredBuffer<Decal> m_decals; 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCulling.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCulling.azsl
@@ -157,6 +157,9 @@ ShaderResourceGroup PassSrg : SRG_PerPass
         uint m_sortKeyPacked;
         uint m_textureArrayIndex;
         uint m_textureIndex;
+        float3 m_decalColor;
+        float m_decalColorFactor;
+        [[pad_to(16)]]
     };
     
     StructuredBuffer<Decal> m_decals;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Decals/DecalFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Decals/DecalFeatureProcessorInterface.h
@@ -41,6 +41,8 @@ namespace AZ
             uint32_t m_textureArrayIndex = UnusedIndex;
             uint32_t m_textureIndex = UnusedIndex;
 
+            AZStd::array<float, 3> m_decalColor = { { 1.0f, 1.0f, 1.0f } };
+            float m_decalColorFactor = 1.0f;
             static constexpr uint32_t UnusedIndex = std::numeric_limits< uint32_t>::max();
         };
 
@@ -68,6 +70,12 @@ namespace AZ
 
             //! Sets the position of the decal
             virtual void SetDecalPosition(DecalHandle handle, const AZ::Vector3& position) = 0;
+
+            //! Sets the color of the decal
+            virtual void SetDecalColor(DecalHandle handle, const AZ::Vector3& color) = 0;
+
+            //! Sets the color factor of the decal
+            virtual void SetDecalColorFactor(DecalHandle handle, float colorFactor) = 0;
 
             //! Sets the orientation of the decal
             virtual void SetDecalOrientation(DecalHandle handle, const AZ::Quaternion& orientation) = 0;

--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
@@ -238,6 +238,39 @@ namespace AZ
             }
         }
 
+        void DecalTextureArrayFeatureProcessor::SetDecalColor(const DecalHandle handle, const AZ::Vector3& color)
+        {
+            if (handle.IsValid())
+            {
+                AZStd::array<float, 3>& writeColor = m_decalData.GetData(handle.GetIndex()).m_decalColor;
+                color.StoreToFloat3(writeColor.data());
+                m_deviceBufferNeedsUpdate = true;
+            }
+            else
+            {
+                AZ_Warning(
+                    "DecalTextureArrayFeatureProcessor",
+                    false,
+                    "Invalid handle passed to DecalTextureArrayFeatureProcessor::SetDecalColor().");
+            }
+        }
+
+        void DecalTextureArrayFeatureProcessor::SetDecalColorFactor(const DecalHandle handle, float colorFactor)
+        {
+            if (handle.IsValid())
+            {
+                m_decalData.GetData(handle.GetIndex()).m_decalColorFactor = colorFactor;
+                m_deviceBufferNeedsUpdate = true;
+            }
+            else
+            {
+                AZ_Warning(
+                    "DecalTextureArrayFeatureProcessor",
+                    false,
+                    "Invalid handle passed to DecalTextureArrayFeatureProcessor::SetDecalColorFactor().");
+            }
+        }
+
         void DecalTextureArrayFeatureProcessor::SetDecalHalfSize(DecalHandle handle, const Vector3& halfSize)
         {
             if (handle.IsValid())

--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.h
@@ -62,6 +62,12 @@ namespace AZ
             //! Sets the position of the decal
             void SetDecalPosition(const DecalHandle handle, const AZ::Vector3& position) override;
 
+            //! Sets the color of the decal
+            void SetDecalColor(const DecalHandle handle, const AZ::Vector3& color) override;
+
+            //! Sets the factor for the decal color
+            void SetDecalColorFactor(const DecalHandle handle, float colorFactor) override;
+
             //! Sets the orientation of the decal
             void SetDecalOrientation(const DecalHandle handle, const AZ::Quaternion& orientation) override;
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Decals/DecalBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Decals/DecalBus.h
@@ -36,6 +36,18 @@ namespace AZ
             //! Sets the decal opacity
             virtual void SetOpacity(float opacity) = 0;
 
+            //! Gets the decal color
+            virtual const AZ::Vector3& GetDecalColor() const = 0;
+
+            //! Sets the decal color
+            virtual void SetDecalColor(const AZ::Vector3& color) = 0;
+
+            //! Gets the decal color factor
+            virtual float GetDecalColorFactor() const = 0;
+
+            //! Sets the decal color factor
+            virtual void SetDecalColorFactor(float colorFactor) = 0;
+
             //! Gets the decal normal map opacity
             virtual float GetNormalMapOpacity() const = 0;
 
@@ -69,6 +81,14 @@ namespace AZ
             //! Signals that the attenuation angle has changed.
             //! @param attenuationAngle This controls how much the angle between geometry and the decal affects decal opacity.
             virtual void OnAttenuationAngleChanged([[maybe_unused]] float attenuationAngle) { }
+
+            //! Signals that the decal color has changed.
+            //! @param decalColor This controls the decal color that gets multiplied with decal texture
+            virtual void OnDecalColorChanged([[maybe_unused]] const AZ::Vector3& decalColor) { }
+
+            //! Signals that the decal color factor has changed.
+            //! @param decalColorFacor This controls the decal color factor (in this case it is a multiplier) applied to the decal color
+            virtual void OnDecalColorFactorChanged([[maybe_unused]] float decalColorFacor) { }
 
             //! Signals that the opacity has changed.
             //! @param opacity The opaqueness of the decal.

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Decals/DecalComponentConfig.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Decals/DecalComponentConfig.h
@@ -30,6 +30,9 @@ namespace AZ
             float m_normalMapOpacity = 1.0f;
             // Decals with a larger sort key appear over top of smaller sort keys            
             uint8_t m_sortKey = DefaultDecalSortKey;
+
+            AZ::Vector3 m_decalColor = AZ::Vector3::CreateOne();
+            float m_decalColorFactor = 1.0f;
         };
     }
 }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Decals/DecalComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Decals/DecalComponentController.cpp
@@ -28,6 +28,8 @@ namespace AZ
                     ->Field("Opacity", &DecalComponentConfig::m_opacity)
                     ->Field("Normal Map Opacity", &DecalComponentConfig::m_normalMapOpacity)
                     ->Field("SortKey", &DecalComponentConfig::m_sortKey)
+                    ->Field("Decal Color", &DecalComponentConfig::m_decalColor)
+                    ->Field("Decal Color Factor", &DecalComponentConfig::m_decalColorFactor)
                     ->Field("Material", &DecalComponentConfig::m_materialAsset)
                 ;
             }
@@ -55,10 +57,16 @@ namespace AZ
                     ->Event("SetNormalMapOpacity", &DecalRequestBus::Events::SetNormalMapOpacity)
                     ->Event("SetSortKey", &DecalRequestBus::Events::SetSortKey)
                     ->Event("GetSortKey", &DecalRequestBus::Events::GetSortKey)
+                    ->Event("GetDecalColor", &DecalRequestBus::Events::GetDecalColor)
+                    ->Event("SetDecalColor", &DecalRequestBus::Events::SetDecalColor)
+                    ->Event("GetDecalColorFactor", &DecalRequestBus::Events::GetDecalColorFactor)
+                    ->Event("SetDecalColorFactor", &DecalRequestBus::Events::SetDecalColorFactor)
                     ->VirtualProperty("AttenuationAngle", "GetAttenuationAngle", "SetAttenuationAngle")
                     ->VirtualProperty("Opacity", "GetOpacity", "SetOpacity")
                     ->VirtualProperty("NormalMapOpacity", "GetNormalMapOpacity", "SetNormalMapOpacity")
                     ->VirtualProperty("SortKey", "GetSortKey", "SetSortKey")
+                    ->VirtualProperty("DecalColor", "GetDecalColor", "SetDecalColor")
+                    ->VirtualProperty("DecalColorFactor", "GetDecalColorFactor", "SetDecalColorFactor")
                     ->Event("SetMaterial", &DecalRequestBus::Events::SetMaterialAssetId)
                     ->Event("GetMaterial", &DecalRequestBus::Events::GetMaterialAssetId)
                     ->VirtualProperty("Material", "GetMaterial", "SetMaterial")
@@ -159,6 +167,8 @@ namespace AZ
             OpacityChanged();
             NormalMapOpacityChanged();
             SortKeyChanged();
+            DecalColorChanged();
+            DecalColorFactorChanged();
             MaterialChanged();
         }
 
@@ -171,6 +181,28 @@ namespace AZ
         {
             m_configuration.m_attenuationAngle = attenuationAngle;
             AttenuationAngleChanged();
+        }
+
+        const AZ::Vector3& DecalComponentController::GetDecalColor() const
+        {
+            return m_configuration.m_decalColor;
+        }
+
+        void DecalComponentController::SetDecalColor(const AZ::Vector3& color)
+        {
+            m_configuration.m_decalColor = color;
+            DecalColorChanged();
+        }
+
+        float DecalComponentController::GetDecalColorFactor() const
+        {
+            return m_configuration.m_decalColorFactor;
+        }
+
+        void DecalComponentController::SetDecalColorFactor(float colorFactor)
+        {
+            m_configuration.m_decalColorFactor = colorFactor;
+            DecalColorFactorChanged();
         }
 
         float DecalComponentController::GetOpacity() const
@@ -212,6 +244,24 @@ namespace AZ
             if (m_featureProcessor)
             {
                 m_featureProcessor->SetDecalAttenuationAngle(m_handle, m_configuration.m_attenuationAngle);
+            }
+        }
+
+        void DecalComponentController::DecalColorChanged()
+        {
+            DecalNotificationBus::Event(m_entityId, &DecalNotifications::OnDecalColorChanged, m_configuration.m_decalColor);
+            if (m_featureProcessor)
+            {
+                m_featureProcessor->SetDecalColor(m_handle, m_configuration.m_decalColor);
+            }
+        }
+
+        void DecalComponentController::DecalColorFactorChanged()
+        {
+            DecalNotificationBus::Event(m_entityId, &DecalNotifications::OnDecalColorFactorChanged, m_configuration.m_decalColorFactor);
+            if (m_featureProcessor)
+            {
+                m_featureProcessor->SetDecalColorFactor(m_handle, m_configuration.m_decalColorFactor);
             }
         }
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Decals/DecalComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Decals/DecalComponentController.h
@@ -50,6 +50,10 @@ namespace AZ
             // DecalRequestBus::Handler overrides ...
             float GetAttenuationAngle() const override;
             void SetAttenuationAngle(float intensity) override;
+            const AZ::Vector3& GetDecalColor() const override;
+            void SetDecalColor(const AZ::Vector3& color) override;
+            float GetDecalColorFactor() const override;
+            void SetDecalColorFactor(float colorFactor) override;
             float GetOpacity() const override;
             void SetOpacity(float opacity) override;
             float GetNormalMapOpacity() const override;
@@ -61,6 +65,8 @@ namespace AZ
 
             void ConfigurationChanged();
             void AttenuationAngleChanged();
+            void DecalColorChanged();
+            void DecalColorFactorChanged();
             void OpacityChanged();
             void NormalMapOpacityChanged();
             void SortKeyChanged();

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Decals/EditorDecalComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Decals/EditorDecalComponent.cpp
@@ -70,6 +70,10 @@ namespace AZ
                         ->Attribute(AZ::Edit::Attributes::Min, std::numeric_limits<uint8_t>::min())
                         ->Attribute(AZ::Edit::Attributes::Max, std::numeric_limits<uint8_t>::max())
 
+                        ->DataElement(AZ::Edit::UIHandlers::Color, &DecalComponentConfig::m_decalColor, "Decal Color", "Decal Color can be applied as a multiplier")
+                        ->DataElement(AZ::Edit::UIHandlers::Slider, &DecalComponentConfig::m_decalColorFactor, "Decal Color Factor", "The factor associated with decal color which also acts as a multiplier. ")
+                        ->Attribute(AZ::Edit::Attributes::Min, 0.f)
+                        ->Attribute(AZ::Edit::Attributes::Max, 5.f)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &DecalComponentConfig::m_materialAsset, "Material", "The material of the decal.")
                         ;
                 }


### PR DESCRIPTION

## What does this PR do?

- Added Decal color to decal component which is defaulted to white. This color is multiplied with the color from the decal texture map
- Added Decal color factor which is also used as a another multiplier to the final decal color.

## How was this PR tested?

Tested decal in AutomatedTesting

![image](https://github.com/carbonated-dev/o3de/assets/47460854/09cdb540-263f-4572-ab83-4f0d4083bd49)
