### PR TITLE
Drag right gesture

### DIFF
--- a/Gems/Gestures/Code/Include/Gestures/GestureRecognizerDragRight.h
+++ b/Gems/Gestures/Code/Include/Gestures/GestureRecognizerDragRight.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include "IGestureRecognizer.h"
+
+#include <AzCore/RTTI/ReflectContext.h>
+#include <AzCore/Time/ITime.h>
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+namespace Gestures
+{
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+    class RecognizerDragRight : public RecognizerContinuous
+    {
+    public:
+        static float GetDefaultMinSecondsHeld() { return 0.0f; }
+        static float GetDefaultMinPixelsMoved() { return 20.0f; }
+        static uint32_t GetDefaultPointerIndex() { return 1; }
+        static int32_t GetDefaultPriority() { return AzFramework::InputChannelEventListener::GetPriorityUI() + 1; }
+
+        struct Config
+        {
+            AZ_CLASS_ALLOCATOR(Config, AZ::SystemAllocator);
+            AZ_RTTI(Config, "{E8D7DAF7-5D96-4255-9FF1-CCD05F902AC4}");
+            static void Reflect(AZ::ReflectContext* context);
+
+            Config()
+                : minSecondsHeld(GetDefaultMinSecondsHeld())
+                , minPixelsMoved(GetDefaultMinPixelsMoved())
+                , pointerIndex(GetDefaultPointerIndex())
+                , priority(GetDefaultPriority())
+            {}
+            virtual ~Config() = default;
+
+            float minSecondsHeld;
+            float minPixelsMoved;
+            uint32_t pointerIndex;
+            int32_t priority;
+        };
+        static const Config& GetDefaultConfig() { static Config s_cfg; return s_cfg; }
+
+        AZ_CLASS_ALLOCATOR(RecognizerDragRight, AZ::SystemAllocator);
+        AZ_RTTI(RecognizerDragRight, "{98764FEB-B996-4EA3-BA24-B360F4038B8E}", RecognizerContinuous);
+
+        explicit RecognizerDragRight(const Config& config = GetDefaultConfig());
+        ~RecognizerDragRight() override;
+
+        int32_t GetPriority() const override { return m_config.priority; }
+        bool OnPressedEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex) override;
+        bool OnDownEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex) override;
+        bool OnReleasedEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex) override;
+
+        Config& GetConfig() { return m_config; }
+        const Config& GetConfig() const { return m_config; }
+        void SetConfig(const Config& config) { m_config = config; }
+
+        AZ::Vector2 GetStartPosition() const { return m_startPosition; }
+        AZ::Vector2 GetCurrentPosition() const { return m_currentPosition; }
+
+        AZ::Vector2 GetDelta() const { return GetCurrentPosition() - GetStartPosition(); }
+        float GetDistance() const { return GetCurrentPosition().GetDistance(GetStartPosition()); }
+
+    private:
+        enum class State
+        {
+            Idle,
+            Pressed,
+            Dragging
+        };
+
+        Config m_config;
+
+        AZ::TimeMs m_startTime;
+        ScreenPosition m_startPosition;
+        ScreenPosition m_currentPosition;
+
+        State m_currentState;
+    };
+}
+
+// Include the implementation inline so the class can be instantiated outside of the gem.
+#include <Gestures/GestureRecognizerDragRight.inl>

--- a/Gems/Gestures/Code/Include/Gestures/GestureRecognizerDragRight.h
+++ b/Gems/Gestures/Code/Include/Gestures/GestureRecognizerDragRight.h
@@ -7,16 +7,22 @@
  */
 #pragma once
 
+// Add the DragRight gesture
+#if defined(CARBONATED)
+
 #include "IGestureRecognizer.h"
 
+#include <AzCore/Memory/Memory.h>
 #include <AzCore/RTTI/ReflectContext.h>
 #include <AzCore/Time/ITime.h>
