### PR TITLE
"Bring back MadWorld Editor Tools" --  moved into the game project

### DIFF
--- a/Code/Editor/CMakeLists.txt
+++ b/Code/Editor/CMakeLists.txt
@@ -14,6 +14,7 @@ add_subdirectory(Plugins)
 
 if(CARBONATED_ENGINE_ADDONS)
 set(azcommonaddon_dependency Legacy::CryCommonAddon)
+set_property(GLOBAL APPEND PROPERTY LY_EDITOR_PLUGINS $<TARGET_FILE_NAME:Legacy::MadWorldEditorPlugin>)
 endif()
 
 ly_add_target(

--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -9,6 +9,12 @@
 
 #include "EditorDefs.h"
 
+// Gruber patch begin
+#if defined(_MSC_VER)
+#pragma warning(disable : 4100)
+#endif
+// Gruber patch end
+
 #ifdef WIN32
 AZ_PUSH_DISABLE_WARNING(4458, "-Wunknown-warning-option")
 #include <gdiplus.h>
@@ -84,6 +90,9 @@ AZ_POP_DISABLE_WARNING
 
 // CryCommon
 #include <CryCommon/ILevelSystem.h>
+#include <CryCommon/ISystem.h>
+#include <CryCommon/IGame.h>
+#include <CryCommon/IGameFramework.h>
 
 // Editor
 #include "Settings.h"
@@ -2321,6 +2330,62 @@ int CCryEditApp::IdleProcessing(bool bBackgroundUpdate)
 
     return res;
 }
+
+#if defined(CARBONATED)
+bool CCryEditApp::SetAIPause(bool paused)
+{
+    gEnv->pGame->GetIGameFramework()->SetAIPaused(paused);
+    return gEnv->pGame->GetIGameFramework()->IsAIPaused();
+}
+
+bool CCryEditApp::SetAICover(bool show)
+{
+    gEnv->pGame->GetIGameFramework()->SetAICover(show);
+    return gEnv->pGame->GetIGameFramework()->IsAICoverShown();
+}
+
+int CCryEditApp::SetCoverElev(int elev)
+{
+    gEnv->pGame->GetIGameFramework()->SetCoverElev(elev);
+    return gEnv->pGame->GetIGameFramework()->GetCoverElev();
+}
+
+int CCryEditApp::SetTimeScale(int inverseScale)
+{
+    gEnv->pGame->GetIGameFramework()->SetTimeScale(inverseScale);
+    return gEnv->pGame->GetIGameFramework()->GetTimeScale();
+}
+
+int CCryEditApp::SetAIImap(int imap)
+{
+    gEnv->pGame->GetIGameFramework()->SetAIImap(imap);
+    return gEnv->pGame->GetIGameFramework()->GetAIImap();
+}
+
+int CCryEditApp::SetAIImapSquad(int squad)
+{
+    gEnv->pGame->GetIGameFramework()->SetAIImapSquad(squad);
+    return gEnv->pGame->GetIGameFramework()->GetAIIMapSquad();
+}
+
+int CCryEditApp::SetAIDebugSquad(int squad)
+{
+    gEnv->pGame->GetIGameFramework()->SetAiSquadDebug(squad);
+    return gEnv->pGame->GetIGameFramework()->GetAiSquadDebug();
+}
+
+int CCryEditApp::SetAIDebugChar(int character)
+{
+    gEnv->pGame->GetIGameFramework()->SetAiCharDebug(character);
+    return gEnv->pGame->GetIGameFramework()->GetAiCharDebug();
+}
+
+int CCryEditApp::SetAIInputOverride(int team)
+{
+    gEnv->pGame->GetIGameFramework()->SetAiInputOverride(team);
+    return gEnv->pGame->GetIGameFramework()->GetAiInputOverride();
+}
+#endif
 
 void CCryEditApp::DisplayLevelLoadErrors()
 {

--- a/Code/Editor/CryEdit.h
+++ b/Code/Editor/CryEdit.h
@@ -113,6 +113,18 @@ public:
     bool CreateLevel(bool& wasCreateLevelOperationCancelled);
     void LoadFile(QString fileName);
     void ForceNextIdleProcessing() { m_bForceProcessIdle = true; }
+#if defined(CARBONATED)
+    bool ToggleForceInactive() { m_bForcePause = !m_bForcePause; return m_bForcePause; }
+    bool SetAIPause(bool paused);
+    bool SetAICover(bool show);
+    int SetCoverElev(int elev);
+    int SetTimeScale(int inverseScale);
+    int SetAIImap(int imap);
+    int SetAIImapSquad(int squad);
+    int SetAIDebugSquad(int squad);
+    int SetAIDebugChar(int chararacter);
+    int SetAIInputOverride(int team);
+#endif
     void KeepEditorActive(bool bActive) { m_bKeepEditorActive = bActive; };
     bool IsInTestMode() const { return m_bTestMode; };
     bool IsInPreviewMode() const { return m_bPreviewMode; };
@@ -312,6 +324,9 @@ private:
     // If this flag is set, the next OnIdle() will update, even if the app is in the background, and then
     // this flag will be reset.
     bool m_bForceProcessIdle = false;
+#if defined(CARBONATED)
+    bool m_bForcePause = false;
+#endif
     // This is set while IdleProcessing is running to prevent re-entrancy
     bool m_idleProcessingRunning = false;
     // Keep the editor alive, even if no focus is set


### PR DESCRIPTION
## What does this PR do?

Changes:
a) make MadWorldEditorPlugin visible for Plugin Manager  in the Editor
b) add missed stuff to support "Carb AI" toolbar

## How was this PR tested?

Locally, in the Editor for PC
