### PR TITLE
Fixed an issue that InstanceGroupHandle's m_drawPacket may not have DrawPacket created.

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -231,11 +231,12 @@ namespace AZ
             }
             else
             {
-                AZStd::vector<Job*> perInstanceGroupJobQueue = CreatePerInstanceGroupJobQueue();
 
                 ExecuteSimulateJobQueue(initJobQueue, parentJob);
                 // Per-InstanceGroup work must be done after the Init jobs are complete, because the init jobs will determine which instance
                 // group each mesh belongs to and populate those instance groups
+                // Note: the Per-InstanceGroup jobs need to be created after init jobs because it's possible new instance groups created in init jobs
+                AZStd::vector<Job*> perInstanceGroupJobQueue = CreatePerInstanceGroupJobQueue();
                 ExecuteSimulateJobQueue(perInstanceGroupJobQueue, parentJob);
                 // Updating the culling scene must happen after the per-instance group work is done
                 // because the per-instance group work will update the draw packets.


### PR DESCRIPTION
## What does this PR do?
User encountered crash when enter/exit game mode in Editor with CentralPlaza level.
Original repro steps:
1. Start Editor.
2. Open CentralPlaza level
3. Ctrl+G to enter game mode.
4. Esc to leave game mode. 
The crash may happen at step 4. If it didn't happen try step 3 again. 

The PR fix the crash. 

The reason is because when MeshDrawPacket is created. It won't generate m_drawPacket(DrawPacket) until its Update function was called. 
The update should be called in mesh instancing group update. Because the jobs were created before Init jobs, they may miss new groups created in the init jobs. 

This issue was exposed by changes in this PR: https://github.com/carbonated-dev/o3de/pull/163/files

## How was this PR tested?
Tested in Editor with CentralPlaza level