+
+#include "GestureRecognizerDrag.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 namespace Gestures
 {
     ////////////////////////////////////////////////////////////////////////////////////////////////
-    class RecognizerDragRight : public RecognizerContinuous
+    class RecognizerDragRight : public RecognizerDrag
     {
     public:
         static float GetDefaultMinSecondsHeld() { return 0.0f; }
@@ -24,65 +30,35 @@ namespace Gestures
         static uint32_t GetDefaultPointerIndex() { return 1; }
         static int32_t GetDefaultPriority() { return AzFramework::InputChannelEventListener::GetPriorityUI() + 1; }
 
-        struct Config
+        struct Config : public RecognizerDrag::Config
         {
             AZ_CLASS_ALLOCATOR(Config, AZ::SystemAllocator);
-            AZ_RTTI(Config, "{E8D7DAF7-5D96-4255-9FF1-CCD05F902AC4}");
+            AZ_RTTI(Config, "{E8D7DAF7-5D96-4255-9FF1-CCD05F902AC4}", RecognizerDrag::Config);
             static void Reflect(AZ::ReflectContext* context);
 
             Config()
-                : minSecondsHeld(GetDefaultMinSecondsHeld())
-                , minPixelsMoved(GetDefaultMinPixelsMoved())
-                , pointerIndex(GetDefaultPointerIndex())
-                , priority(GetDefaultPriority())
-            {}
+            {
+                minSecondsHeld = GetDefaultMinSecondsHeld();
+                minPixelsMoved = GetDefaultMinPixelsMoved();
+                pointerIndex = GetDefaultPointerIndex();
+                priority = GetDefaultPriority();
+            }
             virtual ~Config() = default;
-
-            float minSecondsHeld;
-            float minPixelsMoved;
-            uint32_t pointerIndex;
-            int32_t priority;
         };
         static const Config& GetDefaultConfig() { static Config s_cfg; return s_cfg; }
 
         AZ_CLASS_ALLOCATOR(RecognizerDragRight, AZ::SystemAllocator);
-        AZ_RTTI(RecognizerDragRight, "{98764FEB-B996-4EA3-BA24-B360F4038B8E}", RecognizerContinuous);
+        AZ_RTTI(RecognizerDragRight, "{98764FEB-B996-4EA3-BA24-B360F4038B8E}", RecognizerDrag);
 
         explicit RecognizerDragRight(const Config& config = GetDefaultConfig());
         ~RecognizerDragRight() override;
 
-        int32_t GetPriority() const override { return m_config.priority; }
-        bool OnPressedEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex) override;
-        bool OnDownEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex) override;
-        bool OnReleasedEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex) override;
-
-        Config& GetConfig() { return m_config; }
-        const Config& GetConfig() const { return m_config; }
-        void SetConfig(const Config& config) { m_config = config; }
-
-        AZ::Vector2 GetStartPosition() const { return m_startPosition; }
-        AZ::Vector2 GetCurrentPosition() const { return m_currentPosition; }
-
-        AZ::Vector2 GetDelta() const { return GetCurrentPosition() - GetStartPosition(); }
-        float GetDistance() const { return GetCurrentPosition().GetDistance(GetStartPosition()); }
-
     private:
-        enum class State
-        {
-            Idle,
-            Pressed,
-            Dragging
-        };
-
         Config m_config;
-
-        AZ::TimeMs m_startTime;
-        ScreenPosition m_startPosition;
-        ScreenPosition m_currentPosition;
-
-        State m_currentState;
     };
 }
 
 // Include the implementation inline so the class can be instantiated outside of the gem.
 #include <Gestures/GestureRecognizerDragRight.inl>
+
+#endif

--- a/Gems/Gestures/Code/Include/Gestures/GestureRecognizerDragRight.inl
+++ b/Gems/Gestures/Code/Include/Gestures/GestureRecognizerDragRight.inl
@@ -8,6 +8,9 @@
 
 #pragma once
 
