### PR TITLE
Removing annoying warnings in EditorSequenceComponent

### DIFF
--- a/Gems/Maestro/Code/Source/Components/EditorSequenceComponent.cpp
+++ b/Gems/Maestro/Code/Source/Components/EditorSequenceComponent.cpp
@@ -235,6 +235,14 @@ namespace Maestro
     ///////////////////////////////////////////////////////////////////////////////////////////////////////
     void EditorSequenceComponent::RemoveEntityToAnimate(AZ::EntityId removedEntityId)
     {
+        // Gruber patch begin. LVB. // To avoid annoying warnings
+#if defined(CARBONATED)
+        if (!GetEntity())   
+        {
+            return;
+        }
+#endif
+        // Gruber patch end. LVB.
         const Maestro::SequenceAgentEventBusId ebusId(GetEntityId(), removedEntityId);
 
         // Notify the SequenceAgentComponent that we're disconnecting from it


### PR DESCRIPTION
## What does this PR do?

Removes annoying warnings like "Can't get component (type: EditorSequenceComponent, addr: 0000022132622CB0) entity ID as it is not attached to an entity yet!" when the level with prefabs that contain EditorSequenceComponent is loaded.

## How was this PR tested?

The level is loaded into the Editor and there are no such warnings anymore.
