### PR TITLE
Fix crash when renderpipeline is null

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/Silhouette_DepthState.lua
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/Silhouette_DepthState.lua
@@ -16,19 +16,19 @@ function GetMaterialPropertyDependencies()
         }
 end
 
-SilhouetteType_AlwaysDraw = 0
-SilhouetteType_Visible = 1
-SilhouetteType_XRay = 2
-SilhouetteType_NeverDraw = 3
+local SilhouetteType_AlwaysDraw = 0
+local SilhouetteType_Visible = 1
+local SilhouetteType_XRay = 2
+local SilhouetteType_NeverDraw = 3
 
-ComparisonFunc_Never = 0
-ComparisonFunc_Less = 1
-ComparisonFunc_Equal = 2
-ComparisonFunc_LessEqual = 3
-ComparisonFunc_Greater = 4
-ComparisonFunc_NotEqual = 5
-ComparisonFunc_GreaterEqual = 6
-ComparisonFunc_Always = 7
+local ComparisonFunc_Never = 0
+local ComparisonFunc_Less = 1
+local ComparisonFunc_Equal = 2
+local ComparisonFunc_LessEqual = 3
+local ComparisonFunc_Greater = 4
+local ComparisonFunc_NotEqual = 5
+local ComparisonFunc_GreaterEqual = 6
+local ComparisonFunc_Always = 7
 
 function Process(context)
     local silhouetteType = context:GetMaterialPropertyValue_enum("silhouetteType")

--- a/Gems/Atom/Feature/Common/Assets/Passes/Silhouette.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/Silhouette.pass
@@ -17,7 +17,7 @@
                     "ShaderInputName": "m_silhouettes",
                     "SlotType": "Input",
                     "ScopeAttachmentUsage": "Shader"
-                }                 
+                }
             ],
             "PassData": {
                 "$type": "FullscreenTrianglePassData",

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Silhouette/SilhouetteGather.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Silhouette/SilhouetteGather.shader
@@ -10,7 +10,7 @@
         "Stencil" :
         {
             "Enable" : true,
-            "ReadMask" : "0x40",
+            "ReadMask" : "0x40", // Needs to match BlockSilhouettes in RenderCommon.h
             "WriteMask" : "0x0",
             "FrontFace" :
             {

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/RenderCommon.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/RenderCommon.h
@@ -42,6 +42,7 @@ namespace AZ
             // The MeshFeatureProcessor sets this stencil bit on any geometry that should block silhouettes in the SilhouetteGather pass. 
             //
             // Used in pass range: Forward -> Silhouette
+            // This setting needs to match the Stencil ReadMask in SilhouetteGather.shader
             const uint32_t BlockSilhouettes = 0x40;
 
             // UseDiffuseGIPass

--- a/Gems/Atom/Feature/Common/Code/Source/Silhouette/SilhouetteFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Silhouette/SilhouetteFeatureProcessor.cpp
@@ -83,7 +83,7 @@ namespace AZ::Render
     {
         if (auto scene = GetParentScene(); scene != nullptr)
         {
-            if (m_compositePass && m_rasterPass)
+            if (m_compositePass && m_rasterPass && m_rasterPass->GetRenderPipeline())
             {
                 // Get DrawList from the dynamic draw interface and view
                 AZStd::vector<RHI::DrawListView> drawLists = AZ::RPI::DynamicDrawInterface::Get()->GetDrawListsForPass(m_rasterPass);


### PR DESCRIPTION
## What does this PR do?

- Fixes a crash in the rare cases when the renderpipeline is null.  This caused a crash in one of our Editor test cases when entering/exiting game mode.

## How was this PR tested?

- verified the test doesn't crash anymore
