### PR TITLE
[No ticket] Find an asset from level name

### DIFF
--- a/Code/Framework/AzCore/AzCore/Debug/Trace.cpp
+++ b/Code/Framework/AzCore/AzCore/Debug/Trace.cpp
@@ -406,7 +406,7 @@ namespace AZ::Debug
 #if defined(CARBONATED)
                 && bg_assertDialogReady != 0
 #endif
-				)
+                )
             {
                 AZ::NativeUI::AssertAction buttonResult;
                 AZ::NativeUI::NativeUIRequestBus::BroadcastResult(

--- a/Code/Legacy/CrySystem/LevelSystem/LevelSystem.cpp
+++ b/Code/Legacy/CrySystem/LevelSystem/LevelSystem.cpp
@@ -834,7 +834,7 @@ void CLevelSystem::UnloadLevel()
 #ifdef CARBONATED
     if (gEnv && gEnv->pSystem)
     {
-        gEnv->pSystem->GetISystemEventDispatcher()->OnSystemEvent(ESYSTEM_EVENT_LEVEL_LOAD_PREPARE, 0, 0);
+        //gEnv->pSystem->GetISystemEventDispatcher()->OnSystemEvent(ESYSTEM_EVENT_LEVEL_UNLOAD, 0, 0);
     }
 #endif
 // Gruber patch end

--- a/Code/Legacy/CrySystem/LevelSystem/LevelSystem.cpp
+++ b/Code/Legacy/CrySystem/LevelSystem/LevelSystem.cpp
@@ -834,7 +834,7 @@ void CLevelSystem::UnloadLevel()
 #ifdef CARBONATED
     if (gEnv && gEnv->pSystem)
     {
-        //gEnv->pSystem->GetISystemEventDispatcher()->OnSystemEvent(ESYSTEM_EVENT_LEVEL_UNLOAD, 0, 0);
+        gEnv->pSystem->GetISystemEventDispatcher()->OnSystemEvent(ESYSTEM_EVENT_LEVEL_UNLOAD, 0, 0);
     }
 #endif
 // Gruber patch end

--- a/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
+++ b/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
@@ -229,6 +229,33 @@ namespace LegacyLevelSystem
                 {
                     validLevelName = possibleLevelAssetPath;
                 }
+#ifdef CARBONATED
+// TODO : fix the level path on the backend
+                else
+                {
+                    AZStd::string levelNameStr = levelName;
+                    AZStd::string assetPath;
+                    if (levelNameStr.starts_with("/dlc/"))
+                    {
+                        assetPath = AZStd::string::format("Levels%s/%s.spawnable", levelName, strrchr(levelName, '/') + 1);
+                    }
+                    else if (levelNameStr.starts_with("dlc/"))
+                    {
+                        assetPath = AZStd::string::format("Levels/%s/%s.spawnable", levelName, strrchr(levelName, '/') + 1);
+                    }
+
+                    AZ::Data::AssetCatalogRequestBus::BroadcastResult(
+                        rootSpawnableAssetId,
+                        &AZ::Data::AssetCatalogRequestBus::Events::GetAssetIdByPath,
+                        assetPath.c_str(),
+                        AZ::Data::AssetType{},
+                        false);
+                    if (rootSpawnableAssetId.IsValid())
+                    {
+                        validLevelName = assetPath;
+                    }
+                }
+#endif // #ifdef CARBONATED
             }
         }
 

--- a/Code/Legacy/CrySystem/LocalizedStringManager.cpp
+++ b/Code/Legacy/CrySystem/LocalizedStringManager.cpp
@@ -269,7 +269,7 @@ CLocalizedStringsManager::CLocalizedStringsManager(ISystem* pSystem)
     , m_cvarLocalizationEncode(1)
 // Gruber patch begin
     , m_cvarLocalizationTest(0)
-    , m_cvarLocalizationFormat(1)		 
+    , m_cvarLocalizationFormat(1)
 // Gruber patch end
     , m_availableLocalizations(0)
 {

--- a/Code/Legacy/CrySystem/LocalizedStringManager.cpp
+++ b/Code/Legacy/CrySystem/LocalizedStringManager.cpp
@@ -317,7 +317,7 @@ CLocalizedStringsManager::CLocalizedStringsManager(ISystem* pSystem)
         "Usage: sys_localization_format [0..1]\n"
         "    0: Crytek Legacy Localization (Excel 2003)\n"
         "    1: AGS XML\n"
-        "Default is 1 (AGS Xml)");																							
+        "Default is 1 (AGS Xml)");
     //Check that someone hasn't added a language ID without a language name
     assert(PLATFORM_INDEPENDENT_LANGUAGE_NAMES[ ILocalizationManager::ePILID_MAX_OR_INVALID - 1 ] != 0);
 
