### PR TITLE
Render scale update related support and fixes

### DIFF
--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -82,7 +82,15 @@ AZ_CVAR(uint32_t, r_width, 1920, nullptr, AZ::ConsoleFunctorFlags::DontReplicate
 AZ_CVAR(uint32_t, r_height, 1080, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Starting window height in pixels.");
 AZ_CVAR(uint32_t, r_fullscreen, false, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Starting fullscreen state.");
 AZ_CVAR(uint32_t, r_resolutionMode, 0, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "0: render resolution same as window client area size, 1: render resolution use the values specified by r_width and r_height");
-AZ_CVAR(float, r_renderScale, 1.0f, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Scale to apply to the window resolution.");
+
+void cvar_r_renderScale_Changed(const float& newRenderScale)
+{
+    AzFramework::WindowSize newSize =
+        AzFramework::WindowSize(static_cast<uint32_t>(r_width * newRenderScale), static_cast<uint32_t>(r_height * newRenderScale));
+    AzFramework::WindowRequestBus::Broadcast(&AzFramework::WindowRequestBus::Events::SetEnableCustomizedResolution, true);
+    AzFramework::WindowRequestBus::Broadcast(&AzFramework::WindowRequestBus::Events::SetRenderResolution, newSize);
+}
+AZ_CVAR(float, r_renderScale, 1.0f, cvar_r_renderScale_Changed, AZ::ConsoleFunctorFlags::DontReplicate, "Scale to apply to the window resolution.");
 
 namespace AZ
 {
@@ -656,7 +664,7 @@ namespace AZ
                     return nullptr;
                 }
             }
-
+ 
             AzFramework::WindowSize BootstrapSystemComponent::GetWindowResolution() const
             {
                 float scale = AZStd::max(static_cast<float>(r_renderScale), 0.f);

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -85,10 +85,14 @@ AZ_CVAR(uint32_t, r_resolutionMode, 0, nullptr, AZ::ConsoleFunctorFlags::DontRep
 
 void cvar_r_renderScale_Changed(const float& newRenderScale)
 {
-    AzFramework::WindowSize newSize =
-        AzFramework::WindowSize(static_cast<uint32_t>(r_width * newRenderScale), static_cast<uint32_t>(r_height * newRenderScale));
-    AzFramework::WindowRequestBus::Broadcast(&AzFramework::WindowRequestBus::Events::SetEnableCustomizedResolution, true);
-    AzFramework::WindowRequestBus::Broadcast(&AzFramework::WindowRequestBus::Events::SetRenderResolution, newSize);
+    AZ_Error("AtomBootstrap", newRenderScale > 0, "RenderScale should be greater than 0");
+    if (newRenderScale > 0)
+    {
+        AzFramework::WindowSize newSize =
+            AzFramework::WindowSize(static_cast<uint32_t>(r_width * newRenderScale), static_cast<uint32_t>(r_height * newRenderScale));
+        AzFramework::WindowRequestBus::Broadcast(&AzFramework::WindowRequestBus::Events::SetEnableCustomizedResolution, true);
+        AzFramework::WindowRequestBus::Broadcast(&AzFramework::WindowRequestBus::Events::SetRenderResolution, newSize);
+    }
 }
 AZ_CVAR(float, r_renderScale, 1.0f, cvar_r_renderScale_Changed, AZ::ConsoleFunctorFlags::DontReplicate, "Scale to apply to the window resolution.");
 
@@ -664,7 +668,7 @@ namespace AZ
                     return nullptr;
                 }
             }
- 
+
             AzFramework::WindowSize BootstrapSystemComponent::GetWindowResolution() const
             {
                 float scale = AZStd::max(static_cast<float>(r_renderScale), 0.f);

--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
@@ -163,8 +163,12 @@ namespace AZ::Render
         }
 
         m_drawParams.m_drawViewportId = viewportContext->GetId();
-        auto viewportSize = viewportContext->GetViewportSize();
-        m_drawParams.m_position = AZ::Vector3(static_cast<float>(viewportSize.m_width), 0.0f, 1.0f) + AZ::Vector3(r_topRightBorderPadding) * viewportContext->GetDpiScalingFactor();
+        
+        AZ::IConsole* console = AZ::Interface<AZ::IConsole>::Get();
+        uint32_t r_width;
+        console->GetCvarValue("r_width", r_width);
+
+        m_drawParams.m_position = AZ::Vector3(static_cast<float>(r_width), 0.0f, 1.0f) + AZ::Vector3(r_topRightBorderPadding) * viewportContext->GetDpiScalingFactor();
         m_drawParams.m_color = AZ::Colors::White;
         m_drawParams.m_scale = AZ::Vector2(BaseFontSize);
         m_drawParams.m_hAlign = AzFramework::TextHorizontalAlignment::Right;

--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
@@ -165,10 +165,23 @@ namespace AZ::Render
         m_drawParams.m_drawViewportId = viewportContext->GetId();
         
         AZ::IConsole* console = AZ::Interface<AZ::IConsole>::Get();
-        uint32_t r_width;
-        console->GetCvarValue("r_width", r_width);
-
-        m_drawParams.m_position = AZ::Vector3(static_cast<float>(r_width), 0.0f, 1.0f) + AZ::Vector3(r_topRightBorderPadding) * viewportContext->GetDpiScalingFactor();
+        uint32_t r_width, r_resolutionMode  = 0;
+        console->GetCvarValue("r_resolutionMode", r_resolutionMode);
+        
+        if (r_resolutionMode > 0u)
+        {
+            //This ensures the debug text is always attached to the top right when r_resolutionMode is enabled
+            console->GetCvarValue("r_width", r_width);
+            m_drawParams.m_position = AZ::Vector3(static_cast<float>(r_width), 0.0f, 1.0f) +
+                AZ::Vector3(r_topRightBorderPadding) * viewportContext->GetDpiScalingFactor();
+        }
+        else
+        {
+            auto viewportSize = viewportContext->GetViewportSize();
+            m_drawParams.m_position = AZ::Vector3(static_cast<float>(viewportSize.m_width), 0.0f, 1.0f) +
+                AZ::Vector3(r_topRightBorderPadding) * viewportContext->GetDpiScalingFactor();
+        }
+        
         m_drawParams.m_color = AZ::Colors::White;
         m_drawParams.m_scale = AZ::Vector2(BaseFontSize);
         m_drawParams.m_hAlign = AzFramework::TextHorizontalAlignment::Right;

--- a/Registry/Platform/iOS/window.setreg
+++ b/Registry/Platform/iOS/window.setreg
@@ -3,7 +3,8 @@
         "Autoexec": {
             "ConsoleCommands": {
                 "r_fullscreen": 1,
-                "sys_PakLogInvalidFileAccess" : 1
+                "sys_PakLogInvalidFileAccess" : 1,
+                "r_resolutionMode" : 1
             }
         }
     }


### PR DESCRIPTION
## What does this PR do?

- Add support to do runtime r_renderScale updates
- Fix 2d debug text rendering to always stay on the top right side even if the render resolution scale changes

## How was this PR tested?

Tested on PC and ios
