### PR TITLE
Fix for the assets alias

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Application/Application.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Application/Application.cpp
@@ -703,11 +703,6 @@ namespace AzFramework
             if (m_settingsRegistry->Get(projectRootPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectPath))
             {
                 fileIoBase->SetAlias("@projectroot@", projectRootPath.c_str());
-                // Gruber patch begin. LVB. // In LY this alias is assigned in "dev\Code\CryEngine\CrySystem\SystemInit.cpp".
-#if defined(CARBONATED)
-                fileIoBase->SetAlias("@assets@", projectRootPath.c_str());
-#endif
-                // Gruber patch end. LVB.
             }
 
             if (AZ::IO::FixedMaxPath exeFolder; m_settingsRegistry->Get(exeFolder.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_BinaryFolder))
@@ -718,6 +713,11 @@ namespace AzFramework
             if (AZ::IO::FixedMaxPath pathAliases; m_settingsRegistry->Get(pathAliases.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_CacheRootFolder))
             {
                 fileIoBase->SetAlias("@products@", pathAliases.c_str());
+                // Gruber patch begin. LVB. // In LY this alias is assigned in "dev\Code\CryEngine\CrySystem\SystemInit.cpp".
+#if defined(CARBONATED)
+                fileIoBase->SetAlias("@assets@", pathAliases.c_str());
+#endif
+                // Gruber patch end. LVB.
             }
 
             AZ::IO::FixedMaxPath projectUserPath;


### PR DESCRIPTION
## What does this PR do?

assets alias ported from LY should be the same as product

## How was this PR tested?

Tested locally
