### PR TITLE
Add new DrawScaledTextOnScreen* methods to DebugDrawRequestBus

### DIFF
--- a/Gems/DebugDraw/Code/Include/DebugDraw/DebugDrawBus.h
+++ b/Gems/DebugDraw/Code/Include/DebugDraw/DebugDrawBus.h
@@ -162,7 +162,7 @@ namespace DebugDraw
          * Draws text on the screen with scaled default render font.
          *
          * @param text              Text to be displayed.
-         * @param fontScale         Scale factor to default render font, if <= 0.0f then set to 1.0f.
+         * @param fontScale         Scale factor to default render font.
          * @param color             Color of text.
          * @param duration          How long to display the text for (in seconds); 0 value will draw for one frame; negative values draw forever.
          */
@@ -175,7 +175,7 @@ namespace DebugDraw
          * @param x                 X coordinate.
          * @param y                 Y coordinate.
          * @param text              Text to be displayed.
-         * @param fontScale         Scale factor to default render font, if <= 0.0f then set to 1.0f.
+         * @param fontScale         Scale factor to default render font.
          * @param color             Color of text.
          * @param duration          How long to display the text for (in seconds); 0 value will draw for one frame; negative values draw forever.
          * @param bCenter           If true (default), centers drawn text relative to x coordinate, otherwise text is left-aligned.

--- a/Gems/DebugDraw/Code/Include/DebugDraw/DebugDrawBus.h
+++ b/Gems/DebugDraw/Code/Include/DebugDraw/DebugDrawBus.h
@@ -156,6 +156,35 @@ namespace DebugDraw
          */
         virtual void DrawTextOnScreen([[maybe_unused]] const AZStd::string& text, [[maybe_unused]] const AZ::Color& color, [[maybe_unused]] float duration) {}
 