+// Add the DragRight gesture
+#if defined(CARBONATED)
+
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <CryCommon/ISystem.h>
@@ -46,11 +49,7 @@ inline void Gestures::RecognizerDragRight::Config::Reflect(AZ::ReflectContext* c
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 inline Gestures::RecognizerDragRight::RecognizerDragRight(const Config& config)
-    : m_config(config)
-    , m_startTime(AZ::Time::ZeroTimeMs)
-    , m_startPosition()
-    , m_currentPosition()
-    , m_currentState(State::Idle)
+    : RecognizerDrag(config)
 {
 }
 
@@ -59,132 +58,4 @@ inline Gestures::RecognizerDragRight::~RecognizerDragRight()
 {
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-inline bool Gestures::RecognizerDragRight::OnPressedEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex)
-{
-    CryLog(
-        "RecognizerDragRight::OnPressedEvent screenPosition (%f, %f) pointerIndex %ul m_config.pointerIndex %ul",
-        screenPosition.GetX(),
-        screenPosition.GetY(),
-        pointerIndex,
-        m_config.pointerIndex);
-
-    if (pointerIndex != m_config.pointerIndex)
-    {
-        return false;
-    }
-
-    switch (m_currentState)
-    {
-    case State::Idle:
-    {
-        m_startTime = AZ::GetRealElapsedTimeMs();
-        m_startPosition = screenPosition;
-        m_currentPosition = screenPosition;
-        m_currentState = State::Pressed;
-    }
-    break;
-    case State::Pressed:
-    case State::Dragging:
-    default:
-    {
-        // Should not be possible, but not fatal if we happen to get here somehow.
-        AZ_Warning("RecognizerDragRight", false, "RecognizerDragRight::OnPressedEvent state logic failure");
-    }
-    break;
-    }
-
-    return false;
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-inline bool Gestures::RecognizerDragRight::OnDownEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex)
-{
-    CryLog(
-        "RecognizerDragRight::OnDownEvent screenPosition (%f, %f) pointerIndex %ul m_config.pointerIndex %ul",
-        screenPosition.GetX(),
-        screenPosition.GetY(),
-        pointerIndex,
-        m_config.pointerIndex);
-
-    if (pointerIndex != m_config.pointerIndex)
-    {
-        return false;
-    }
-
-    m_currentPosition = screenPosition;
-
-    switch (m_currentState)
-    {
-    case State::Pressed:
-    {
-        const AZ::TimeMs currentTime = AZ::GetRealElapsedTimeMs();
-        if ((AZ::TimeMsToSeconds(currentTime - m_startTime) >= m_config.minSecondsHeld) &&
-            (GetDistance() >= m_config.minPixelsMoved))
-        {
-            m_startTime = currentTime;
-            m_startPosition = m_currentPosition;
-            OnContinuousGestureInitiated();
-            m_currentState = State::Dragging;
-        }
-    }
-    break;
-    case State::Dragging:
-    {
-        OnContinuousGestureUpdated();
-    }
-    break;
-    case State::Idle:
-    default:
-    {
-        // Should not be possible, but not fatal if we happen to get here somehow.
-        AZ_Warning("RecognizerDragRight", false, "RecognizerDragRight::OnDownEvent state logic failure");
-    }
-    break;
-    }
-
-    return false;
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-inline bool Gestures::RecognizerDragRight::OnReleasedEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex)
-{
-    CryLog(
-        "RecognizerDragRight::OnReleasedEvent screenPosition (%f, %f) pointerIndex %ul m_config.pointerIndex %ul",
-        screenPosition.GetX(),
-        screenPosition.GetY(),
-        pointerIndex,
-        m_config.pointerIndex);
-
-    if (pointerIndex != m_config.pointerIndex)
-    {
-        return false;
-    }
-
-    switch (m_currentState)
-    {
-    case State::Pressed:
-    {
-        // We never actually started dragging
-        m_currentPosition = screenPosition;
-        m_currentState = State::Idle;
-    }
-    break;
-    case State::Dragging:
-    {
-        m_currentPosition = screenPosition;
-        OnContinuousGestureEnded();
-        m_currentState = State::Idle;
-    }
-    break;
-    case State::Idle:
-    default:
-    {
-        // Should not be possible, but not fatal if we happen to get here somehow.
-        AZ_Warning("RecognizerDragRight", false, "RecognizerDragRight::OnReleasedEvent state logic failure");
-    }
-    break;
-    }
-
-    return false;
-}
+#endif

--- a/Gems/Gestures/Code/Source/GesturesSystemComponent.cpp
+++ b/Gems/Gestures/Code/Source/GesturesSystemComponent.cpp
@@ -47,7 +47,10 @@ namespace Gestures
                 ->Version(0)
                 ->Field("DoublePressConfig", &GesturesSystemComponent::m_doublePressConfig)
                 ->Field("DragConfig", &GesturesSystemComponent::m_dragConfig)
+// Add the DragRight gesture
+#if defined(CARBONATED)
                 ->Field("DragRightConfig", &GesturesSystemComponent::m_dragRightConfig)
+#endif
                 ->Field("HoldConfig", &GesturesSystemComponent::m_holdConfig)
                 ->Field("PinchConfig", &GesturesSystemComponent::m_pinchConfig)
                 ->Field("RotateConfig", &GesturesSystemComponent::m_rotateConfig)
@@ -64,8 +67,11 @@ namespace Gestures
                         "Double Press", "The config used to create the default double press gesture input channel.")
                     ->DataElement(0, &GesturesSystemComponent::m_dragConfig,
                         "Drag", "The config used to create the default drag gesture input channel.")
