### PR TITLE
Fix a crash related to signaling  MTLSharedEvent with uncommitted encoder

### DIFF
--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/FrameGraphExecuteGroup.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/FrameGraphExecuteGroup.cpp
@@ -113,7 +113,12 @@ namespace AZ
             RHI::FrameGraphExecuteContext& context,
             AZ::u32 contextIndex)
         {
-            m_scope->End(*static_cast<CommandList*>(context.GetCommandList()), context.GetCommandListIndex(), context.GetCommandListCount());
+            //For non-merged groups we handle signalling fences related to aliased resources at the end of the group within
+            //FrameGraphExecuteGroup::EndInternal. The reason for this is that you can only signal fences once the parallel
+            //encoders (within FrameGraphExecuteGroup) are flushed. Hence we can not signal at the end of the context itself
+            //as it is still in the middle of encoding work for active scope
+            const bool signalFencesForAliasedResources = false;
+            m_scope->End(*static_cast<CommandList*>(context.GetCommandList()), signalFencesForAliasedResources);
             static_cast<CommandList*>(context.GetCommandList())->Close();
         }
     }

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/FrameGraphExecuteGroupMerged.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/FrameGraphExecuteGroupMerged.cpp
@@ -107,9 +107,10 @@ namespace AZ
             
             const Scope* scope = m_scopes[contextIndex];
             CommandList* commandList = static_cast<CommandList*>(context.GetCommandList());
-            scope->End(*commandList, context.GetCommandListIndex(), context.GetCommandListCount());
+            //In a merged group every scope needs to signal the fences (related to aliased resources) after all
+            //the work related to it is encoded.
+            bool signalFencesForAliasedResources = context.GetCommandListCount() == 1;
+            scope->End(*commandList, signalFencesForAliasedResources);
         }
-
-
     }
 }

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Scope.cpp
@@ -340,17 +340,14 @@ namespace AZ
 
         void Scope::End(
             CommandList& commandList,
-            AZ::u32 commandListIndex,
-            AZ::u32 commandListCount) const
+            bool signalFencesForAliasedResources) const
         {
             AZ_PROFILE_FUNCTION(RHI);
             commandList.FlushEncoder();
             
-            //Check if the scope is part of merged group (i.e FrameGraphExecuteGroupMerged). For non-merged
-            //groups (i.e FrameGraphExecuteGroup) we handle signalling at the end of the group within FrameGraphExecuteGroup::EndInternal
-            //The reason for this is that you can only signal fences once the parallel encoders (within FrameGraphExecuteGroup) are flushed
-            const bool isScopePartOfMergedGroup = commandListCount == 1;
-            if (isScopePartOfMergedGroup)
+            //Signal all the fences related to aliased resources. This is to ensure that the GPU does not start work for
+            //scopes that overlap memory with other scopes that are still being worked on.
+            if (signalFencesForAliasedResources)
             {
                 SignalAllResourceFences(commandList);
             }

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Scope.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Scope.h
@@ -49,8 +49,7 @@ namespace AZ
 
             void End(
                 CommandList& commandList,
-                AZ::u32 commandListIndex,
-                AZ::u32 commandListCount) const;
+                bool signalFencesForAliasedResources) const;
             
             MTLRenderPassDescriptor* GetRenderPassDescriptor() const;
             


### PR DESCRIPTION
## What does this PR do?

For parallel encoding we were getting into a state where we had a scope with 1 command list doing parallel encoding and in this state we were incorrectly signaling fences before flushing all the parallel encoders. We do not need the command list count check for parallel encoding.

## How was this PR tested?

Tested on MadWorld