### PR TITLE
Removing deprecated SetLocalScale and GetLocalScale from TransformComponent and TransfrormBus

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/TransformBus.h
+++ b/Code/Framework/AzCore/AzCore/Component/TransformBus.h
@@ -230,7 +230,7 @@ namespace AZ
         //! @deprecated GetLocalScale is deprecated, and is left only to allow migration of legacy vector scale.
         //! Get the legacy vector scale value in local space.
         //! @return The scale value in local space.
-        virtual AZ::Vector3 GetLocalScale() { return AZ::Vector3(FLT_MAX); }
+        // virtual AZ::Vector3 GetLocalScale() { return AZ::Vector3(FLT_MAX); } // Gruber patch. Deprecated
 
         // carbonated begin (mp-438-2): Methods called from o3de-gruber
 #if defined(CARBONATED)
@@ -238,7 +238,7 @@ namespace AZ
          * Set local scale of the transform.
          * @param scale The new scale to set along three local axes.
          */
-        virtual void SetLocalScale(const AZ::Vector3& /*scale*/) {}
+        // virtual void SetLocalScale(const AZ::Vector3& /*scale*/) {}  // Gruber patch. Deprecated
 #endif
         // carbonated end
 

--- a/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
@@ -844,8 +844,6 @@ namespace AzFramework
         AZ::Vector3 scale = m_worldTM.RetrieveScaleExact();
         return scale;
     }
-#endif
-
     void TransformComponent::SetLocalScale(const AZ::Vector3& /* scale */)
     {
         AZ::Transform newLocalTM = m_localTM;
@@ -860,12 +858,12 @@ namespace AzFramework
 
         SetLocalTM(newLocalTM);
     }
-    
     AZ::Vector3 TransformComponent::GetLocalScale()
     {
         AZ_WarningOnce("TransformComponent", false, "GetLocalScale is deprecated, please use GetLocalUniformScale instead");
         return AZ::Vector3(m_localTM.GetUniformScale());
     }
+#endif
 
     void TransformComponent::SetLocalUniformScale(float scale)
     {
@@ -1484,16 +1482,14 @@ namespace AzFramework
                 ->Event("GetScaleZ", &AZ::TransformBus::Events::GetScaleZ)
                     ->Attribute(AZ::Script::Attributes::Deprecated, true)
                     ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
-#endif
                 ->Event("SetLocalScale", &AZ::TransformBus::Events::SetLocalScale)
-#if 0
                 ->Event("SetLocalScaleX", &AZ::TransformBus::Events::SetLocalScaleX)
                 ->Event("SetLocalScaleY", &AZ::TransformBus::Events::SetLocalScaleY)
                 ->Event("SetLocalScaleZ", &AZ::TransformBus::Events::SetLocalScaleZ)
-#endif
+                ->VirtualProperty("Scale", "GetLocalScale", "SetLocalScale")
                 ->Event("GetLocalScale", &AZ::TransformBus::Events::GetLocalScale)
                     ->Attribute("Scale", AZ::Edit::Attributes::PropertyScale)
-                ->VirtualProperty("Scale", "GetLocalScale", "SetLocalScale")
+#endif
                 ->Event("SetLocalUniformScale", &AZ::TransformBus::Events::SetLocalUniformScale)
                 ->Event("GetLocalUniformScale", &AZ::TransformBus::Events::GetLocalUniformScale)
                 ->VirtualProperty("Uniform Scale", "GetLocalUniformScale", "SetLocalUniformScale")

--- a/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.h
+++ b/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.h
@@ -90,7 +90,7 @@ namespace AzFramework
 
         // Scale modifiers
         // Get local scale as vector (deprecated)
-        AZ::Vector3 GetLocalScale() override;
+        // AZ::Vector3 GetLocalScale() override;    // Gruber patch. GetLocalScale is deprecated. Use GetLocalUniformScale
         // Set the uniform scale value in local space.
         void SetLocalUniformScale([[maybe_unused]] float scale) override;
         // Get the uniform scale value in local space.
@@ -198,8 +198,8 @@ namespace AzFramework
 
         AZ::Vector3 GetLocalScale() override;
         AZ::Vector3 GetWorldScale() override;
-#endif
         void SetLocalScale(const AZ::Vector3& scale) override;
+#endif
         //////////////////////////////////////////////////////////////////////////
 
         AZStd::vector<AZ::EntityId> GetChildren() override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
@@ -631,13 +631,14 @@ namespace AzToolsFramework
             AZ::Quaternion result = AZ::ConvertEulerDegreesToQuaternion(m_editorTransform.m_rotate);
             return result;
         }
-
+#if 0
+        // Gruber patch. GetLocalScale is deprecated
         AZ::Vector3 TransformComponent::GetLocalScale()
         {
             AZ_WarningOnce("TransformComponent", false, "GetLocalScale is deprecated, please use GetLocalUniformScale instead");
             return m_editorTransform.m_legacyScale;
         }
-
+#endif
         void TransformComponent::SetLocalUniformScale(float scale)
         {
             m_editorTransform.m_uniformScale = scale;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.h
@@ -114,7 +114,7 @@ namespace AzToolsFramework
             AZ::Quaternion GetLocalRotationQuaternion() override;
 
             // Scale Modifiers
-            AZ::Vector3 GetLocalScale() override;
+            // AZ::Vector3 GetLocalScale() override;    // Gruber patch. GetLocalScale is deprecated
 
             void SetLocalUniformScale(float scale) override;
             float GetLocalUniformScale() override;

--- a/Gems/TestAssetBuilder/Code/Source/Builder/TestAssetBuilderComponent.cpp
+++ b/Gems/TestAssetBuilder/Code/Source/Builder/TestAssetBuilderComponent.cpp
@@ -479,7 +479,7 @@ namespace TestAssetBuilder
             }
             if (depAssetInfo.m_assetId.m_subId != depAssetId.m_subId)
             {
-                AZ_Error("AssetBuilder", false, "GetAssetInfoById - Asset Info m_subId for %s shoudl be %d.", depAssetId.ToString<AZStd::string>().c_str(), depAssetId.m_subId);
+                AZ_Error("AssetBuilder", false, "GetAssetInfoById - Asset Info m_subId for %s should be %d.", depAssetId.ToString<AZStd::string>().c_str(), depAssetId.m_subId);
                 return;
             }
             AZ::Data::AssetStreamInfo resultInfo = AZ::Data::AssetManager::Instance().GetLoadStreamInfoForAsset(depAssetId, depAssetInfo.m_assetType);


### PR DESCRIPTION
## What does this PR do?

To speed up the porting process from LY to O3DE some methods of TransformComponent were copied from LY to O3DE. But in O3DE there is "float" local scale and "Vector3" non uniform scale. 

So this PR removes old (deprecated) methods "Vector3 GetLocaScale" and SetLocalScale(Vector3) from TransfromComponent and TansformBus

## How was this PR tested?

The whole project with TESTS were compiled and the game was started in the Editor.

