### PR TITLE
Fix Asset Bundler looking for assets on disabled/unsupported platforms

### DIFF
--- a/Code/Tools/AssetBundler/source/models/SeedListTableModel.cpp
+++ b/Code/Tools/AssetBundler/source/models/SeedListTableModel.cpp
@@ -65,13 +65,29 @@ namespace AssetBundler
 
         AZ::Data::AssetInfo assetInfo;
         QString platformList;
+        const auto& enabledPlatforms = AzToolsFramework::PlatformAddressedAssetCatalogManager::GetEnabledPlatforms();
+        if (enabledPlatforms.empty())
+        {
+            AZ_Error(AssetBundler::AppWindowName, false, "Unable to find any enabled asset platforms. Please verify the Asset Processor has run and generated assets successfully.");
+        }
+
         for (const auto& seed : m_seedListManager->GetAssetSeedList())
         {
-            assetInfo = AzToolsFramework::AssetSeedManager::GetAssetInfoById(
-                seed.m_assetId,
-                AzFramework::PlatformHelper::GetPlatformIndicesInterpreted(seed.m_platformFlags)[0],
-                absolutePath,
-                seed.m_assetRelativePath);
+            for (auto platformId : enabledPlatforms)
+            {
+                if (AZ::PlatformHelper::HasPlatformFlag(seed.m_platformFlags, platformId))
+                {
+                    assetInfo = AzToolsFramework::AssetSeedManager::GetAssetInfoById(
+                        seed.m_assetId,
+                        platformId,
+                        absolutePath,
+                        seed.m_assetRelativePath);
+                    if (assetInfo.m_assetId.IsValid())
+                    {
+                        break;
+                    }
+                }
+            }
             platformList = QString(m_seedListManager->GetReadablePlatformList(seed).c_str());
 
             m_additionalSeedInfoMap[seed.m_assetId].reset(new AdditionalSeedInfo(assetInfo.m_relativePath.c_str(), platformList));


### PR DESCRIPTION
The AssetBundler was looking for the first platform each asset had a platform flag for, however this breaks on non-PC platforms for most engine assets which support building on all platforms, but PC assets will not exist on Mac or Linux platforms and so the asset will not be found.  This change makes the asset lookup only consider enabled platforms.

## What does this PR do?

Fixes an issue where the Asset Bundler was trying to look for assets in asset catalogs that did not exist because they were not enabled on that platform - for example, looking up an asset in a PC asset catalog on a Mac where PC assets are not supported.

## How was this PR tested?

- Ran the Asset Bundler on default engine assets on a Mac to verify the listed assets no longer appear as missing, even though they have been processed and found in the asset catalog and in the Cache folder for the enabled platforms.
