### PR TITLE
Fix not using "assetbundlerbatch" specialization

### DIFF
--- a/Code/Tools/AssetBundler/CMakeLists.txt
+++ b/Code/Tools/AssetBundler/CMakeLists.txt
@@ -47,9 +47,22 @@ ly_add_target(
             AZ::AssetBundlerBatch.Static
 )
 
-# Adds a specialized .setreg to identify gems enabled in the active project.
-# This associates the AssetBundlerBatch target with the .Builders gem variants.
-ly_set_gem_variant_to_load(TARGETS AssetBundlerBatch VARIANTS Builders)
+if(TARGET AssetBundlerBatch)
+    # Adds a specialized .setreg to identify gems enabled in the active project.
+    # This associates the AssetBundlerBatch target with the .Builders gem variants.
+    ly_set_gem_variant_to_load(TARGETS AssetBundlerBatch VARIANTS Builders)
+
+    set_source_files_properties(
+        source/utils/AssetBundlerBatchBuildTarget.cpp
+        PROPERTIES
+            COMPILE_DEFINITIONS
+                O3DE_CMAKE_TARGET="AssetBundlerBatch"
+    )
+else()
+    message(FATAL_ERROR "Cannot set O3DE_CMAKE_TARGET define to AssetBundlerBatch as the target doesn't exist anymore."
+        " Perhaps it has been renamed")
+endif()
+
 
 # AssetBundler - Qt GUI Application
 ly_add_target(
@@ -81,9 +94,22 @@ if(LY_DEFAULT_PROJECT_PATH)
     set_property(TARGET AssetBundler AssetBundlerBatch APPEND PROPERTY VS_DEBUGGER_COMMAND_ARGUMENTS "--project-path=\"${LY_DEFAULT_PROJECT_PATH}\"")
 endif()
 
-# Adds a specialized .setreg to identify gems enabled in the active project.
-# This associates the AssetBundler target with the .Builders gem variants.
-ly_set_gem_variant_to_load(TARGETS AssetBundler VARIANTS Builders)
+if(TARGET AssetBundler)
+    # Adds a specialized .setreg to identify gems enabled in the active project.
+    # This associates the AssetBundler target with the .Builders gem variants.
+    ly_set_gem_variant_to_load(TARGETS AssetBundler VARIANTS Builders)
+
+    set_source_files_properties(
+        source/utils/AssetBundlerBuildTarget.cpp
+        PROPERTIES
+            COMPILE_DEFINITIONS
+                O3DE_CMAKE_TARGET="AssetBundler"
+    )
+else()
+    message(FATAL_ERROR "Cannot set O3DE_CMAKE_TARGET define to AssetBundler as the target doesn't exist anymore."
+        " Perhaps it has been renamed")
+endif()
+
 
 if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
 

--- a/Code/Tools/AssetBundler/assetbundlerbatch_files.cmake
+++ b/Code/Tools/AssetBundler/assetbundlerbatch_files.cmake
@@ -11,4 +11,5 @@ set(FILES
     source/utils/utils.cpp
     source/utils/applicationManager.h
     source/utils/applicationManager.cpp
+    source/utils/AssetBundlerBatchBuildTarget.cpp
 )

--- a/Code/Tools/AssetBundler/assetbundlergui_files.cmake
+++ b/Code/Tools/AssetBundler/assetbundlergui_files.cmake
@@ -64,4 +64,5 @@ set(FILES
     source/ui/SeedTabWidget.ui
     source/utils/GUIApplicationManager.h
     source/utils/GUIApplicationManager.cpp
+    source/utils/AssetBundlerBuildTarget.cpp
 )

--- a/Code/Tools/AssetBundler/source/utils/AssetBundlerBatchBuildTarget.cpp
+++ b/Code/Tools/AssetBundler/source/utils/AssetBundlerBatchBuildTarget.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <AzCore/std/string/string_view.h>
+
+namespace AssetBundler
+{
+    //! This file is to be added only to the AssetProcessorBatch build target
+    //! This function returns the build system target name
+    AZStd::string_view GetBuildTargetName()
+    {
+#if !defined (O3DE_CMAKE_TARGET)
+#error "O3DE_CMAKE_TARGET must be defined in order to add this source file to a CMake executable target"
+#endif
+        return AZStd::string_view{ O3DE_CMAKE_TARGET };
+    }
+}

--- a/Code/Tools/AssetBundler/source/utils/AssetBundlerBuildTarget.cpp
+++ b/Code/Tools/AssetBundler/source/utils/AssetBundlerBuildTarget.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <AzCore/std/string/string_view.h>
+
+namespace AssetBundler
+{
+    //! This file is to be added only to the AssetProcessor build target
+    //! This function returns the build system target name
+    AZStd::string_view GetBuildTargetName()
+    {
+#if !defined (O3DE_CMAKE_TARGET)
+#error "O3DE_CMAKE_TARGET must be defined in order to add this source file to a CMake executable target"
+#endif
+        return AZStd::string_view{ O3DE_CMAKE_TARGET };
+    }
+}

--- a/Code/Tools/AssetBundler/source/utils/applicationManager.cpp
+++ b/Code/Tools/AssetBundler/source/utils/applicationManager.cpp
@@ -37,6 +37,11 @@
 
 namespace AssetBundler
 {
+    // Added a declaration of GetBuildTargetName which retrieves the name of the build target
+    // The build target changes depending on which shared library/executable applicationManager.cpp
+    // is linked to 
+    AZStd::string_view GetBuildTargetName();
+
     const char compareVariablePrefix = '$';
 
     ApplicationManager::ApplicationManager(int* argc, char*** argv, QObject* parent)
@@ -189,7 +194,7 @@ namespace AssetBundler
     void ApplicationManager::SetSettingsRegistrySpecializations(AZ::SettingsRegistryInterface::Specializations& specializations)
     {
         AzToolsFramework::ToolsApplication::SetSettingsRegistrySpecializations(specializations);
-        specializations.Append("assetbundler");
+        specializations.Append(GetBuildTargetName());
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## What does this PR do?

AssetBundlerBatch was always using the "assetbundler" specialization which mean it tried to load the `bin/profile/Registry/cmake_dependencies.assetbundler.profile.setreg` files which won't exist if you haven't ever configured and build that target.  This change fixes the issue by using the correct specialization for the correct target.

## How was this PR tested?

- configured, built and ran both assetbundler batch and gui to make sure the correct specialization was used.
