### PR TITLE
[NO TICKET] Auto detect Android screen size

### DIFF
--- a/Registry/Platform/Android/window.setreg
+++ b/Registry/Platform/Android/window.setreg
@@ -4,7 +4,7 @@
             "ConsoleCommands": {
                 "sys_PakLogInvalidFileAccess" : 1,
                 "r_fullscreen" : 1,
-                "r_resolutionMode" : 1
+                "r_resolutionMode" : 0
             }
         }
     }


### PR DESCRIPTION
## What does this PR do?

The value "r_resolutionMode" should be 0 to auto detect Android screen size.
It is processed in "\\o3de\Gems\Atom\Bootstrap\Code\Source\BootstrapSystemComponent.cpp".
Otherwise O3DE will try to get screen size from "r_width" and "r_height". 
If these values are wrong for an Android device, the Vulkan renderer will show broken screen content.

## How was this PR tested?

Verified on SAMSUNG S23+
