### PR TITLE
Update O3DE LyShine GEM with missing CARBONATED patches.

### DIFF
--- a/Gems/LyShine/Code/Source/UiCanvasManager.cpp
+++ b/Gems/LyShine/Code/Source/UiCanvasManager.cpp
@@ -175,6 +175,10 @@ AZ::EntityId UiCanvasManager::CreateCanvas()
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 AZ::EntityId UiCanvasManager::LoadCanvas(const AZStd::string& assetIdPathname)
 {
+#if defined(CARBONATED) // Carbonated patch : porting 02_27, to match LY Log // TODO // FIXME : remove for release
+    AZ_TracePrintf("UiCanvasManager", "Loading UI Canvas: %s", assetIdPathname.c_str());
+#endif // CARBONATED
+
     // Prevent canvas from being loaded when we are in the editor in a simulation mode
     // but not in game mode (ex. AI/Physics mode or Preview mode).
     // NOTE: Normal Preview mode load does not come through here since we clone the canvas rather than load it

--- a/Gems/LyShine/Code/Source/UiElementComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiElementComponent.cpp
@@ -1259,7 +1259,12 @@ bool UiElementComponent::FixupPostLoad(AZ::Entity* entity, UiCanvasComponent* ca
         {
             // with slices it is possible for users to get themselves into situations where a child no
             // longer exists, we should report an error in this case rather than asserting
+#if defined(CARBONATED)  // Carbonated patch : porting 02_27, to match LY Log
+            AZ_Error("UI", false,"Child element of Parent %s with Entity ID %llu no longer exists. Data will be lost.",
+                parent ? parent->GetName().c_str() : "(No Parent)", child);
+#else
             AZ_Error("UI", false, "Child element with Entity ID %llu no longer exists. Data will be lost.", child);
+#endif // CARBONATED
             // This case could happen if a slice asset has been deleted. We should try to continue and load the
             // canvas with errors.
             missingChildren.push_back(child);
@@ -1272,7 +1277,12 @@ bool UiElementComponent::FixupPostLoad(AZ::Entity* entity, UiCanvasComponent* ca
             // with slices it is possible for users to get themselves into situations where a child no
             // longer has an element component. In this case report an error and fail to load the data but do not
             // crash.
+#if defined(CARBONATED) // Carbonated patch : porting 02_27, to match LY Log
+            AZ_Error("UI", false, "Child element of Parent %s with Entity ID %llu no longer has a UiElementComponent. Data cannot be loaded.",
+                parent ? parent->GetName().c_str() : "(No Parent)", child);
+#else
             AZ_Error("UI", false, "Child element with Entity ID %llu no longer has a UiElementComponent. Data cannot be loaded.", child);
+#endif // CARBONATED
             return false;
         }
 

--- a/Gems/LyShine/Code/Source/UiTransform2dComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiTransform2dComponent.cpp
@@ -1343,10 +1343,7 @@ void UiTransform2dComponent::Reflect(AZ::ReflectContext* context)
 
             // carbonated begin (alukyanov/lyshine-related)
 #if defined(CARBONATED)
-            editInfo->DataElement(
-                AZ::Edit::UIHandlers::CheckBox,
-                &UiTransform2dComponent::m_isFlooringOffsets,
-                "Floor offsets",
+            editInfo->DataElement(AZ::Edit::UIHandlers::CheckBox, &UiTransform2dComponent::m_isFlooringOffsets, "Floor offsets",
                 "When checked, this element's offsets are floored");
 #endif
             // carbonated end
@@ -1396,6 +1393,10 @@ void UiTransform2dComponent::Reflect(AZ::ReflectContext* context)
             ->Event("SetPivotY", &UiTransformBus::Events::SetPivotY)
             ->Event("GetScaleToDeviceMode", &UiTransformBus::Events::GetScaleToDeviceMode)
             ->Event("SetScaleToDeviceMode", &UiTransformBus::Events::SetScaleToDeviceMode)
+#if defined(CARBONATED) // Carbonated patch : porting 02_27
+            ->Event("GetIsFlooringOffsets", &UiTransformBus::Events::GetIsFlooringOffsets)
+            ->Event("SetIsFlooringOffsets", &UiTransformBus::Events::SetIsFlooringOffsets)
+#endif // CARBONATED
             ->Event("GetViewportPosition", &UiTransformBus::Events::GetViewportPosition)
             ->Event("SetViewportPosition", &UiTransformBus::Events::SetViewportPosition)
             ->Event("GetCanvasPosition", &UiTransformBus::Events::GetCanvasPosition)

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Datum.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Datum.cpp
@@ -2243,7 +2243,10 @@ namespace ScriptCanvas
 
         if (!Data::IsValueType(m_type) && !SatisfiesTraits(static_cast<AZ::u8>(description.m_traits)))
         {
-            return AZ::Failure(AZStd::string("Attempting to convert null value to BehaviorArgument that expects reference or value"));
+            // Carbonated patch begin : porting 02_27
+            //return AZ::Failure(AZStd::string("Attempting to convert null value to BehaviorArgument that expects reference or value"));
+            return AZ::Failure(AZStd::string::format("Attempting to convert null value %s to BehaviorArgument that expects reference or value", description.m_name));
+            // Carbonated patch end
         }
 
         if (IS_A(Data::Type::Number()))


### PR DESCRIPTION
## What does this PR do?
* Updates LyShine Logs to correspond to LY MW Logs (changed by `CARBONATED` patches to LY), under `CARBONATED` define, in 3 lyShine files.
* Adds missing serialization for 2 events previously added to `Gems/LyShine/Code/Source/UiTransform2dComponent.cpp`, under `CARBONATED` define.
* In `Gems/LyShine/Code/Source/UiScrollBoxComponent.cpp`, under `CARBONATED` define:
* * Adds missing serialization for previously added fields; makes use of added `m_scrollSensitivity` field;
* * Adds missing version increment to serialization for added fields;
* * Adds missing `TickBus` connection / disconnection.
* * Fixes minor typo.

## How was this PR tested?
* MW game run in Editor and standalone.
* In AssetProcessor, several UI slices, which previously logged serialization warnings for missing fields, were reprocessed: warnings gone.
