### PR TITLE
Missed changes from the previous spotlight fix

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/RayTracing/RayTracingSceneSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/RayTracing/RayTracingSceneSrg.azsli
@@ -60,7 +60,8 @@ ShaderResourceGroup RayTracingSceneSrg : SRG_RayTracingScene
         uint m_shadowIndex;
         float m_affectsGIFactor;
         bool m_affectsGI;
-        float2 m_padding;
+        float m_padding;
+        [[pad_to(16)]] // Here to ensure we pad the struct to 16 in case someone adds incorrect padding
     };
 
     StructuredBuffer<SimpleSpotLight> m_simpleSpotLights;

--- a/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCulling.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCulling.azsl
@@ -52,7 +52,8 @@ ShaderResourceGroup PassSrg : SRG_PerPass
         uint m_shadowIndex; 
         float m_affectsGIFactor;
         bool m_affectsGI;
-        float2 m_padding;
+        float m_padding;
+        [[pad_to(16)]] // Here to ensure we pad the struct to 16 in case someone adds incorrect padding
     };
 
     struct PointLight


### PR DESCRIPTION
## What does this PR do?
Missed updating the SimpleSpotlight struct for LightCulling and RT shader.

Fixes RHI validation error like
<21:09:56.838> [Error] (ShaderResourceGroupData) - Buffer Input 'm_simpleSpotLights[0]': Does not match expected stride size 64

## How was this PR tested?

_Please describe any testing performed._

Tested running CentralPlaza in Editor