+// carbonated begin : additional DebugDrawText methods
+#if defined(CARBONATED)
+        /**
+         * Draws text on the screen with scaled default render font.
+         *
+         * @param text              Text to be displayed.
+         * @param fontScale         Scale factor to default render font, if <= 0.0f then set to 1.0f.
+         * @param color             Color of text.
+         * @param duration          How long to display the text for (in seconds); 0 value will draw for one frame; negative values draw forever.
+         */
+        virtual void DrawScaledTextOnScreen([[maybe_unused]] const AZStd::string& text
+            , [[maybe_unused]] float fontScale, [[maybe_unused]] const AZ::Color& color, [[maybe_unused]] float duration) {}
+
+        /**
+         * Draws text on the screen with scaled default render font at given 2D coordinates.
+         *
+         * @param x                 X coordinate.
+         * @param y                 Y coordinate.
+         * @param text              Text to be displayed.
+         * @param fontScale         Scale factor to default render font, if <= 0.0f then set to 1.0f.
+         * @param color             Color of text.
+         * @param duration          How long to display the text for (in seconds); 0 value will draw for one frame; negative values draw forever.
+         * @param bCenter           If true (default), centers drawn text relative to x coordinate, otherwise text is left-aligned.
+         */
+        virtual void DrawScaledTextOnScreenPos([[maybe_unused]] float x, [[maybe_unused]] float y, [[maybe_unused]] const AZStd::string& text
+            , [[maybe_unused]] float fontScale, [[maybe_unused]] const AZ::Color& color, [[maybe_unused]] float duration, [[maybe_unused]] bool bCenter = true) {}
+#endif // CARBONATED
+// carbonated end
+
         /**
          * Draws a ray in the world for a specified duration
          *

--- a/Gems/DebugDraw/Code/Source/DebugDrawSystemComponent.cpp
+++ b/Gems/DebugDraw/Code/Source/DebugDrawSystemComponent.cpp
@@ -1028,7 +1028,7 @@ namespace DebugDraw
         DebugDrawTextElement& newText = m_activeTexts.emplace_back();
         newText.m_drawMode = DebugDrawTextElement::DrawMode::OnScreen;
         newText.m_text = text;
-        newText.m_fontScale = fontScale > 0.0f ? fontScale : 1.0f;
+        newText.m_fontScale = fontScale;
         newText.m_color = color;
         newText.m_duration = duration;
         AZ::TickRequestBus::BroadcastResult(newText.m_activateTime, &AZ::TickRequestBus::Events::GetTimeAtCurrentTick);

--- a/Gems/DebugDraw/Code/Source/DebugDrawSystemComponent.cpp
+++ b/Gems/DebugDraw/Code/Source/DebugDrawSystemComponent.cpp
@@ -459,7 +459,13 @@ namespace DebugDraw
         #endif // DEBUGDRAW_GEM_EDITOR
 
         // Draw text elements and remove any that are expired
+// carbonated begin : additional DebugDrawText methods
+#if defined(CARBONATED)
+        float currentOnScreenY = 20.f; // Initial shift down for the 1st line, then recalculate shifts down for next lines accounting for textElement.m_fontScale
+#else
         int numScreenTexts = 0;
+#endif // CARBONATED
+// carbonated end
         AZ::EntityId lastTargetEntityId;
 
         for (auto& textElement : m_activeTexts)
@@ -468,8 +474,27 @@ namespace DebugDraw
             debugDisplay.SetColor(textColor);
             if (textElement.m_drawMode == DebugDrawTextElement::DrawMode::OnScreen)
             {
+// carbonated begin : additional DebugDrawText methods
+#if defined(CARBONATED)
+                if (textElement.m_useOnScreenCoordinates)
+                {
+                    // Reuse textElement.m_worldLocation for 2D OnScreen positioning.
+                    debugDisplay.Draw2dTextLabel(textElement.m_worldLocation.GetX(),textElement.m_worldLocation.GetY(),textElement.m_fontScale
+                        , textElement.m_text.c_str(), textElement.m_bCenter);
+                }
+                else
+                {
+                    // Hardcoded 2D OnScreen positioning as in original code. Note original code below with constant shifts.
+                    debugDisplay.Draw2dTextLabel(100.0f, currentOnScreenY, textElement.m_fontScale, textElement.m_text.c_str());
+                    // Prepare the shift down for a next line assuming default m_textSizeFactor = 12.0f + line gap. 
+                    // Could be more precise if Draw2dTextLabel() returned drawn text size with current viewport settings.
+                    currentOnScreenY += textElement.m_fontScale * 14.0f + 2.0f; 
+                }
+#else
                 debugDisplay.Draw2dTextLabel(100.0f, 20.f + ((float)numScreenTexts * 15.0f), 1.4f, textElement.m_text.c_str() );
                 ++numScreenTexts;
+#endif // CARBONATED
+                // carbonated end
             }
             else if (textElement.m_drawMode == DebugDrawTextElement::DrawMode::InWorld)
             {
@@ -995,7 +1020,38 @@ namespace DebugDraw
         AZ::TickRequestBus::BroadcastResult(newText.m_activateTime, &AZ::TickRequestBus::Events::GetTimeAtCurrentTick);
     }
 
-    void DebugDrawSystemComponent::CreateTextEntryForComponent(const AZ::EntityId& componentEntityId, const DebugDrawTextElement& element)
+    // carbonated begin : additional DebugDrawText methods
+#if defined(CARBONATED)
+    void DebugDrawSystemComponent::DrawScaledTextOnScreen(const AZStd::string& text, float fontScale, const AZ::Color& color, float duration)
+    {
+        AZStd::lock_guard<AZStd::mutex> locker(m_activeTextsMutex);
+        DebugDrawTextElement& newText = m_activeTexts.emplace_back();
+        newText.m_drawMode = DebugDrawTextElement::DrawMode::OnScreen;
+        newText.m_text = text;
+        newText.m_fontScale = fontScale > 0.0f ? fontScale : 1.0f;
+        newText.m_color = color;
+        newText.m_duration = duration;
+        AZ::TickRequestBus::BroadcastResult(newText.m_activateTime, &AZ::TickRequestBus::Events::GetTimeAtCurrentTick);
+    }
+
+    void DebugDrawSystemComponent::DrawScaledTextOnScreenPos(float x, float y, const AZStd::string& text, float fontScale, const AZ::Color& color, float duration, bool bCenter)
+    {
+        AZStd::lock_guard<AZStd::mutex> locker(m_activeTextsMutex);
+        DebugDrawTextElement& newText = m_activeTexts.emplace_back();
+        newText.m_drawMode = DebugDrawTextElement::DrawMode::OnScreen;
+        newText.m_text = text;
+        newText.m_fontScale = fontScale > 0.0f ? fontScale : 1.0f;
+        newText.m_color = color;
+        newText.m_duration = duration;
+        newText.m_bCenter = bCenter;
+        newText.m_useOnScreenCoordinates = true;
+        newText.m_worldLocation.Set(x, y, 1.f);
+        AZ::TickRequestBus::BroadcastResult(newText.m_activateTime, &AZ::TickRequestBus::Events::GetTimeAtCurrentTick);
+    }
+#endif // CARBONATED
+    // carbonated end
+
+    void DebugDrawSystemComponent::DebugDrawSystemComponent::CreateTextEntryForComponent(const AZ::EntityId& componentEntityId, const DebugDrawTextElement& element)
     {
         AZStd::lock_guard<AZStd::mutex> locker(m_activeTextsMutex);
         m_activeTexts.push_back(element);

--- a/Gems/DebugDraw/Code/Source/DebugDrawSystemComponent.h
+++ b/Gems/DebugDraw/Code/Source/DebugDrawSystemComponent.h
@@ -103,6 +103,12 @@ namespace DebugDraw
         void DrawTextAtLocation(const AZ::Vector3& worldLocation, const AZStd::string& text, const AZ::Color& color, float duration) override;
         void DrawTextOnEntity(const AZ::EntityId& targetEntity, const AZStd::string& text, const AZ::Color& color, float duration) override;
         void DrawTextOnScreen(const AZStd::string& text, const AZ::Color& color, float duration) override;
+// carbonated begin : additional DebugDrawText methods
+#if defined(CARBONATED)
+        void DrawScaledTextOnScreen(const AZStd::string& text, float fontScale, const AZ::Color& color, float duration) override;
+        void DrawScaledTextOnScreenPos(float x, float y, const AZStd::string& text, float fontScale, const AZ::Color& color, float duration, bool bCenter = true) override;
+#endif // CARBONATED
+// carbonated end
 
         // DebugDrawInternalRequestBus interface implementation
         void RegisterDebugDrawComponent(AZ::Component* component) override;

--- a/Gems/DebugDraw/Code/Source/DebugDrawTextComponent.h
+++ b/Gems/DebugDraw/Code/Source/DebugDrawTextComponent.h
@@ -40,6 +40,13 @@ namespace DebugDraw
         AZ::EntityId m_targetEntityId;
         AZ::Vector3 m_worldLocation = AZ::Vector3::CreateZero();
         AZ::ComponentId m_owningEditorComponent = AZ::InvalidComponentId;
+        // carbonated begin : additional DebugDrawText methods
+#if defined(CARBONATED)
+        float m_fontScale = 1.0f; // Scale factor to default render font
+        bool m_useOnScreenCoordinates = false; // Whether to use m_worldLocation.X and m_worldLocation.Y as OnScreen 2d Coordinates
+        bool m_bCenter = false; // If true, centers drawn text relative to x coordinate
+#endif // CARBONATED
+        // carbonated end
     };
 
 


### PR DESCRIPTION
## What does this PR do?
Adds 2 new  methods to `DebugDrawRequestBus` to correspond to MW usage:
* `DrawScaledTextOnScreen` - to draw texts of different sizes at O3DE hardcoded positions line-below-line;
* `DrawScaledTextOnScreenPos` - to draw texts of different sizes in given on-screen positions.

## How was this PR tested?
* MW `System/Utils*` have been updated to use 2 new `DebugDrawRequestBus` metods (see https://github.com/carbonated-dev/o3de-gruber/pull/563).
* MW game code was temporary changed to call both updated `System/Utils* methods.
* Game played in Editor and Standalone watching drawing of debug texts.