+// Add the DragRight gesture
+#if defined(CARBONATED)
                     ->DataElement(0, &GesturesSystemComponent::m_dragRightConfig,
                         "DragRight", "The config used to create the right drag gesture input channel.")
+#endif
                     ->DataElement(0, &GesturesSystemComponent::m_holdConfig,
                         "Hold", "The config used to create the default hold gesture input channel.")
                     ->DataElement(0, &GesturesSystemComponent::m_pinchConfig,
@@ -114,7 +120,10 @@ namespace Gestures
         InputDeviceGestures::ConfigsByNameMap configsByName;
         configsByName[InputDeviceGestures::Gesture::DoublePress.GetName()] = &m_doublePressConfig;
         configsByName[InputDeviceGestures::Gesture::Drag.GetName()] = &m_dragConfig;
+// Add the DragRight gesture
+#if defined(CARBONATED)
         configsByName[InputDeviceGestures::Gesture::DragRight.GetName()] = &m_dragRightConfig;
+#endif
         configsByName[InputDeviceGestures::Gesture::Hold.GetName()] = &m_holdConfig;
         configsByName[InputDeviceGestures::Gesture::Pinch.GetName()] = &m_pinchConfig;
         configsByName[InputDeviceGestures::Gesture::Rotate.GetName()] = &m_rotateConfig;

--- a/Gems/Gestures/Code/Source/GesturesSystemComponent.cpp
+++ b/Gems/Gestures/Code/Source/GesturesSystemComponent.cpp
@@ -47,6 +47,7 @@ namespace Gestures
                 ->Version(0)
                 ->Field("DoublePressConfig", &GesturesSystemComponent::m_doublePressConfig)
                 ->Field("DragConfig", &GesturesSystemComponent::m_dragConfig)
+                ->Field("DragRightConfig", &GesturesSystemComponent::m_dragRightConfig)
                 ->Field("HoldConfig", &GesturesSystemComponent::m_holdConfig)
                 ->Field("PinchConfig", &GesturesSystemComponent::m_pinchConfig)
                 ->Field("RotateConfig", &GesturesSystemComponent::m_rotateConfig)
@@ -63,6 +64,8 @@ namespace Gestures
                         "Double Press", "The config used to create the default double press gesture input channel.")
                     ->DataElement(0, &GesturesSystemComponent::m_dragConfig,
                         "Drag", "The config used to create the default drag gesture input channel.")
