### PR TITLE
Shader options for simple point/spot lights and decals

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Decals.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Decals.azsli
@@ -28,6 +28,15 @@
 void ApplyDecal(uint currDecalIndex, inout Surface surface);
 
 #if ENABLE_DECALS
+
+void ApplyDecalInternal(uint currDecalIndex, inout Surface surface)
+{
+    if (o_enableDecals)
+    {
+        ApplyDecal(currDecalIndex, surface);
+    }
+}
+
 void ApplyDecals(inout LightCullingTileIterator tileIterator, inout Surface surface)
 {
 #if ENABLE_LIGHT_CULLING
@@ -38,14 +47,14 @@ void ApplyDecals(inout LightCullingTileIterator tileIterator, inout Surface surf
         uint currDecalIndex = tileIterator.GetValue();
         tileIterator.LoadAdvance();
         
-        ApplyDecal(currDecalIndex, surface);
+        ApplyDecalInternal(currDecalIndex, surface);
     }
 #else
     // Since there's no GPU culling for decals, we rely on culling done by CPU
     // Only apply visible decals
     for(uint decalIndex = 0; (decalIndex < ENABLE_DECALS_CAP && decalIndex < ViewSrg::m_visibleDecalCount); decalIndex++)
     {
-        ApplyDecal(ViewSrg::m_visibleDecalIndices[decalIndex], surface);
+        ApplyDecalInternal(ViewSrg::m_visibleDecalIndices[decalIndex], surface);
     }
 #endif
 }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/LightingOptions.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/LightingOptions.azsli
@@ -89,10 +89,10 @@ option bool o_enableCapsuleLights = true;
 option bool o_enableQuadLightLTC = true;
 option bool o_enableQuadLightApprox = true;
 option bool o_enablePolygonLights = true;
-option bool o_enableSimplePointLights = false;
-option bool o_enableSimpleSpotLights = false;
+option bool o_enableSimplePointLights = true;
+option bool o_enableSimpleSpotLights = true;
 option bool o_enableSimpleSpotLightShadows = true;
-option bool o_enableDecals = false;
+option bool o_enableDecals = true;
 
 option bool o_enableIBL = true;
 option bool o_enableSubsurfaceScattering = false;

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/LightingOptions.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/LightingOptions.azsli
@@ -89,7 +89,10 @@ option bool o_enableCapsuleLights = true;
 option bool o_enableQuadLightLTC = true;
 option bool o_enableQuadLightApprox = true;
 option bool o_enablePolygonLights = true;
+option bool o_enableSimplePointLights = false;
+option bool o_enableSimpleSpotLights = false;
 option bool o_enableSimpleSpotLightShadows = true;
+option bool o_enableDecals = false;
 
 option bool o_enableIBL = true;
 option bool o_enableSubsurfaceScattering = false;

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/SimplePointLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/SimplePointLight.azsli
@@ -36,6 +36,15 @@ void ApplySimplePointLight(ViewSrg::SimplePointLight light, Surface surface, ino
     }
 }
 
+void ApplySimplePointLightInternal(uint lightIndex, Surface surface, inout LightingData lightingData)
+{
+    if (o_enableSimplePointLights)
+    {
+        ViewSrg::SimplePointLight light = ViewSrg::m_simplePointLights[lightIndex];
+        ApplySimplePointLight(light, surface, lightingData);
+    }
+}
+
 void ApplySimplePointLights(Surface surface, inout LightingData lightingData)
 {
 #if ENABLE_LIGHT_CULLING
@@ -45,14 +54,12 @@ void ApplySimplePointLights(Surface surface, inout LightingData lightingData)
         uint currLightIndex = lightingData.tileIterator.GetValue(); 
         lightingData.tileIterator.LoadAdvance();
     
-        ViewSrg::SimplePointLight light = ViewSrg::m_simplePointLights[currLightIndex];
-        ApplySimplePointLight(light, surface, lightingData);
+        ApplySimplePointLightInternal(currLightIndex, surface, lightingData);
     }
 #else
     for(uint lightIndex = 0; lightIndex < ViewSrg::m_simplePointLightCount; lightIndex++)
     {
-        ViewSrg::SimplePointLight light = ViewSrg::m_simplePointLights[lightIndex];
-        ApplySimplePointLight(light, surface, lightingData);
+        ApplySimplePointLightInternal(lightIndex, surface, lightingData);
     }
 #endif
 }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/SimpleSpotLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/SimpleSpotLight.azsli
@@ -78,6 +78,15 @@ void ApplySimpleSpotLight(ViewSrg::SimpleSpotLight light, Surface surface, inout
     }
 }
 
