### PR TITLE
Return 0.1 for the default bulb position - fixes a nearClip == 0 DIV/0 error

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/SpotLightUtils.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/SpotLightUtils.h
@@ -40,11 +40,7 @@ namespace AZ
             template<class LightData>
             float GetBulbPositionOffset([[maybe_unused]] const LightData& light, general_)
             {
-#if defined(CARBONATED)
                 return 0.01f;
-#else
-                return 0.0f;
-#endif
             }
 
             //! Creates the bounds for a spot light

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/SpotLightUtils.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/SpotLightUtils.h
@@ -40,7 +40,11 @@ namespace AZ
             template<class LightData>
             float GetBulbPositionOffset([[maybe_unused]] const LightData& light, general_)
             {
+#if defined(CARBONATED)
+                return 0.01f;
+#else
                 return 0.0f;
+#endif
             }
 
             //! Creates the bounds for a spot light


### PR DESCRIPTION
When the general implement of GetBulbPositionOffset is called, the frustum's nearClip ends up as 0.0.  This causes a DIV/0 that finally causes an assert down the line about a non-normalized vector.

The fix here is just to return 0.01f as the default