+                    ->DataElement(0, &GesturesSystemComponent::m_dragRightConfig,
+                        "DragRight", "The config used to create the right drag gesture input channel.")
                     ->DataElement(0, &GesturesSystemComponent::m_holdConfig,
                         "Hold", "The config used to create the default hold gesture input channel.")
                     ->DataElement(0, &GesturesSystemComponent::m_pinchConfig,
@@ -111,6 +114,7 @@ namespace Gestures
         InputDeviceGestures::ConfigsByNameMap configsByName;
         configsByName[InputDeviceGestures::Gesture::DoublePress.GetName()] = &m_doublePressConfig;
         configsByName[InputDeviceGestures::Gesture::Drag.GetName()] = &m_dragConfig;
+        configsByName[InputDeviceGestures::Gesture::DragRight.GetName()] = &m_dragRightConfig;
         configsByName[InputDeviceGestures::Gesture::Hold.GetName()] = &m_holdConfig;
         configsByName[InputDeviceGestures::Gesture::Pinch.GetName()] = &m_pinchConfig;
         configsByName[InputDeviceGestures::Gesture::Rotate.GetName()] = &m_rotateConfig;

--- a/Gems/Gestures/Code/Source/GesturesSystemComponent.h
+++ b/Gems/Gestures/Code/Source/GesturesSystemComponent.h
@@ -15,6 +15,7 @@
 
 #include "InputChannelGestureClickOrTap.h"
 #include "InputChannelGestureDrag.h"
+#include "InputChannelGestureDragRight.h"
 #include "InputChannelGestureHold.h"
 #include "InputChannelGesturePinch.h"
 #include "InputChannelGestureRotate.h"
@@ -71,6 +72,7 @@ namespace Gestures
         //! The config used to create a default gesture input channel
         InputChannelGestureClickOrTap::TypeAndConfig m_doublePressConfig;
         InputChannelGestureDrag::TypeAndConfig       m_dragConfig;
+        InputChannelGestureDragRight::TypeAndConfig       m_dragRightConfig;
         InputChannelGestureHold::TypeAndConfig       m_holdConfig;
         InputChannelGesturePinch::TypeAndConfig      m_pinchConfig;
         InputChannelGestureRotate::TypeAndConfig     m_rotateConfig;

--- a/Gems/Gestures/Code/Source/GesturesSystemComponent.h
+++ b/Gems/Gestures/Code/Source/GesturesSystemComponent.h
@@ -15,7 +15,10 @@
 
 #include "InputChannelGestureClickOrTap.h"
 #include "InputChannelGestureDrag.h"
+// Add the DragRight gesture
+#if defined(CARBONATED)
 #include "InputChannelGestureDragRight.h"
+#endif
 #include "InputChannelGestureHold.h"
 #include "InputChannelGesturePinch.h"
 #include "InputChannelGestureRotate.h"
@@ -72,7 +75,10 @@ namespace Gestures
         //! The config used to create a default gesture input channel
         InputChannelGestureClickOrTap::TypeAndConfig m_doublePressConfig;
         InputChannelGestureDrag::TypeAndConfig       m_dragConfig;
-        InputChannelGestureDragRight::TypeAndConfig       m_dragRightConfig;
+// Add the DragRight gesture
+#if defined(CARBONATED)
+        InputChannelGestureDragRight::TypeAndConfig  m_dragRightConfig;
+#endif
         InputChannelGestureHold::TypeAndConfig       m_holdConfig;
         InputChannelGesturePinch::TypeAndConfig      m_pinchConfig;
         InputChannelGestureRotate::TypeAndConfig     m_rotateConfig;

--- a/Gems/Gestures/Code/Source/InputChannelGestureDragRight.cpp
+++ b/Gems/Gestures/Code/Source/InputChannelGestureDragRight.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "InputChannelGestureDragRight.h"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+namespace Gestures
+{
+    using namespace AzFramework;
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+    void InputChannelGestureDragRight::TypeAndConfig::Reflect(AZ::ReflectContext* context)
+    {
+        if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serialize->Class<TypeAndConfig, Type, Config>()
+                ->Version(0)
+            ;
+
+            if (AZ::EditContext* ec = serialize->GetEditContext())
+            {
+                ec->Class<TypeAndConfig>("DragRight", "Gesture recognizer for drags.")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                ;
+            }
+        }
+
+        RecognizerDragRight::Config::Reflect(context);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+    InputChannelGesture* InputChannelGestureDragRight::TypeAndConfig::CreateInputChannel(
+        const AzFramework::InputChannelId& channelId,
+        const AzFramework::InputDevice& inputDevice)
+    {
+        return aznew InputChannelGestureDragRight(channelId, inputDevice, *this);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+    InputChannelGestureDragRight::InputChannelGestureDragRight(const InputChannelId& inputChannelId,
+                                                     const InputDevice& inputDevice,
+                                                     const Config& config)
+        : InputChannelGesture(inputChannelId, inputDevice)
+        , RecognizerDragRight(config)
+    {
+        RecognizerDragRight::Enable();
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+    InputChannelGestureDragRight::~InputChannelGestureDragRight()
+    {
+        RecognizerDragRight::Disable();
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+    float InputChannelGestureDragRight::GetValue() const
+    {
+        return InputChannel::IsActive() ? GetDistance() : 0.0f;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+    const InputChannel::CustomData* InputChannelGestureDragRight::GetCustomData() const
+    {
+        return this;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+    void InputChannelGestureDragRight::OnContinuousGestureInitiated()
+    {
+        UpdateNormalizedPositionAndDeltaFromScreenPosition(GetCurrentPosition());
+        InputChannel::UpdateState(true);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+    void InputChannelGestureDragRight::OnContinuousGestureUpdated()
+    {
+        UpdateNormalizedPositionAndDeltaFromScreenPosition(GetCurrentPosition());
+        InputChannel::UpdateState(true);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+    void InputChannelGestureDragRight::OnContinuousGestureEnded()
+    {
+        UpdateNormalizedPositionAndDeltaFromScreenPosition(GetCurrentPosition());
+        InputChannel::UpdateState(false);
+    }
+} // namespace Gestures

--- a/Gems/Gestures/Code/Source/InputChannelGestureDragRight.cpp
+++ b/Gems/Gestures/Code/Source/InputChannelGestureDragRight.cpp
@@ -6,6 +6,9 @@
  *
  */
 
+// Add the DragRight gesture
+#if defined(CARBONATED)
+
 #include "InputChannelGestureDragRight.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -91,3 +94,5 @@ namespace Gestures
         InputChannel::UpdateState(false);
     }
 } // namespace Gestures
+
+#endif

--- a/Gems/Gestures/Code/Source/InputChannelGestureDragRight.h
+++ b/Gems/Gestures/Code/Source/InputChannelGestureDragRight.h
@@ -8,6 +8,9 @@
 
 #pragma once
 
+// Add the DragRight gesture
+#if defined(CARBONATED)
+
 #include "InputChannelGesture.h"
 
 #include <Gestures/GestureRecognizerDragRight.h>
@@ -92,3 +95,5 @@ namespace Gestures
         void OnContinuousGestureEnded() override;
     };
 } // namespace Gestures
+
+#endif

--- a/Gems/Gestures/Code/Source/InputChannelGestureDragRight.h
+++ b/Gems/Gestures/Code/Source/InputChannelGestureDragRight.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include "InputChannelGesture.h"
+
+#include <Gestures/GestureRecognizerDragRight.h>
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+namespace Gestures
+{
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+    //! Input channel that recognizes continuous drag gestures.
+    class InputChannelGestureDragRight : public InputChannelGesture
+                                  , public RecognizerDragRight
+    {
+    public:
+        ////////////////////////////////////////////////////////////////////////////////////////////
+        //! The gesture configuration values that are exposed to the editor.
+        struct TypeAndConfig : public Type, public Config
+        {
+        public:
+            ////////////////////////////////////////////////////////////////////////////////////////
+            // Allocator
+            AZ_CLASS_ALLOCATOR(TypeAndConfig, AZ::SystemAllocator);
+
+            ////////////////////////////////////////////////////////////////////////////////////////
+            // Type Info
+            AZ_RTTI(TypeAndConfig, "{B6483887-D937-4458-ADC2-242A112E772D}", Type, Config);
+
+            ////////////////////////////////////////////////////////////////////////////////////////
+            // Reflection
+            static void Reflect(AZ::ReflectContext* context);
+
+        protected:
+            ////////////////////////////////////////////////////////////////////////////////////////
+            //! \ref Gestures::InputChannelGesture::CreateInputChannel
+            InputChannelGesture* CreateInputChannel(const AzFramework::InputChannelId& channelId,
+                                                    const AzFramework::InputDevice& inputDevice) override;
+        };
+
+        ////////////////////////////////////////////////////////////////////////////////////////////
+        // Allocator
+        AZ_CLASS_ALLOCATOR(InputChannelGestureDragRight, AZ::SystemAllocator);
+
+        ////////////////////////////////////////////////////////////////////////////////////////////
+        // Type Info
+        AZ_RTTI(InputChannelGestureDragRight, "{AD19678E-FE79-410D-8256-87FDAEA78099}", InputChannel);
+
+        ////////////////////////////////////////////////////////////////////////////////////////////
+        //! Constructor
+        //! \param[in] inputChannelId Id of the input channel being constructed
+        //! \param[in] inputDevice Input device that owns the input channel
+        //! \param[in] config The configuration used to setup the gesture recognizer base class
+        explicit InputChannelGestureDragRight(const AzFramework::InputChannelId& inputChannelId,
+                                         const AzFramework::InputDevice& inputDevice,
+                                         const Config& config);
+
+        ////////////////////////////////////////////////////////////////////////////////////////////
+        // Disable copying
+        AZ_DISABLE_COPY_MOVE(InputChannelGestureDragRight);
+
+        ////////////////////////////////////////////////////////////////////////////////////////////
+        //! Destructor
+        ~InputChannelGestureDragRight() override;
+
+    protected:
+        ////////////////////////////////////////////////////////////////////////////////////////////
+        //! \ref AzFramework::InputChannel::GetValue
+        float GetValue() const override;
+
+        ////////////////////////////////////////////////////////////////////////////////////////////
+        //! \ref AzFramework::InputChannel::GetCustomData
+        const InputChannel::CustomData* GetCustomData() const override;
+
+        ////////////////////////////////////////////////////////////////////////////////////////////
+        //! \ref Gestures::RecognizerContinuous::OnContinuousGestureInitiated
+        void OnContinuousGestureInitiated() override;
+
+        ////////////////////////////////////////////////////////////////////////////////////////////
+        //! \ref Gestures::RecognizerContinuous::OnContinuousGestureUpdated
+        void OnContinuousGestureUpdated() override;
+
+        ////////////////////////////////////////////////////////////////////////////////////////////
+        //! \ref Gestures::RecognizerContinuous::OnContinuousGestureEnded
+        void OnContinuousGestureEnded() override;
+    };
+} // namespace Gestures

--- a/Gems/Gestures/Code/Source/InputDeviceGestures.cpp
+++ b/Gems/Gestures/Code/Source/InputDeviceGestures.cpp
@@ -38,7 +38,12 @@ namespace Gestures
     const InputChannelId InputDeviceGestures::Gesture::Pinch("gesture_pinch");
     const InputChannelId InputDeviceGestures::Gesture::Rotate("gesture_rotate");
     const InputChannelId InputDeviceGestures::Gesture::Swipe("gesture_swipe");
+// Add the DragRight gesture
+#if defined(CARBONATED)
     const AZStd::array<InputChannelId, 7> InputDeviceGestures::Gesture::All =
+#else
+    const AZStd::array<InputChannelId, 6> InputDeviceGestures::Gesture::All =
+#endif
     {{
         DoublePress,
         Drag,

--- a/Gems/Gestures/Code/Source/InputDeviceGestures.cpp
+++ b/Gems/Gestures/Code/Source/InputDeviceGestures.cpp
@@ -30,14 +30,16 @@ namespace Gestures
     ////////////////////////////////////////////////////////////////////////////////////////////////
     const InputChannelId InputDeviceGestures::Gesture::DoublePress("gesture_double_press");
     const InputChannelId InputDeviceGestures::Gesture::Drag("gesture_drag");
+    const InputChannelId InputDeviceGestures::Gesture::DragRight("gesture_drag_right");
     const InputChannelId InputDeviceGestures::Gesture::Hold("gesture_hold");
     const InputChannelId InputDeviceGestures::Gesture::Pinch("gesture_pinch");
     const InputChannelId InputDeviceGestures::Gesture::Rotate("gesture_rotate");
     const InputChannelId InputDeviceGestures::Gesture::Swipe("gesture_swipe");
-    const AZStd::array<InputChannelId, 6> InputDeviceGestures::Gesture::All =
+    const AZStd::array<InputChannelId, 7> InputDeviceGestures::Gesture::All =
     {{
         DoublePress,
         Drag,
+        DragRight,
         Hold,
         Pinch,
         Rotate,
@@ -66,6 +68,7 @@ namespace Gestures
 
                 ->Constant(Gesture::DoublePress.GetName(), BehaviorConstant(Gesture::DoublePress.GetName()))
                 ->Constant(Gesture::Drag.GetName(), BehaviorConstant(Gesture::Drag.GetName()))
+                ->Constant(Gesture::DragRight.GetName(), BehaviorConstant(Gesture::DragRight.GetName()))
                 ->Constant(Gesture::Hold.GetName(), BehaviorConstant(Gesture::Hold.GetName()))
                 ->Constant(Gesture::Pinch.GetName(), BehaviorConstant(Gesture::Pinch.GetName()))
                 ->Constant(Gesture::Rotate.GetName(), BehaviorConstant(Gesture::Rotate.GetName()))

--- a/Gems/Gestures/Code/Source/InputDeviceGestures.cpp
+++ b/Gems/Gestures/Code/Source/InputDeviceGestures.cpp
@@ -30,7 +30,10 @@ namespace Gestures
     ////////////////////////////////////////////////////////////////////////////////////////////////
     const InputChannelId InputDeviceGestures::Gesture::DoublePress("gesture_double_press");
     const InputChannelId InputDeviceGestures::Gesture::Drag("gesture_drag");
+// Add the DragRight gesture
+#if defined(CARBONATED)
     const InputChannelId InputDeviceGestures::Gesture::DragRight("gesture_drag_right");
+#endif
     const InputChannelId InputDeviceGestures::Gesture::Hold("gesture_hold");
     const InputChannelId InputDeviceGestures::Gesture::Pinch("gesture_pinch");
     const InputChannelId InputDeviceGestures::Gesture::Rotate("gesture_rotate");
@@ -39,7 +42,10 @@ namespace Gestures
     {{
         DoublePress,
         Drag,
+// Add the DragRight gesture
+#if defined(CARBONATED)
         DragRight,
+#endif
         Hold,
         Pinch,
         Rotate,
@@ -68,7 +74,10 @@ namespace Gestures
 
                 ->Constant(Gesture::DoublePress.GetName(), BehaviorConstant(Gesture::DoublePress.GetName()))
                 ->Constant(Gesture::Drag.GetName(), BehaviorConstant(Gesture::Drag.GetName()))
+// Add the DragRight gesture
+#if defined(CARBONATED)
                 ->Constant(Gesture::DragRight.GetName(), BehaviorConstant(Gesture::DragRight.GetName()))
+#endif
                 ->Constant(Gesture::Hold.GetName(), BehaviorConstant(Gesture::Hold.GetName()))
                 ->Constant(Gesture::Pinch.GetName(), BehaviorConstant(Gesture::Pinch.GetName()))
                 ->Constant(Gesture::Rotate.GetName(), BehaviorConstant(Gesture::Rotate.GetName()))

--- a/Gems/Gestures/Code/Source/InputDeviceGestures.h
+++ b/Gems/Gestures/Code/Source/InputDeviceGestures.h
@@ -37,13 +37,14 @@ namespace Gestures
         {
             static const AzFramework::InputChannelId DoublePress;
             static const AzFramework::InputChannelId Drag;
+            static const AzFramework::InputChannelId DragRight;
             static const AzFramework::InputChannelId Hold;
             static const AzFramework::InputChannelId Pinch;
             static const AzFramework::InputChannelId Rotate;
             static const AzFramework::InputChannelId Swipe;
 
             //!< All gesture channel ids
-            static const AZStd::array<AzFramework::InputChannelId, 6> All;
+            static const AZStd::array<AzFramework::InputChannelId, 7> All;
         };
 
         ////////////////////////////////////////////////////////////////////////////////////////////

--- a/Gems/Gestures/Code/Source/InputDeviceGestures.h
+++ b/Gems/Gestures/Code/Source/InputDeviceGestures.h
@@ -37,14 +37,22 @@ namespace Gestures
         {
             static const AzFramework::InputChannelId DoublePress;
             static const AzFramework::InputChannelId Drag;
+// Add the DragRight gesture
+#if defined(CARBONATED)
             static const AzFramework::InputChannelId DragRight;
+#endif
             static const AzFramework::InputChannelId Hold;
             static const AzFramework::InputChannelId Pinch;
             static const AzFramework::InputChannelId Rotate;
             static const AzFramework::InputChannelId Swipe;
 
             //!< All gesture channel ids
+// Add the DragRight gesture
+#if defined(CARBONATED)
             static const AZStd::array<AzFramework::InputChannelId, 7> All;
+#else
+            static const AZStd::array<AzFramework::InputChannelId, 6> All;
+#endif
         };
 
         ////////////////////////////////////////////////////////////////////////////////////////////

--- a/Gems/Gestures/Code/gestures_files.cmake
+++ b/Gems/Gestures/Code/gestures_files.cmake
@@ -11,6 +11,8 @@ set(FILES
     Include/Gestures/GestureRecognizerClickOrTap.inl
     Include/Gestures/GestureRecognizerDrag.h
     Include/Gestures/GestureRecognizerDrag.inl
+    Include/Gestures/GestureRecognizerDragRight.h
+    Include/Gestures/GestureRecognizerDragRight.inl
     Include/Gestures/GestureRecognizerHold.h
     Include/Gestures/GestureRecognizerHold.inl
     Include/Gestures/GestureRecognizerPinch.h
@@ -29,6 +31,8 @@ set(FILES
     Source/InputChannelGestureClickOrTap.h
     Source/InputChannelGestureDrag.cpp
     Source/InputChannelGestureDrag.h
+    Source/InputChannelGestureDragRight.cpp
+    Source/InputChannelGestureDragRight.h
     Source/InputChannelGestureHold.cpp
     Source/InputChannelGestureHold.h
     Source/InputChannelGesturePinch.cpp


### PR DESCRIPTION
## What does this PR do?

Adds the drag right gesture governed by the `pointer #1`.

## How was this PR tested?

Tested locally on Windows (for backwards compatibility) and iOS.
