### PR TITLE
Compilation fixes when CARBONATED is not defined

### DIFF
--- a/Code/Legacy/CryCommon/ISystem.h
+++ b/Code/Legacy/CryCommon/ISystem.h
@@ -119,7 +119,7 @@ enum ESystemConfigSpec
 enum ESystemUpdateFlags
 {
     ESYSUPDATE_EDITOR = 0x0004
-}
+};
 #endif
 
 // Description:

--- a/Code/Legacy/CrySystem/LocalizedStringManager.cpp
+++ b/Code/Legacy/CrySystem/LocalizedStringManager.cpp
@@ -1877,7 +1877,9 @@ CLocalizedStringsManager::LoadFunc CLocalizedStringsManager::GetLoadFunction() c
         }
         if(localizationFormat == 1)
 #endif
+#if defined(CARBONATED)
         if (m_cvarLocalizationFormat == 1)
+#endif
         {
             return &CLocalizedStringsManager::DoLoadAGSXmlDocument;
         }
@@ -2266,7 +2268,6 @@ bool CLocalizedStringsManager::LocalizeLabel(const char* sLabel, AZStd::string& 
             if (entry != NULL)
             {
 #if defined(CARBONATED)
-#else
                 switch (m_cvarLocalizationTest)
                 {
                 case 0:  // Ignore the cvar, continue localization as expected


### PR DESCRIPTION
## What does this PR do?

Compilation fixes when CARBONATED is not defined

## How was this PR tested?

Tested locally