+void ApplySimpleSpotLightInternal(uint lightIndex, Surface surface, inout LightingData lightingData)
+{
+    if (o_enableSimpleSpotLights)
+    {
+        ViewSrg::SimpleSpotLight light = ViewSrg::m_simpleSpotLights[lightIndex];
+        ApplySimpleSpotLight(light, surface, lightingData);
+    }
+}
+
 void ApplySimpleSpotLights(Surface surface, inout LightingData lightingData)
 {
 #if ENABLE_LIGHT_CULLING
@@ -88,14 +97,12 @@ void ApplySimpleSpotLights(Surface surface, inout LightingData lightingData)
         uint currLightIndex = lightingData.tileIterator.GetValue(); 
         lightingData.tileIterator.LoadAdvance();
     
-        ViewSrg::SimpleSpotLight light = ViewSrg::m_simpleSpotLights[currLightIndex];
-        ApplySimpleSpotLight(light, surface, lightingData);
+        ApplySimpleSpotLightInternal(currLightIndex, surface, lightingData);
     }
 #else
     for(uint lightIndex = 0; lightIndex < ViewSrg::m_simpleSpotLightCount; lightIndex++)
     {
-        ViewSrg::SimpleSpotLight light = ViewSrg::m_simpleSpotLights[lightIndex];
-        ApplySimpleSpotLight(light, surface, lightingData);
+        ApplySimpleSpotLightInternal(lightIndex, surface, lightingData);
     }
 #endif
 }

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/SimplePointLightFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/SimplePointLightFeatureProcessor.h
@@ -12,7 +12,7 @@
 #include <Atom/Feature/CoreLights/PhotometricValue.h>
 #include <Atom/Feature/CoreLights/SimplePointLightFeatureProcessorInterface.h>
 #include <Atom/Feature/Utils/GpuBufferHandler.h>
-#include <Atom/Feature/Utils/IndexedDataVector.h>
+#include <Atom/Feature/Utils/MultiIndexedDataVector.h>
 
 namespace AZ
 {
@@ -30,7 +30,7 @@ namespace AZ
 
             static void Reflect(AZ::ReflectContext* context);
 
-            struct ShaderData
+            struct SimplePointLightData
             {
                 AZStd::array<float, 3> m_position = { { 0.0f, 0.0f, 0.0f } };
                 float m_invAttenuationRadiusSquared = 0.0f; // Inverse of the distance at which this light no longer has an effect, squared. Also used for falloff calculations.
@@ -71,9 +71,9 @@ namespace AZ
 
             static constexpr const char* FeatureProcessorName = "SimplePointLightFeatureProcessor";
 
-            using LightContainer = IndexedDataVector<ShaderData>;
-            LightContainer m_lightData;
+            MultiIndexedDataVector<SimplePointLightData, AZ::Sphere> m_lightData;
             GpuBufferHandler m_lightBufferHandler;
+            RHI::Handle<uint32_t> m_lightMeshFlag;
             bool m_deviceBufferNeedsUpdate = false;
 
         };

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/SimpleSpotLightFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/SimpleSpotLightFeatureProcessor.h
@@ -97,6 +97,7 @@ namespace AZ
 
             MultiIndexedDataVector<SimpleSpotLightData, MeshCommon::BoundsVariant> m_lightData;
             GpuBufferHandler m_lightBufferHandler;
+            RHI::Handle<uint32_t> m_lightMeshFlag;
             RHI::Handle<uint32_t> m_shadowMeshFlag;
             bool m_deviceBufferNeedsUpdate = false;
 

--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.h
@@ -11,10 +11,12 @@
 #include <Atom/Feature/Utils/GpuBufferHandler.h>
 #include <Atom/Feature/Utils/IndexedDataVector.h>
 #include <Atom/Feature/Decals/DecalFeatureProcessorInterface.h>
+#include <Atom/Feature/Utils/MultiIndexedDataVector.h>
 #include <Atom/RPI.Reflect/Image/ImageAsset.h>
 #include <Atom/RPI.Public/Image/StreamingImage.h>
 #include <AtomCore/Instance/Instance.h>
 #include <Atom/Feature/Utils/IndexableList.h>
+#include <AzCore/Math/Sphere.h>
 #include <Decals/DecalTextureArray.h>
 #include <Decals/AsyncLoadTracker.h>
 
@@ -143,8 +145,10 @@ namespace AZ
             void CullDecals(const RPI::ViewPtr& view);
             // Get or create a buffer that will be used for visibility when doing CPU culling.
             GpuBufferHandler& GetOrCreateVisibleBuffer();
+            void UpdateBounds(const DecalHandle handle);
 
-            IndexedDataVector<DecalData> m_decalData;
+            MultiIndexedDataVector<DecalData, AZ::Aabb> m_decalData;
+            RHI::Handle<uint32_t> m_decalMeshFlag;
 
             // Texture arrays are organized one per texture size permutation.
             // e.g. There may be a situation where we have 3 texture arrays:


### PR DESCRIPTION
## What does this PR do?

- Add support for shader options related to point and area lights.
- Add support for shader options for decals.
- In order to activate the shader options we will need to build variants with them as well as enable r_enablePerMeshShaderOptionFlags which is currently not compatible with mesh instancing.

## How was this PR tested?

Tested on PC Vulkand as well as ios metal
