### PR TITLE
Disable stencil writing in transparent pass

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/Transparent_StandardLighting.shader.template
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/Transparent_StandardLighting.shader.template
@@ -11,23 +11,7 @@
         },
         "Stencil" :
         {
-            "Enable" : true,
-            "ReadMask" : "0x00",
-            "WriteMask" : "0xFF",
-            "FrontFace" :
-            {
-                "Func" : "Always",
-                "DepthFailOp" : "Keep",
-                "FailOp" : "Keep",
-                "PassOp" : "Replace"
-            },
-            "BackFace" :
-            {
-                "Func" : "Always",
-                "DepthFailOp" : "Keep",
-                "FailOp" : "Keep",
-                "PassOp" : "Replace"
-            }
+            "Enable" : false
         }
     },
     

--- a/Gems/Atom/Feature/Common/Assets/Passes/Mobile/Transparent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/Mobile/Transparent.pass
@@ -25,16 +25,16 @@
                         ]
                     }
                 },
+                {
+                    "Name": "DepthStencil",
+                    "SlotType": "Input",
+                    "ScopeAttachmentUsage": "DepthStencil"
+                },
                 // Input/Outputs
                 {
                     "Name": "InputOutput",
                     "SlotType": "InputOutput",
                     "ScopeAttachmentUsage": "RenderTarget"
-                },
-                {
-                    "Name": "DepthStencil",
-                    "SlotType": "InputOutput",
-                    "ScopeAttachmentUsage": "DepthStencil"
                 }
             ],
             "ImageAttachments": [


### PR DESCRIPTION
## What does this PR do?

Disable stencil writing during the transparent pass due to validation errors on Vulkan

## How was this PR tested?

Run the RV scene of MadWorld. Also run a custom level to test for the Silhouette feature still works