### PR TITLE
Temporary hack to fix server asset loading

### DIFF
--- a/scripts/commit_validation/commit_validation/pal_allowedlist.txt
+++ b/scripts/commit_validation/commit_validation/pal_allowedlist.txt
@@ -1,4 +1,5 @@
 */Code/Legacy/*
+*/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
 */Code/Framework/AzCore/AzCore/Math/Aabb.h
 */Code/Framework/AzCore/AzCore/Math/Color.h
 */Code/Framework/AzCore/AzCore/Math/Crc.h


### PR DESCRIPTION
## What does this PR do?

Linux dedicated server cannot load a few .motion assets due to weird timing of loading and blocking threads. This temporary hack adds a delay that enables blocking thread to do its job before the blocking call.
I use platform define to limit the hack to linux platform only.

## How was this PR tested?

Tested on local linux dedicated server with extended logging.
Tested on local linux dedicated server without extended logging (as it is now)
