### PR TITLE
Add Gobo support to simple spot light. 

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/SimpleSpotLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/SimpleSpotLight.azsli
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <Atom/Features/Bindless.azsli>
 #include <Atom/Features/PBR/Lights/LightTypesCommon.azsli>
 
 #if ENABLE_SHADOWS

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/SimpleSpotLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/SimpleSpotLight.azsli
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <Atom/Features/Bindless.azsli>
 #include <Atom/Features/PBR/Lights/LightTypesCommon.azsli>
 
 #if ENABLE_SHADOWS
@@ -58,6 +59,12 @@ void ApplySimpleSpotLight(ViewSrg::SimpleSpotLight light, Surface surface, inout
                 surface.vertexNormal);
         }
 #endif
+
+        // apply gobo texture
+        if (light.m_goboTexIndex < ViewSrg::MaxGoboTextureCount)
+        {
+            lightIntensity *= ViewSrg::m_bogoTextures[light.m_goboTexIndex].Sample(PassSrg::LinearSampler, uv).r;
+        }
 
         if (dotWithDirection < cosInnerConeAngle) // in penumbra
         {   

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/SimpleSpotLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/SimpleSpotLight.azsli
@@ -63,7 +63,10 @@ void ApplySimpleSpotLight(ViewSrg::SimpleSpotLight light, Surface surface, inout
         // apply gobo texture
         if (light.m_goboTexIndex < ViewSrg::MaxGoboTextureCount)
         {
-            lightIntensity *= ViewSrg::m_bogoTextures[light.m_goboTexIndex].Sample(PassSrg::LinearSampler, uv).r;
+            float4 positionInView = mul(light.m_viewProjectionMatrix, float4(surface.position, 1.0));
+            positionInView /= positionInView.w;
+            float2 goboUv = float2((positionInView.x + 1.0)/2.0, (positionInView.y + 1.0)/2.0);
+            lightIntensity *= ViewSrg::m_goboTextures[light.m_goboTexIndex].Sample(PassSrg::LinearSampler, goboUv);
         }
 
         if (dotWithDirection < cosInnerConeAngle) // in penumbra

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/RayTracing/RayTracingSceneSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/RayTracing/RayTracingSceneSrg.azsli
@@ -51,7 +51,7 @@ ShaderResourceGroup RayTracingSceneSrg : SRG_RayTracingScene
     // simple spot lights
     struct SimpleSpotLight
     {
-        float4x4 m_viewProjectionMatrix;    // Light's view projection matrix. Used for calculate uv for gobo 
+        float4x4 m_viewProjectionMatrix;    // Light's view projection matrix. Used to calculate uv for gobo 
         float3 m_position;
         float m_invAttenuationRadiusSquared; // For a radius at which this light no longer has an effect, 1 / radius^2.
         float3 m_direction;

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/RayTracing/RayTracingSceneSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/RayTracing/RayTracingSceneSrg.azsli
@@ -51,6 +51,7 @@ ShaderResourceGroup RayTracingSceneSrg : SRG_RayTracingScene
     // simple spot lights
     struct SimpleSpotLight
     {
+        float4x4 m_viewProjectionMatrix;    // Light's view projection matrix. Used for calculate uv for gobo 
         float3 m_position;
         float m_invAttenuationRadiusSquared; // For a radius at which this light no longer has an effect, 1 / radius^2.
         float3 m_direction;
@@ -58,9 +59,9 @@ ShaderResourceGroup RayTracingSceneSrg : SRG_RayTracingScene
         float3 m_rgbIntensityCandelas;
         float m_cosOuterConeAngle; // cosine of the inner cone angle
         uint m_shadowIndex;
+        uint m_goboTexIndex;
         float m_affectsGIFactor;
         bool m_affectsGI;
-        float m_padding;
         [[pad_to(16)]] // Here to ensure we pad the struct to 16 in case someone adds incorrect padding
     };
 

--- a/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/CoreLights/ViewSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/CoreLights/ViewSrg.azsli
@@ -54,6 +54,7 @@ partial ShaderResourceGroup ViewSrg
 
     struct SimpleSpotLight
     {
+        float4x4 m_viewProjectionMatrix;    // Light's view projection matrix. Used for calculate uv for gobo 
         float3 m_position;
         float m_invAttenuationRadiusSquared; // For a radius at which this light no longer has an effect, 1 / radius^2.
         float3 m_direction;
@@ -73,7 +74,7 @@ partial ShaderResourceGroup ViewSrg
     uint m_visibleSimpleSpotLightCount;
     
     static const uint MaxGoboTextureCount = 8;
-    Texture2d<float> m_goboTextures[MaxGoboTextureCount];
+    Texture2D<float> m_goboTextures[MaxGoboTextureCount];
 
     // Point lights (sphere lights)
 

--- a/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/CoreLights/ViewSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/CoreLights/ViewSrg.azsli
@@ -61,9 +61,9 @@ partial ShaderResourceGroup ViewSrg
         float3 m_rgbIntensityCandelas;
         float m_cosOuterConeAngle; // cosine of the inner cone angle
         uint m_shadowIndex;
+        uint m_goboTexIndex;
         float m_affectsGIFactor;
         bool m_affectsGI;
-        float m_padding;
         [[pad_to(16)]] // Here to ensure we pad the struct to 16 in case someone adds incorrect padding
     };
 
@@ -71,6 +71,9 @@ partial ShaderResourceGroup ViewSrg
     uint m_simpleSpotLightCount;
     Buffer<uint> m_visibleSimpleSpotLightIndices;
     uint m_visibleSimpleSpotLightCount;
+    
+    static const uint MaxGoboTextureCount = 8;
+    Texture2d<float> m_goboTextures[MaxGoboTextureCount];
 
     // Point lights (sphere lights)
 

--- a/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/CoreLights/ViewSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/CoreLights/ViewSrg.azsli
@@ -54,7 +54,7 @@ partial ShaderResourceGroup ViewSrg
 
     struct SimpleSpotLight
     {
-        float4x4 m_viewProjectionMatrix;    // Light's view projection matrix. Used for calculate uv for gobo 
+        float4x4 m_viewProjectionMatrix;    // Light's view projection matrix. Used to calculate uv for gobo 
         float3 m_position;
         float m_invAttenuationRadiusSquared; // For a radius at which this light no longer has an effect, 1 / radius^2.
         float3 m_direction;
@@ -73,7 +73,7 @@ partial ShaderResourceGroup ViewSrg
     Buffer<uint> m_visibleSimpleSpotLightIndices;
     uint m_visibleSimpleSpotLightCount;
     
-    static const uint MaxGoboTextureCount = 8;
+    static const uint MaxGoboTextureCount = 5;
     Texture2D<float> m_goboTextures[MaxGoboTextureCount];
 
     // Point lights (sphere lights)

--- a/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCulling.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCulling.azsl
@@ -43,6 +43,7 @@ ShaderResourceGroup PassSrg : SRG_PerPass
 
     struct SimpleSpotLight
     {
+        float4x4 m_viewProjectionMatrix;    // Light's view projection matrix. Used for calculate uv for gobo 
         float3 m_position;
         float m_invAttenuationRadiusSquared; // For a radius at which this light no longer has an effect, 1 / radius^2.
         float3 m_direction;
@@ -50,9 +51,9 @@ ShaderResourceGroup PassSrg : SRG_PerPass
         float3 m_rgbIntensityCandelas;
         float m_cosOuterConeAngle; // cosine of the inner cone angle
         uint m_shadowIndex; 
+        uint m_goboTexIndex;
         float m_affectsGIFactor;
         bool m_affectsGI;
-        float m_padding;
         [[pad_to(16)]] // Here to ensure we pad the struct to 16 in case someone adds incorrect padding
     };
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCulling.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCulling.azsl
@@ -43,7 +43,7 @@ ShaderResourceGroup PassSrg : SRG_PerPass
 
     struct SimpleSpotLight
     {
-        float4x4 m_viewProjectionMatrix;    // Light's view projection matrix. Used for calculate uv for gobo 
+        float4x4 m_viewProjectionMatrix;    // Light's view projection matrix. Used to calculate uv for gobo 
         float3 m_position;
         float m_invAttenuationRadiusSquared; // For a radius at which this light no longer has an effect, 1 / radius^2.
         float3 m_direction;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/SimpleSpotLightFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/SimpleSpotLightFeatureProcessorInterface.h
@@ -37,10 +37,8 @@ namespace AZ
 
             //! Sets the intensity in RGB candela for a given LightHandle.
             virtual void SetRgbIntensity(LightHandle handle, const PhotometricColor<PhotometricUnitType>& lightColor) = 0;
-            //! Sets the position for a given LightHandle.
-            virtual void SetPosition(LightHandle handle, const AZ::Vector3& lightPosition) = 0;
-            //! Sets the direction for a given LightHandle.
-            virtual void SetDirection(LightHandle handle, const AZ::Vector3& lightDirection) = 0;
+            //! Sets the light's transformation for a given LightHandle.
+            virtual void SetTransform(LightHandle handle, const AZ::Transform& transform) = 0;
             //! Sets the radius in meters at which the provided LightHandle will no longer have an effect.
             virtual void SetAttenuationRadius(LightHandle handle, float attenuationRadius) = 0;
             //! Sets the inner and outer cone angles in radians.

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/SimpleSpotLightFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/SimpleSpotLightFeatureProcessorInterface.h
@@ -49,6 +49,8 @@ namespace AZ
             virtual void SetAffectsGI(LightHandle handle, bool affectsGI) = 0;
             //! Specifies the contribution of this light to the diffuse global illumination in the scene.
             virtual void SetAffectsGIFactor(LightHandle handle, float affectsGIFactor) = 0;
+            //! Set a gobo texture to the light
+            virtual void SetGoboTexture(LightHandle handle, AZ::Data::Instance<AZ::RPI::Image> goboTexture) = 0;
 
             // Shadow Settings
 

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/SimpleSpotLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/SimpleSpotLightFeatureProcessor.cpp
@@ -174,6 +174,7 @@ namespace AZ
                     {
                         if (currentIdx >= MaxGoboTextureCount)
                         {
+                            AZ_WarningOnce("SimpleSpotLight", false, "There are more than %d (MaxGoboTextureCount) gobo textures used in the level.", MaxGoboTextureCount);
                             break;
                         }
                         m_goboTextures.push_back(item.first);
@@ -373,7 +374,7 @@ namespace AZ
             float halfFov = acosf(lightData.m_cosOuterConeAngle);
             float attenuationRadius = LightCommon::GetRadiusFromInvRadiusSquared(lightData.m_invAttenuationRadiusSquared);
             attenuationRadius = AZStd::max(0.02f, attenuationRadius);
-            MakePerspectiveFovMatrixRH(viewToClipMatrix, halfFov * 2, 1.0f, 0.01f, attenuationRadius, false);
+            MakePerspectiveFovMatrixRH(viewToClipMatrix, halfFov * 2.0f, 1.0f, 0.01f, attenuationRadius, false);
 
             auto& extraData = m_lightData.GetData<1>(handle.GetIndex());
             AZ::Matrix4x4 worldMatrix = AZ::Matrix4x4::CreateFromTransform(extraData.m_transform).GetInverseFast();

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/SimpleSpotLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/SimpleSpotLightFeatureProcessor.cpp
@@ -147,19 +147,19 @@ namespace AZ
                 if (m_goboArrayChanged)
                 {
                     // collect all gobo textures and assign index for each spot light
-                    AZStd::unordered_map<AZ::Data::Instance<AZ::RPI::Image>, int> gobos;
+                    AZStd::unordered_map<AZ::Data::Instance<AZ::RPI::Image>, int> gobosTextures;
 
                     for (int32_t idx = 0; idx < m_lightData.GetDataCount(); idx++)
                     {
                         auto& lightData = m_lightData.GetData<0>(idx);
-                        auto image = m_lightData.GetData<1>(idx).m_gobo;
+                        auto image = m_lightData.GetData<1>(idx).m_goboTexture;
                         if (image)
                         {
-                            if (gobos.find(image) == gobos.end())
+                            if (gobosTextures.find(image) == gobosTextures.end())
                             {
-                                gobos[image] = aznumeric_cast<int>(gobos.size());
+                                gobosTextures[image] = aznumeric_cast<int>(gobosTextures.size());
                             }
-                            lightData.m_goboTextureIndex = gobos[image];
+                            lightData.m_goboTextureIndex = gobosTextures[image];
                         }
                         else
                         {
@@ -170,7 +170,7 @@ namespace AZ
                     m_goboTextures.clear();
                     int32_t currentIdx = 0;
                     // add gobo textures to the vector. Limit the max gobo texture count.
-                    for (auto& item : gobos)
+                    for (auto& item : gobosTextures)
                     {
                         if (currentIdx >= MaxGoboTextureCount)
                         {
@@ -318,7 +318,7 @@ namespace AZ
 
         void SimpleSpotLightFeatureProcessor::SetGoboTexture(LightHandle handle, AZ::Data::Instance<AZ::RPI::Image> goboTexture)
         {
-            m_lightData.GetData<1>(handle.GetIndex()).m_gobo = goboTexture;
+            m_lightData.GetData<1>(handle.GetIndex()).m_goboTexture = goboTexture;
             m_deviceBufferNeedsUpdate = true;
             m_goboArrayChanged = true;
         }

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/SimpleSpotLightFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/SimpleSpotLightFeatureProcessor.h
@@ -25,7 +25,7 @@ namespace AZ
 
     namespace Render
     {
-        static const uint8_t MaxGoboTextureCount = 8;
+        static const uint8_t MaxGoboTextureCount = 5;
 
         struct SimpleSpotLightData
         {
@@ -107,11 +107,11 @@ namespace AZ
             // Cull the lights for a view using the CPU.
             void CullLights(const RPI::ViewPtr& view);
 
-            // Extra light data which are not used directly by the gpu shader
+            // Extra light data which is not used directly by the gpu shader
             struct ExtraData
             {
                 MeshCommon::BoundsVariant m_boundsVariant;
-                AZ::Data::Instance<AZ::RPI::Image> m_gobo;
+                AZ::Data::Instance<AZ::RPI::Image> m_goboTexture;
                 Transform m_transform;
             };
 
@@ -119,6 +119,7 @@ namespace AZ
             GpuBufferHandler m_lightBufferHandler;
             RHI::Handle<uint32_t> m_lightMeshFlag;
             RHI::Handle<uint32_t> m_shadowMeshFlag;
+            RHI::Handle<uint32_t> m_goboTextureFlag;
             bool m_deviceBufferNeedsUpdate = false;
 
             RHI::ShaderInputNameIndex m_goboTexturesIndex = "m_goboTextures";

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/SimpleSpotLightFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/SimpleSpotLightFeatureProcessor.h
@@ -25,6 +25,7 @@ namespace AZ
 
     namespace Render
     {
+        static const uint8_t MaxGoboTextureCount = 8;
 
         struct SimpleSpotLightData
         {
@@ -36,10 +37,9 @@ namespace AZ
             float m_cosOuterConeAngle = 0.0f; // Cosine of the outer cone angle
 
             uint16_t m_shadowIndex = std::numeric_limits<uint16_t>::max(); // index for ProjectedShadowData. A value of 0xFFFF indicates an illegal index.
-
+            uint32_t m_goboTextureIndex = MaxGoboTextureCount; // index for m_goboTextures.
             float m_affectsGIFactor = 1.0f;
             bool m_affectsGI = true;
-            float m_padding0 = 0.0f;
         };
 
         class SimpleSpotLightFeatureProcessor final
@@ -79,6 +79,7 @@ namespace AZ
             void SetFilteringSampleCount(LightHandle handle, uint16_t count) override;
             void SetEsmExponent(LightHandle handle, float esmExponent) override;
             void SetUseCachedShadows(LightHandle handle, bool useCachedShadows) override;
+            void SetGoboTexture(LightHandle handle, AZ::Data::Instance<AZ::RPI::Image> goboTexture) override;
 
             const Data::Instance<RPI::Buffer>  GetLightBuffer() const;
             uint32_t GetLightCount()const;
@@ -104,11 +105,13 @@ namespace AZ
             // Cull the lights for a view using the CPU.
             void CullLights(const RPI::ViewPtr& view);
 
-            MultiIndexedDataVector<SimpleSpotLightData, MeshCommon::BoundsVariant> m_lightData;
+            MultiIndexedDataVector<SimpleSpotLightData, MeshCommon::BoundsVariant, AZ::Data::Instance<AZ::RPI::Image>> m_lightData;
             GpuBufferHandler m_lightBufferHandler;
             RHI::Handle<uint32_t> m_lightMeshFlag;
             RHI::Handle<uint32_t> m_shadowMeshFlag;
             bool m_deviceBufferNeedsUpdate = false;
+            RHI::ShaderInputNameIndex m_goboTexturesIndex = "m_bogoTextures";
+            AZStd::vector<AZ::Data::Instance<AZ::RPI::Image>> m_goboTextures;
 
             ProjectedShadowFeatureProcessor* m_shadowFeatureProcessor = nullptr;
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/CoreLights/AreaLightComponentConfig.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/CoreLights/AreaLightComponentConfig.h
@@ -12,6 +12,7 @@
 #include <AzCore/Math/Color.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <Atom/Feature/CoreLights/PhotometricValue.h>
+#include <Atom/RPI.Reflect/Image/StreamingImageAsset.h>
 #include <AtomLyIntegration/CommonFeatures/CoreLights/CoreLightsConstants.h>
 
 namespace AZ
@@ -55,6 +56,7 @@ namespace AZ
             bool m_lightEmitsBothDirections = false;
             bool m_useFastApproximation = false;
             AZ::Crc32 m_shapeType;
+            AZ::Data::Asset<AZ::RPI::StreamingImageAsset> m_goboImageAsset;
 
             bool m_enableShutters = false;
             LightType m_lightType = LightType::Unknown;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/CoreLights/AreaLightComponentConfig.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/CoreLights/AreaLightComponentConfig.h
@@ -135,6 +135,9 @@ namespace AZ
             
             //! Returns true if exponential shadow maps are disabled.
             bool IsEsmDisabled() const;
+
+            //! Returns true if the light type supports gobo texture
+            bool SupportsGobo() const;
         };
     }
 }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/AreaLightComponentConfig.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/AreaLightComponentConfig.cpp
@@ -200,5 +200,10 @@ namespace AZ
             return ShadowsDisabled() ||
                 !(m_shadowFilterMethod == ShadowFilterMethod::Esm || m_shadowFilterMethod == ShadowFilterMethod::EsmPcf);
         }
+
+        bool AreaLightComponentConfig::SupportsGobo() const
+        {
+            return m_lightType == LightType::SimpleSpot;
+        }
     }
 }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/AreaLightComponentConfig.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/AreaLightComponentConfig.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AtomLyIntegration/CommonFeatures/CoreLights/AreaLightComponentConfig.h>
+#include <AzCore/Asset/AssetSerializer.h>
 #include <AzCore/std/limits.h>
 
 namespace AZ
@@ -18,7 +19,7 @@ namespace AZ
             if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
             {
                 serializeContext->Class<AreaLightComponentConfig, ComponentConfig>()
-                    ->Version(8) // Added AffectsGI
+                    ->Version(9) // Added m_goboImageAsset
                     ->Field("LightType", &AreaLightComponentConfig::m_lightType)
                     ->Field("Color", &AreaLightComponentConfig::m_color)
                     ->Field("IntensityMode", &AreaLightComponentConfig::m_intensityMode)
@@ -27,6 +28,7 @@ namespace AZ
                     ->Field("AttenuationRadius", &AreaLightComponentConfig::m_attenuationRadius)
                     ->Field("LightEmitsBothDirections", &AreaLightComponentConfig::m_lightEmitsBothDirections)
                     ->Field("UseFastApproximation", &AreaLightComponentConfig::m_useFastApproximation)
+                    ->Field("GoboAsset", &AreaLightComponentConfig::m_goboImageAsset)
                     // Shutters
                     ->Field("EnableShutters", &AreaLightComponentConfig::m_enableShutters)
                     ->Field("InnerShutterAngleDegrees", &AreaLightComponentConfig::m_innerShutterAngleDegrees)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/AreaLightComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/AreaLightComponentController.cpp
@@ -15,6 +15,7 @@
 #include <CoreLights/SimpleSpotLightDelegate.h>
 #include <CoreLights/SphereLightDelegate.h>
 #include <Atom/Feature/CoreLights/PhotometricValue.h>
+#include <Atom/RPI.Public/Image/StreamingImage.h>
 
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/EditContext.h>
@@ -268,6 +269,12 @@ namespace AZ::Render
             m_lightShapeDelegate->SetUseFastApproximation(m_configuration.m_useFastApproximation);
             m_lightShapeDelegate->SetAffectsGI(m_configuration.m_affectsGI);
             m_lightShapeDelegate->SetAffectsGIFactor(m_configuration.m_affectsGIFactor);
+            AZ::Data::Instance<AZ::RPI::StreamingImage> image = nullptr;
+            if (m_configuration.m_goboImageAsset.GetId().IsValid())
+            {
+                image = AZ::RPI::StreamingImage::FindOrCreate(m_configuration.m_goboImageAsset);
+            }
+            m_lightShapeDelegate->SetGoboTexture(image);
         }
     }
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorAreaLightComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorAreaLightComponent.cpp
@@ -90,6 +90,8 @@ namespace AZ
                             ->Attribute(Edit::Attributes::Visibility, &AreaLightComponentConfig::SupportsBothDirections)
                         ->DataElement(Edit::UIHandlers::CheckBox, &AreaLightComponentConfig::m_useFastApproximation, "Fast approximation", "Whether the light should use the default high quality linear transformed cosine technique or a faster approximation.")
                             ->Attribute(Edit::Attributes::Visibility, &AreaLightComponentConfig::SupportsFastApproximation)
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &AreaLightComponentConfig::m_goboImageAsset, "Gobo", "Select a texture to be used as gobo")
+                            ->Attribute(Edit::Attributes::Visibility, &AreaLightComponentConfig::SupportsGobo)
                         ->ClassElement(Edit::ClassElements::Group, "Attenuation radius")
                             ->Attribute(Edit::Attributes::AutoExpand, true)
                             ->Attribute(Edit::Attributes::Visibility, &AreaLightComponentConfig::LightTypeIsSelected)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/LightDelegateBase.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/LightDelegateBase.h
@@ -64,6 +64,8 @@ namespace AZ
             void SetAffectsGI([[maybe_unused]] bool affectsGI) override {}
             void SetAffectsGIFactor([[maybe_unused]] float affectsGIFactor) override {}
 
+            void SetGoboTexture([[maybe_unused]] AZ::Data::Instance<AZ::RPI::Image> goboTexture) override {}
+
         protected:
             void InitBase(EntityId entityId);
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/LightDelegateInterface.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/LightDelegateInterface.h
@@ -10,7 +10,9 @@
 
 #include <Atom/Feature/CoreLights/PhotometricValue.h>
 #include <Atom/Feature/CoreLights/ShadowConstants.h>
+#include <AtomCore/Instance/Instance.h>
 #include <AzCore/Component/TransformBus.h>
+
 
 namespace AzFramework
 {
@@ -23,6 +25,11 @@ namespace AZ
     class Transform;
     class Aabb;
 
+    namespace RPI
+    {
+        class Image;
+    }
+    
     namespace Render
     {
         //! Delegate for managing light shape specific functionality in the AreaLightComponentController.
@@ -59,6 +66,9 @@ namespace AZ
                 const Transform& transform, const Color& color, AzFramework::DebugDisplayRequests& debugDisplay, bool isSelected) const = 0;
             //! Turns the visibility of this light on/off.
             virtual void SetVisibility(bool visibility) = 0;
+
+            // gobo
+            virtual void SetGoboTexture(AZ::Data::Instance<AZ::RPI::Image> goboTexture) = 0;
 
             // Shutters
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/SimpleSpotLightDelegate.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/SimpleSpotLightDelegate.cpp
@@ -185,4 +185,13 @@ namespace AZ::Render
                 GetLightHandle(), cachingMode == AreaLightComponentConfig::ShadowCachingMode::UpdateOnChange);
         }
     }
+
+    void SimpleSpotLightDelegate::SetGoboTexture(AZ::Data::Instance<AZ::RPI::Image> goboTexture)
+    {
+        if (GetLightHandle().IsValid())
+        {
+            GetFeatureProcessor()->SetGoboTexture(GetLightHandle(), goboTexture);
+        }
+    }
+
 } // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/SimpleSpotLightDelegate.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/SimpleSpotLightDelegate.cpp
@@ -22,8 +22,7 @@ namespace AZ::Render
     {
         if (GetLightHandle().IsValid())
         {
-            GetFeatureProcessor()->SetDirection(GetLightHandle(), GetTransform().GetBasisZ());
-            GetFeatureProcessor()->SetPosition(GetLightHandle(), GetTransform().GetTranslation());
+            GetFeatureProcessor()->SetTransform(GetLightHandle(), GetTransform());
         }
     }
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/SimpleSpotLightDelegate.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/SimpleSpotLightDelegate.h
@@ -44,6 +44,7 @@ namespace AZ::Render
         void SetEsmExponent(float exponent) override;
         void SetNormalShadowBias(float bias) override;
         void SetShadowCachingMode(AreaLightComponentConfig::ShadowCachingMode cachingMode) override;
+        void SetGoboTexture(AZ::Data::Instance<AZ::RPI::Image> goboTexture) override;
 
     private:
         void HandleShapeChanged() override;


### PR DESCRIPTION
## What does this PR do?
Add Gobo support to simple spot light.
The gobo texture can be selected in light component after select light type to Simple Spot. 
There is a limitation of maximum 8 gobo textures in a level. But it can be changed to a different number (defines in shader and in code). 

## How was this PR tested?
Editor with MobileRenderPipeline enabled. 

![image](https://github.com/carbonated-dev/o3de/assets/55564570/cd8a2569-2858-4c53-af0a-b5727c4c1885)

