### PR TITLE
Added support for recursive pattern in dependency xml files

### DIFF
--- a/Code/Tools/AssetProcessor/native/AssetManager/PathDependencyManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/PathDependencyManager.cpp
@@ -566,11 +566,11 @@ namespace AssetProcessor
                             //  2. When another product is created, all existing wildcard dependencies are compared against that product to
                             //  see if it matches them.
                             // This check here makes sure that the filter for 1 matches 2.
-                            if (!isExactDependency
 #if defined(CARBONATED)
-                                && !isRecursiveDependency
+                            if (!isExactDependency && isRecursiveDependency)
+#else
+                            if (!isExactDependency)
 #endif
-                                )
                             {
                                 AZ::IO::PathView searchPath(productDatabaseEntry.m_productName);
 

--- a/Code/Tools/AssetProcessor/native/AssetManager/PathDependencyManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/PathDependencyManager.cpp
@@ -511,6 +511,10 @@ namespace AssetProcessor
 
             bool isExcludedDependency = dependencyPathSearch.starts_with(ExcludedDependenciesSymbol);
             dependencyPathSearch = isExcludedDependency ? dependencyPathSearch.substr(1) : dependencyPathSearch;
+#if defined(CARBONATED)
+            bool isRecursiveDependency = dependencyPathSearch.ends_with(RecursiveDependenciesPattern);
+            dependencyPathSearch = isRecursiveDependency ? dependencyPathSearch.substr(0, dependencyPathSearch.length() - 1) : dependencyPathSearch;
+#endif
             // The database uses % for wildcards, both path based searching uses *, so keep a copy of the path with the * wildcard for later
             // use.
             AZStd::string pathWildcardSearchPath(dependencyPathSearch);
@@ -562,7 +566,11 @@ namespace AssetProcessor
                             //  2. When another product is created, all existing wildcard dependencies are compared against that product to
                             //  see if it matches them.
                             // This check here makes sure that the filter for 1 matches 2.
-                            if (!isExactDependency)
+                            if (!isExactDependency
+#if defined(CARBONATED)
+                                && !isRecursiveDependency
+#endif
+                                )
                             {
                                 AZ::IO::PathView searchPath(productDatabaseEntry.m_productName);
 

--- a/Code/Tools/AssetProcessor/native/AssetManager/PathDependencyManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/PathDependencyManager.cpp
@@ -512,31 +512,15 @@ namespace AssetProcessor
             bool isExcludedDependency = dependencyPathSearch.starts_with(ExcludedDependenciesSymbol);
             dependencyPathSearch = isExcludedDependency ? dependencyPathSearch.substr(1) : dependencyPathSearch;
 #if defined(CARBONATED)
-            bool isRecursiveDependency = false;
-            AZStd::string searchExtension;
-            const auto pos = dependencyPathSearch.rfind(RecursiveDependenciesExtPattern);
-            const bool isRecursiveExtDependency = pos != AZStd::string::npos;
-            if (isRecursiveExtDependency)
-            {
-                searchExtension = dependencyPathSearch.substr(pos + RecursiveDependenciesExtPatternLen - 1);
-                dependencyPathSearch = dependencyPathSearch.substr(0, pos + 1);
-            }
-            else
-            {
-                isRecursiveDependency = dependencyPathSearch.ends_with(RecursiveDependenciesPattern);
-                dependencyPathSearch = isRecursiveDependency ? dependencyPathSearch.substr(0, dependencyPathSearch.length() - 1) : dependencyPathSearch;
-            }
+            bool isRecursiveDependency = dependencyPathSearch.ends_with(RecursiveDependenciesPattern);
+            dependencyPathSearch = isRecursiveDependency ? dependencyPathSearch.substr(0, dependencyPathSearch.length() - 1) : dependencyPathSearch;
 #endif
             // The database uses % for wildcards, both path based searching uses *, so keep a copy of the path with the * wildcard for later
             // use.
             AZStd::string pathWildcardSearchPath(dependencyPathSearch);
             bool isExactDependency = !AzFramework::StringFunc::Replace(dependencyPathSearch, '*', '%');
 
-            if (
-#if defined(CARBONATED)
-                isRecursiveExtDependency ||
-#endif
-                cleanedupDependency.m_dependencyType == AssetBuilderSDK::ProductPathDependencyType::ProductFile)
+            if (cleanedupDependency.m_dependencyType == AssetBuilderSDK::ProductPathDependencyType::ProductFile)
             {
                 SanitizeForDatabase(dependencyPathSearch);
                 SanitizeForDatabase(pathWildcardSearchPath);
@@ -574,15 +558,6 @@ namespace AssetProcessor
                     {
                         if (m_stateData->GetSourceByJobID(productDatabaseEntry.m_jobPK, sourceDatabaseEntry))
                         {
-#if defined(CARBONATED)
-                            if (isRecursiveExtDependency)
-                            {
-                                if (!productDatabaseEntry.m_productName.contains(searchExtension))
-                                {
-                                    continue;
-                                }
-                            }
-#endif
                             // The SQL wildcard search is greedy and doesn't match the path based, glob style wildcard search that is
                             // expected in this case. This also matches the behavior of resolving unmet dependencies later. There are two
                             // cases that wildcard dependencies resolve:
@@ -593,7 +568,7 @@ namespace AssetProcessor
                             // This check here makes sure that the filter for 1 matches 2.
                             if (!isExactDependency
 #if defined(CARBONATED)
-                                && !isRecursiveDependency && !isRecursiveExtDependency
+                                && !isRecursiveDependency
 #endif
                                 )
                             {

--- a/Code/Tools/AssetProcessor/native/AssetManager/PathDependencyManager.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/PathDependencyManager.h
@@ -23,6 +23,9 @@ namespace AssetProcessor
     class AssetDatabaseConnection;
 
     const char ExcludedDependenciesSymbol = ':';
+#if defined(CARBONATED)
+    constexpr const char RecursiveDependenciesPattern[] = "**";
+#endif
 
     /// Handles resolving and saving product path dependencies
     class PathDependencyManager

--- a/Code/Tools/AssetProcessor/native/AssetManager/PathDependencyManager.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/PathDependencyManager.h
@@ -24,9 +24,7 @@ namespace AssetProcessor
 
     const char ExcludedDependenciesSymbol = ':';
 #if defined(CARBONATED)
-    static constexpr size_t RecursiveDependenciesExtPatternLen = 5;
-    static constexpr const char RecursiveDependenciesExtPattern[RecursiveDependenciesExtPatternLen + 1] = "**/*.";
-    static constexpr const char RecursiveDependenciesPattern[] = "**";
+    constexpr const char RecursiveDependenciesPattern[] = "**";
 #endif
 
     /// Handles resolving and saving product path dependencies

--- a/Code/Tools/AssetProcessor/native/AssetManager/PathDependencyManager.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/PathDependencyManager.h
@@ -24,7 +24,9 @@ namespace AssetProcessor
 
     const char ExcludedDependenciesSymbol = ':';
 #if defined(CARBONATED)
-    constexpr const char RecursiveDependenciesPattern[] = "**";
+    static constexpr size_t RecursiveDependenciesExtPatternLen = 5;
+    static constexpr const char RecursiveDependenciesExtPattern[RecursiveDependenciesExtPatternLen + 1] = "**/*.";
+    static constexpr const char RecursiveDependenciesPattern[] = "**";
 #endif
 
     /// Handles resolving and saving product path dependencies


### PR DESCRIPTION
## What does this PR do?

Added support for recursive pattern in dependency xml files

One can use the pattern 

`foo/bar/**`

to add dependency for all assets under `foo/bar/` path hint.

Use 

`foo/bar/**/*.png`

to match all `*.png` assets under `foo/bar/` path hint.

## How was this PR tested?

Tested locally by adding / removing the recursive pattern from existing `_dependency.xml`'s and checking the resulting asset lists