@@ -556,7 +556,7 @@ void CLocalizedStringsManager::AddSupportedLanguage(const AZStd::string& langNam
 //////////////////////////////////////////////////////////////////////////
 int CLocalizedStringsManager::GetLocalizationFormat() const
 {
-/* Gruber patch begin	
+/* Gruber patch begin
     int32_t localizationFormat{};
     if (auto console = AZ::Interface<AZ::IConsole>::Get();
         console !=nullptr)
@@ -851,7 +851,7 @@ bool CLocalizedStringsManager::LoadLocalizationDataByTag(
     for (TStringVec::iterator it2 = vEntries.begin(); it2 != vEntries.end(); ++it2)
     {
         //Only load files of the correct type for the configured format
-		// Gruber patch
+        // Gruber patch
         //if ((localizationFormat == 0 && strstr(it2->c_str(), ".xml")) || (localizationFormat == 1 && strstr(it2->c_str(), ".agsxml")))
         if ((m_cvarLocalizationFormat == 0 && strstr(it2->c_str(), ".xml")) || (m_cvarLocalizationFormat == 1 && strstr(it2->c_str(), ".agsxml")))
         {
@@ -1850,7 +1850,7 @@ CLocalizedStringsManager::LoadFunc CLocalizedStringsManager::GetLoadFunction() c
     CRY_ASSERT_MESSAGE(gEnv && gEnv->pConsole, "System environment or console missing!");
     if (gEnv && gEnv->pConsole)
     {
-/* Gruber patch begin		
+/* Gruber patch begin
         int32_t localizationFormat{};
         if (auto console = AZ::Interface<AZ::IConsole>::Get();
             console !=nullptr)
@@ -1858,7 +1858,7 @@ CLocalizedStringsManager::LoadFunc CLocalizedStringsManager::GetLoadFunction() c
             console->GetCvarValue(c_sys_localization_format, localizationFormat);
         }
         if(localizationFormat == 1)*/
-        if(m_cvarLocalizationFormat == 1)			
+        if(m_cvarLocalizationFormat == 1)
 // Gruber patch end
         {
             return &CLocalizedStringsManager::DoLoadAGSXmlDocument;
@@ -2247,7 +2247,7 @@ bool CLocalizedStringsManager::LocalizeLabel(const char* sLabel, AZStd::string& 
 
             if (entry != NULL)
             {
-// Gruber patch begin				
+// Gruber patch begin
                 switch (m_cvarLocalizationTest)
                 {
                 case 0:  // Ignore the cvar, continue localization as expected

--- a/Code/Legacy/CrySystem/LocalizedStringManager.h
+++ b/Code/Legacy/CrySystem/LocalizedStringManager.h
@@ -278,9 +278,9 @@ private:
     // CVARs
     int m_cvarLocalizationDebug;
     int m_cvarLocalizationEncode; //Encode/Compress translated text to save memory
-// Gruber patch begin	
+// Gruber patch begin
     int m_cvarLocalizationFormat;
-    int m_cvarLocalizationTest;		   
+    int m_cvarLocalizationTest;  
 // Gruber patch end
 
     //The localizations that are available for this SKU. Used for determining what to show on a language select screen or whether to show one at all

--- a/Code/Legacy/CrySystem/LocalizedStringManager.h
+++ b/Code/Legacy/CrySystem/LocalizedStringManager.h
@@ -277,7 +277,7 @@ private:
 
     // CVARs
     int m_cvarLocalizationDebug;
-    int m_cvarLocalizationEncode;   //Encode/Compress translated text to save memory
+    int m_cvarLocalizationEncode; //Encode/Compress translated text to save memory
 // Gruber patch begin	
     int m_cvarLocalizationFormat;
     int m_cvarLocalizationTest;		   


### PR DESCRIPTION
## What does this PR do?

- Firing the ESYSTEM_EVENT_LEVEL_UNLOAD event on level unload
- Handing the level name asset path if the level name starts from dlc or /dlc

## How was this PR tested?

Locally on PC in Gruber o3de game
