### PR TITLE
Adds cvar to overwrite directional shadow filtering mode and sample count mode

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
@@ -33,8 +33,9 @@ namespace AZ
     namespace Render
     {
         AZ_CVAR(bool, r_excludeItemsInSmallerShadowCascades, true, nullptr, ConsoleFunctorFlags::Null, "Set to true to exclude drawing items to a directional shadow cascade that are already covered by a smaller cascade.");
-        AZ_CVAR(int, r_directionalShadowFilteringMethod, -1, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Starting window width in pixels.");
-        AZ_CVAR(int, r_directionalShadowFilteringSampleCountMode, -1, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Starting window width in pixels.");
+        
+        AZ_CVAR(int, r_directionalShadowFilteringMethod, -1, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Cvar to override directional shadow filtering mode. -1 = default settings from Editor, 0 = None, 1 = Pcf, 2 = Esm, 3 = EsmPcf.");
+        AZ_CVAR(int, r_directionalShadowFilteringSampleCountMode, -1, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Cvar to override directional shadow sample count mode. -1 = default settings from Editor, 0 = PcfTap4, 1 = PcfTap9, 2 = PcfTap16");
 
         // --- Camera Configuration ---
 

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
@@ -210,14 +210,16 @@ namespace AZ
             {
                 SetFullscreenPassSettings();
 
-                uint32_t shadowFilterMethod = m_shadowData.at(nullptr).GetData(m_shadowingLightHandle.GetIndex()).m_shadowFilterMethod;
+                const auto& shadowData = m_shadowData.at(nullptr).GetData(m_shadowingLightHandle.GetIndex());
+
+                uint32_t shadowFilterMethod = shadowData.m_shadowFilterMethod;
                 if(r_directionalShadowFilteringMethod >= 0)
                 {
                     shadowFilterMethod = r_directionalShadowFilteringMethod;
                 }
                 RPI::ShaderSystemInterface::Get()->SetGlobalShaderOption(m_directionalShadowFilteringMethodName, AZ::RPI::ShaderOptionValue{shadowFilterMethod});
 
-                uint32_t shadowFilteringSampleCountMode = m_shadowData.at(nullptr).GetData(m_shadowingLightHandle.GetIndex()).m_filteringSampleCountMode;
+                uint32_t shadowFilteringSampleCountMode = shadowData.m_filteringSampleCountMode;
                 if(r_directionalShadowFilteringSampleCountMode >= 0)
                 {
                     shadowFilteringSampleCountMode = r_directionalShadowFilteringSampleCountMode;
@@ -228,7 +230,7 @@ namespace AZ
                 
                 RPI::ShaderSystemInterface::Get()->SetGlobalShaderOption(m_directionalShadowReceiverPlaneBiasEnableName, AZ::RPI::ShaderOptionValue{ m_shadowProperties.GetData(m_shadowingLightHandle.GetIndex()).m_isReceiverPlaneBiasEnabled });
 
-                const uint32_t cascadeCount = m_shadowData.at(nullptr).GetData(m_shadowingLightHandle.GetIndex()).m_cascadeCount;
+                const uint32_t cascadeCount = shadowData.m_cascadeCount;
 
                 RPI::ShaderSystemInterface::Get()->SetGlobalShaderOption(m_BlendBetweenCascadesEnableName, AZ::RPI::ShaderOptionValue{cascadeCount > 1 && m_shadowProperties.GetData(m_shadowingLightHandle.GetIndex()).m_blendBetweenCascades });
 
@@ -1787,9 +1789,10 @@ namespace AZ
 
             if (m_fullscreenShadowPass)
             {
-                const uint32_t shadowFilterMethod = m_shadowData.at(nullptr).GetData(m_shadowingLightHandle.GetIndex()).m_shadowFilterMethod;
-                const uint32_t filteringSampleCountMode = m_shadowData.at(nullptr).GetData(m_shadowingLightHandle.GetIndex()).m_filteringSampleCountMode;
-                const uint32_t cascadeCount = m_shadowData.at(nullptr).GetData(m_shadowingLightHandle.GetIndex()).m_cascadeCount;
+                const auto& shadowData = m_shadowData.at(nullptr).GetData(m_shadowingLightHandle.GetIndex());
+                const uint32_t shadowFilterMethod = shadowData.m_shadowFilterMethod;
+                const uint32_t filteringSampleCountMode = shadowData.m_filteringSampleCountMode;
+                const uint32_t cascadeCount = shadowData.m_cascadeCount;
                 m_fullscreenShadowPass->SetLightRawIndex(m_shadowProperties.GetRawIndex(m_shadowingLightHandle.GetIndex()));
                 m_fullscreenShadowPass->SetBlendBetweenCascadesEnable(cascadeCount > 1 && shadowProperty.m_blendBetweenCascades);
                 m_fullscreenShadowPass->SetFilterMethod(static_cast<ShadowFilterMethod>(shadowFilterMethod));

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
@@ -34,8 +34,8 @@ namespace AZ
     {
         AZ_CVAR(bool, r_excludeItemsInSmallerShadowCascades, true, nullptr, ConsoleFunctorFlags::Null, "Set to true to exclude drawing items to a directional shadow cascade that are already covered by a smaller cascade.");
         
-        AZ_CVAR(int, r_directionalShadowFilteringMethod, -1, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Cvar to override directional shadow filtering mode. -1 = default settings from Editor, 0 = None, 1 = Pcf, 2 = Esm, 3 = EsmPcf.");
-        AZ_CVAR(int, r_directionalShadowFilteringSampleCountMode, -1, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Cvar to override directional shadow sample count mode. -1 = default settings from Editor, 0 = PcfTap4, 1 = PcfTap9, 2 = PcfTap16");
+        AZ_CVAR(int, r_directionalShadowFilteringMethod, -1, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Cvar to override directional shadow filtering mode. -1 = Default settings from Editor, 0 = None, 1 = Pcf, 2 = Esm, 3 = EsmPcf.");
+        AZ_CVAR(int, r_directionalShadowFilteringSampleCountMode, -1, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Cvar to override directional shadow sample count mode. -1 = Default settings from Editor, 0 = PcfTap4, 1 = PcfTap9, 2 = PcfTap16");
 
         // --- Camera Configuration ---
 

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
@@ -33,6 +33,8 @@ namespace AZ
     namespace Render
     {
         AZ_CVAR(bool, r_excludeItemsInSmallerShadowCascades, true, nullptr, ConsoleFunctorFlags::Null, "Set to true to exclude drawing items to a directional shadow cascade that are already covered by a smaller cascade.");
+        AZ_CVAR(int, r_directionalShadowFilteringMethod, -1, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Starting window width in pixels.");
+        AZ_CVAR(int, r_directionalShadowFilteringSampleCountMode, -1, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Starting window width in pixels.");
 
         // --- Camera Configuration ---
 
@@ -207,12 +209,21 @@ namespace AZ
             {
                 SetFullscreenPassSettings();
 
-                const uint32_t shadowFilterMethod = m_shadowData.at(nullptr).GetData(m_shadowingLightHandle.GetIndex()).m_shadowFilterMethod;
+                uint32_t shadowFilterMethod = m_shadowData.at(nullptr).GetData(m_shadowingLightHandle.GetIndex()).m_shadowFilterMethod;
+                if(r_directionalShadowFilteringMethod >= 0)
+                {
+                    shadowFilterMethod = r_directionalShadowFilteringMethod;
+                }
                 RPI::ShaderSystemInterface::Get()->SetGlobalShaderOption(m_directionalShadowFilteringMethodName, AZ::RPI::ShaderOptionValue{shadowFilterMethod});
 
-                uint32_t shadowFilteringSampleCount = m_shadowData.at(nullptr).GetData(m_shadowingLightHandle.GetIndex()).m_filteringSampleCountMode;
+                uint32_t shadowFilteringSampleCountMode = m_shadowData.at(nullptr).GetData(m_shadowingLightHandle.GetIndex()).m_filteringSampleCountMode;
+                if(r_directionalShadowFilteringSampleCountMode >= 0)
+                {
+                    shadowFilteringSampleCountMode = r_directionalShadowFilteringSampleCountMode;
+                }
+                
                 RPI::ShaderSystemInterface::Get()->SetGlobalShaderOption(
-                    m_directionalShadowFilteringSamplecountName, AZ::RPI::ShaderOptionValue{ shadowFilteringSampleCount });
+                    m_directionalShadowFilteringSamplecountName, AZ::RPI::ShaderOptionValue{ shadowFilteringSampleCountMode });
                 
                 RPI::ShaderSystemInterface::Get()->SetGlobalShaderOption(m_directionalShadowReceiverPlaneBiasEnableName, AZ::RPI::ShaderOptionValue{ m_shadowProperties.GetData(m_shadowingLightHandle.GetIndex()).m_isReceiverPlaneBiasEnabled });
 

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -2018,6 +2018,7 @@ namespace AZ
                     drawPacket.SetStencilRef(stencilRef);
                     drawPacket.SetSortKey(m_sortKey);
                     drawPacket.SetEnableDraw(meshMotionDrawListTag, m_flags.m_isDrawMotion);
+                    // Note: do not add drawPacket.Update() here. It's not needed.It may cause issue with m_shaderVariantHandler which captures 'this' pointer. 
 
                     if (!r_meshInstancingEnabled)
                     {

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -2018,7 +2018,6 @@ namespace AZ
                     drawPacket.SetStencilRef(stencilRef);
                     drawPacket.SetSortKey(m_sortKey);
                     drawPacket.SetEnableDraw(meshMotionDrawListTag, m_flags.m_isDrawMotion);
-                    drawPacket.Update(*m_scene, false);
 
                     if (!r_meshInstancingEnabled)
                     {
@@ -2027,7 +2026,7 @@ namespace AZ
                     else
                     {
                         MeshInstanceGroupData& instanceGroupData = meshInstanceManager[instanceGroupInsertResult.m_handle];
-                        instanceGroupData.m_drawPacket = drawPacket;
+                        instanceGroupData.m_drawPacket = AZStd::move(drawPacket);
                         instanceGroupData.m_isDrawMotion = m_flags.m_isDrawMotion;
 
                         // We're going to need an interval for the root constant data that we update every frame for each draw item, so cache that here

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineState.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineState.cpp
@@ -126,6 +126,8 @@ namespace AZ
             {
                 NSString* entryPointStr = [[NSString alloc] initWithCString : entryPoint.data() encoding: NSASCIIStringEncoding];
                 pFunction = [lib newFunctionWithName:entryPointStr];
+                [entryPointStr release];
+                entryPointStr = nil;
                 [lib release];
                 lib = nil;
             }

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/Material.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/Material.h
@@ -141,6 +141,10 @@ namespace AZ
             //! Returns whether the material has property changes that have not been compiled yet.
             bool NeedsCompile() const;
 
+            using OnMaterialShaderVariantReadyEvent = AZ::Event<>;
+            //! Connect a handler to listen to the event that a shader variant asset of the shaders used by this material is ready
+            void ConnectEvent(OnMaterialShaderVariantReadyEvent::Handler& handler);
+
         private:
             Material() = default;
 
@@ -215,6 +219,8 @@ namespace AZ
             bool m_isInitializing = false;
 
             MaterialPropertyPsoHandling m_psoHandling = MaterialPropertyPsoHandling::Warning;
+
+            OnMaterialShaderVariantReadyEvent m_shaderVariantReadyEvent;
         };
 
     } // namespace RPI

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/MeshDrawPacket.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/MeshDrawPacket.h
@@ -113,6 +113,9 @@ namespace AZ
             // Tracks whether the Material has change since the DrawPacket was last built
             Material::ChangeId m_materialChangeId = Material::DEFAULT_CHANGE_ID;
 
+            // A handler which is called when a shader variant of the material is ready 
+            Material::OnMaterialShaderVariantReadyEvent::Handler m_shaderVariantHandler;
+
             // Set the sort key for the draw packet
             RHI::DrawItemSortKey m_sortKey = 0;
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
@@ -322,16 +322,10 @@ namespace AZ
         {
             ShaderReloadDebugTracker::ScopedSection reloadSection("{%p}->Material::OnShaderVariantReinitialized %s", this, shaderVariant.GetShaderVariantAsset().GetHint().c_str());
 
-            // Note that it would be better to check the shaderVariantId to see if that variant is relevant to this particular material before reinitializing it.
-            // There could be hundreds or even thousands of variants for a shader, but only one of those variants will be used by any given material. So we could
-            // get better reload performance by only reinitializing the material when a relevant shader variant is updated.
-            //
-            // But it isn't always possible to know the exact ShaderVariantId that this material is using. For example, some of the shader options might not be
-            // owned by the material and could be set externally *later* in the frame (see SetSystemShaderOption). We could probably check the shader option ownership
-            // and mask out the parts of the ShaderVariantId that aren't owned by the material, but that would be premature optimization at this point, adding
-            // potentially unnecessary complexity. There may also be more edge cases I haven't thought of. In short, it's much safer to just reinitialize every time
-            // this callback happens.
-            Init(*m_materialAsset);
+            // Note: we don't need to re-compile the material if a shader variant is ready or changed
+            // The DrawPacket created for the material need to be updated since the PSO need to be re-creaed.
+            // This event can be used to notify the owners to update their DrawPackets
+            m_shaderVariantReadyEvent.Signal();
         }
         ///////////////////////////////////////////////////////////////////
 
@@ -353,6 +347,11 @@ namespace AZ
         bool Material::NeedsCompile() const
         {
             return m_compiledChangeId != m_currentChangeId;
+        }
+
+        void Material::ConnectEvent(OnMaterialShaderVariantReadyEvent::Handler& handler)
+        {
+            handler.Connect(m_shaderVariantReadyEvent);
         }
 
         bool Material::TryApplyPropertyConnectionToShaderInput(

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
@@ -182,6 +182,20 @@ namespace AZ
 
         bool MeshDrawPacket::Update(const Scene& parentScene, bool forceUpdate /*= false*/)
         {
+            // Setup the Shader variant handler when first update this MeshDrawPacket.
+            // This is because the MeshDrawPacket data can be copied or moved right after it's created.
+            // The m_shaderVariantHandler won't be copied correctly due to the capture of 'this' pointer.
+            // Instead of override all the copy and move operators, this might be a better solution.
+            if (!m_shaderVariantHandler.IsConnected())
+            {
+                m_shaderVariantHandler = Material::OnMaterialShaderVariantReadyEvent::Handler(
+                    [this]()
+                    {
+                        this->m_needUpdate = true;
+                    });
+                m_material->ConnectEvent(m_shaderVariantHandler);
+            }
+
             // Why we need to check "!m_material->NeedsCompile()"...
             //    Frame A:
             //      - Material::SetPropertyValue("foo",...). This bumps the material's CurrentChangeId()

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
@@ -182,7 +182,7 @@ namespace AZ
 
         bool MeshDrawPacket::Update(const Scene& parentScene, bool forceUpdate /*= false*/)
         {
-            // Setup the Shader variant handler when first update this MeshDrawPacket.
+            // Setup the Shader variant handler when update this MeshDrawPacket the first time .
             // This is because the MeshDrawPacket data can be copied or moved right after it's created.
             // The m_shaderVariantHandler won't be copied correctly due to the capture of 'this' pointer.
             // Instead of override all the copy and move operators, this might be a better solution.


### PR DESCRIPTION
## What does this PR do?

- All the forward pass related shaders were loading root shaders because we were using shadow filtering options that did not have variants related to them. Added support to override those options via cvars.

- Minor Metal related memory leak fix.

## How was this PR tested?

Tested iOS and windows