### PR TITLE
Add per mesh shader option support when mesh instancing is enabled.

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshCommon.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshCommon.h
@@ -37,7 +37,8 @@ namespace AZ::Render::MeshCommon
                 bool nodeIsContainedInBounds = ShapeIntersection::Contains(boundsRef, nodeData.m_bounds);
                 for (auto* visibleEntry : nodeData.m_entries)
                 {
-                    if (visibleEntry->m_typeFlags == AzFramework::VisibilityEntry::TYPE_RPI_Cullable)
+                    if (visibleEntry->m_typeFlags & AzFramework::VisibilityEntry::TYPE_RPI_Cullable ||
+                        visibleEntry->m_typeFlags & AzFramework::VisibilityEntry::TYPE_RPI_VisibleObjectList)
                     {
                         RPI::Cullable* cullable = static_cast<RPI::Cullable*>(visibleEntry->m_userData);
 

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
@@ -61,6 +61,9 @@ namespace AZ
 
             using PostCullingInstanceDataList = AZStd::vector<PostCullingInstanceData>;
 
+            //! called when a DrawPacket used by this ModelDataInstance was updated. 
+            void HandleDrawPacketUpdate();
+
         private:
             class MeshLoader
                 : private Data::AssetBus::Handler
@@ -122,7 +125,6 @@ namespace AZ
             bool MaterialRequiresForwardPassIblSpecular(Data::Instance<RPI::Material> material) const;
             void SetVisible(bool isVisible);
             CustomMaterialInfo GetCustomMaterialWithFallback(const CustomMaterialId& id) const;
-            void HandleDrawPacketUpdate();
 
             // When instancing is disabled, draw packets are owned by the ModelDataInstance
             RPI::MeshDrawPacketLods m_drawPacketListsByLod;
@@ -132,11 +134,6 @@ namespace AZ
             // which are turned into instance draw calls after culling
             AZStd::vector<PostCullingInstanceDataList> m_postCullingInstanceDataByLod;
             
-            // AZ::Event is used to communicate back to all the objects that refer to an instance group whenever a draw packet is updated
-            // This is used to trigger an update to the cullable to use the new draw packet
-            using UpdateDrawPacketHandlerList = AZStd::vector<AZ::Event<>::Handler>;
-            AZStd::vector<UpdateDrawPacketHandlerList> m_updateDrawPacketEventHandlersByLod;
-
             size_t m_lodBias = 0;
 
             RPI::Cullable m_cullable;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
@@ -25,7 +25,7 @@ namespace AZ
     {
         AZ_CVAR(bool,
             r_enablePerMeshShaderOptionFlags,
-            false,
+            true,
             nullptr,
             AZ::ConsoleFunctorFlags::Null,
             "Enable allowing systems to set shader options on a per-mesh basis."

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
@@ -25,7 +25,7 @@ namespace AZ
     {
         AZ_CVAR(bool,
             r_enablePerMeshShaderOptionFlags,
-            true,
+            false,
             nullptr,
             AZ::ConsoleFunctorFlags::Null,
             "Enable allowing systems to set shader options on a per-mesh basis."

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -943,7 +943,7 @@ namespace AZ
                             instanceGroupDataIter->UpdateDrawPacket(*GetParentScene(), true);
 
                             // Note, we don't need to call CacheRootConstantInterval() here because the root constant layout won't change
-                            // when switch shader variants.
+                            // when we switch shader variants.
                         }
                     }
                 }

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -925,7 +925,7 @@ namespace AZ
 
                         if (shaderOptionFlagsChanged)
                         {
-                            // Set shader optioins here
+                            // Set shader options here
                             m_flagRegistry->VisitTags(
                                 [&](AZ::Name shaderOption, FlagRegistry::TagType tag)
                                 {

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -44,8 +44,9 @@
 #include <AzCore/RTTI/TypeInfo.h>
 #include <AzCore/Serialization/SerializeContext.h>
 
-
 #include <algorithm>
+
+#pragma optimize("", off)
 
 namespace AZ
 {
@@ -274,17 +275,11 @@ namespace AZ
                     for (auto instanceGroupDataIter = iteratorRange.m_begin; instanceGroupDataIter != iteratorRange.m_end;
                          ++instanceGroupDataIter)
                     {
-                        RPI::MeshDrawPacket& drawPacket = instanceGroupDataIter->m_drawPacket;
-                        if (drawPacket.Update(*scene, m_forceRebuildDrawPackets))
+                        if (instanceGroupDataIter->UpdateDrawPacket(*scene, m_forceRebuildDrawPackets))
                         {
-                            // Clear any cached draw packets, since they need to be re-created
-                            instanceGroupDataIter->m_perViewDrawPackets.clear();
-
                             // We're going to need an interval for the root constant data that we update every frame for each draw item, so
                             // cache that here
                             CacheRootConstantInterval(*instanceGroupDataIter);
-
-                            instanceGroupDataIter->m_updateDrawPacketEvent.Signal();
                         }
                     }
                 };
@@ -300,9 +295,10 @@ namespace AZ
             const auto iteratorRanges = m_modelData.GetParallelRanges();
             AZStd::vector<Job*> initJobQueue;
             initJobQueue.reserve(iteratorRanges.size());
+            bool removePerMeshShaderOptionFlags = !r_enablePerMeshShaderOptionFlags && m_enablePerMeshShaderOptionFlags;
             for (const auto& iteratorRange : iteratorRanges)
             {
-                const auto initJobLambda = [this, iteratorRange]() -> void
+                const auto initJobLambda = [this, iteratorRange, removePerMeshShaderOptionFlags]() -> void
                 {
                     AZ_PROFILE_SCOPE(AzRender, "MeshFeatureProcessor: Simulate: Init");
 
@@ -337,6 +333,25 @@ namespace AZ
                         // so they don't need to be updated here
                         if (!r_meshInstancingEnabled)
                         {
+                            // Unset per mesh shader options 
+                            if (removePerMeshShaderOptionFlags)
+                            {
+                                for (RPI::MeshDrawPacketList& drawPacketList : meshDataIter->m_drawPacketListsByLod)
+                                {
+                                    for (RPI::MeshDrawPacket& drawPacket : drawPacketList)
+                                    {
+                                        m_flagRegistry->VisitTags(
+                                            [&](AZ::Name shaderOption, [[maybe_unused]] FlagRegistry::TagType tag)
+                                            {
+                                                drawPacket.UnsetShaderOption(shaderOption);
+                                            });
+                                    }
+                                }
+
+                                meshDataIter->m_cullable.m_shaderOptionFlags = 0;
+                                meshDataIter->m_cullable.m_prevShaderOptionFlags = 0;
+                            }
+
                             // [GFX TODO] [ATOM-1357] Currently all of the draw packets have to be checked for material ID changes because
                             // material properties can impact which actual shader is used, which impacts the SRG in the draw packet.
                             // This is scheduled to be optimized so the work is only done on draw packets that need it instead of having
@@ -356,6 +371,7 @@ namespace AZ
             const auto iteratorRanges = m_modelData.GetParallelRanges();
             AZStd::vector<Job*> updateCullingJobQueue;
             updateCullingJobQueue.reserve(iteratorRanges.size());
+
             for (const auto& iteratorRange : iteratorRanges)
             {
                 const auto updateCullingJobLambda = [this, iteratorRange]() -> void
@@ -836,52 +852,16 @@ namespace AZ
         void MeshFeatureProcessor::OnBeginPrepareRender()
         {
             m_meshDataChecker.soft_lock();
-            AZ_Error("MeshFeatureProcessor::OnBeginPrepareRender", !(r_enablePerMeshShaderOptionFlags && r_meshInstancingEnabled),
-                "r_enablePerMeshShaderOptionFlags and r_meshInstancingEnabled are incompatible at this time. r_enablePerMeshShaderOptionFlags results "
-                "in a unique shader permutation for a given object depending on which light types are in range of the object. This isn't known until "
-                "immediately before rendering. Determining whether or not two meshes can be instanced happens when the object is first set up, and we don't "
-                "want to update that instance map every frame, so if instancing is enabled we treat r_enablePerMeshShaderOptionFlags as disabled. "
-                "This can be relaxed for static meshes in the future when we know they won't be moving. ");
-            if (!r_enablePerMeshShaderOptionFlags && m_enablePerMeshShaderOptionFlags && !r_meshInstancingEnabled)
+                        
+            // The per-mesh shader option flags are set in feature processors' simulate function
+            // So we want to process the flags here to update the draw packets if needed.
+            // Update MeshDrawPacket's shader options if PerMeshShaderOption is enabled
+            if (r_enablePerMeshShaderOptionFlags || m_enablePerMeshShaderOptionFlags)
             {
+                // For mesh instance groups when r_meshInstancingEnabled is enabled
+                AZStd::vector<ModelDataInstance::InstanceGroupHandle> instanceGroupsNeedUpdate;
+
                 // Per mesh shader option flags was on, but now turned off, so reset all the shader options.
-                for (auto& modelHandle : m_modelData)
-                {
-                    // skip if the model need to be initialized
-                    if (modelHandle.m_flags.m_needsInit)
-                    {
-                        continue;
-                    }
-                    
-                    for (RPI::MeshDrawPacketList& drawPacketList : modelHandle.m_drawPacketListsByLod)
-                    {
-                        for (RPI::MeshDrawPacket& drawPacket : drawPacketList)
-                        {
-                            m_flagRegistry->VisitTags(
-                                [&](AZ::Name shaderOption, [[maybe_unused]] FlagRegistry::TagType tag)
-                                {
-                                    drawPacket.UnsetShaderOption(shaderOption);
-                                }
-                            );
-                            drawPacket.Update(*GetParentScene(), true);
-                        }
-                    }
-                    modelHandle.m_cullable.m_shaderOptionFlags = 0;
-                    modelHandle.m_cullable.m_prevShaderOptionFlags = 0;
-                    modelHandle.m_flags.m_cullableNeedsRebuild = true;
-
-                    // [GHI-13619]
-                    // Update the draw packets on the cullable, since we just set a shader item.
-                    // BuildCullable is a bit overkill here, this could be reduced to just updating the drawPacket specific info
-                    // It's also going to cause m_cullableNeedsUpdate to be set, which will execute next frame, which we don't need
-                    modelHandle.BuildCullable();
-                }
-            }
-
-            m_enablePerMeshShaderOptionFlags = r_enablePerMeshShaderOptionFlags && !r_meshInstancingEnabled;
-
-            if (m_enablePerMeshShaderOptionFlags)
-            {
                 for (auto& modelHandle : m_modelData)
                 {
                     if (modelHandle.m_cullable.m_prevShaderOptionFlags != modelHandle.m_cullable.m_shaderOptionFlags)
@@ -891,32 +871,87 @@ namespace AZ
                         {
                             continue;
                         }
-                        // Per mesh shader option flags have changed, so rebuild the draw packet with the new shader options.
-                        for (RPI::MeshDrawPacketList& drawPacketList : modelHandle.m_drawPacketListsByLod)
+
+                        if (!r_meshInstancingEnabled)
                         {
-                            for (RPI::MeshDrawPacket& drawPacket : drawPacketList)
+                            for (RPI::MeshDrawPacketList& drawPacketList : modelHandle.m_drawPacketListsByLod)
                             {
-                                m_flagRegistry->VisitTags(
-                                    [&](AZ::Name shaderOption, FlagRegistry::TagType tag)
-                                    {
-                                        bool shaderOptionValue = (modelHandle.m_cullable.m_shaderOptionFlags & tag.GetIndex()) > 0;
-                                        drawPacket.SetShaderOption(shaderOption, AZ::RPI::ShaderOptionValue(shaderOptionValue));
-                                    }
-                                );
-                                drawPacket.Update(*GetParentScene(), true);
+                                for (RPI::MeshDrawPacket& drawPacket : drawPacketList)
+                                {
+                                    m_flagRegistry->VisitTags(
+                                        [&](AZ::Name shaderOption, FlagRegistry::TagType tag)
+                                        {
+                                            bool shaderOptionValue = (modelHandle.m_cullable.m_shaderOptionFlags & tag.GetIndex()) > 0;
+                                            drawPacket.SetShaderOption(shaderOption, AZ::RPI::ShaderOptionValue(shaderOptionValue));
+                                        });
+                                    drawPacket.Update(*GetParentScene(), true);
+                                }
+                            }
+
+                            modelHandle.m_flags.m_cullableNeedsRebuild = true;
+                            // [GHI-13619]
+                            // Update the draw packets on the cullable, since we just set a shader item.
+                            // BuildCullable is a bit overkill here, this could be reduced to just updating the drawPacket specific info
+                            // It's also going to cause m_cullableNeedsUpdate to be set, which will execute next frame, which we don't need
+                            modelHandle.BuildCullable();
+                        }
+                        else
+                        {
+                            // mark the instance groups which need to update their shader options
+                            for (size_t lodIndex = 0; lodIndex < modelHandle.m_postCullingInstanceDataByLod.size(); ++lodIndex)
+                            {
+                                ModelDataInstance::PostCullingInstanceDataList& postCullingInstanceDataList =
+                                    modelHandle.m_postCullingInstanceDataByLod[lodIndex];
+                                for (const ModelDataInstance::PostCullingInstanceData& postCullingData : postCullingInstanceDataList)
+                                {
+                                    instanceGroupsNeedUpdate.push_back(postCullingData.m_instanceGroupHandle);
+                                }
                             }
                         }
-                        modelHandle.m_flags.m_cullableNeedsRebuild = true;
+                    }
+                }
 
-                        // [GHI-13619]
-                        // Update the draw packets on the cullable, since we just set a shader item.
-                        // BuildCullable is a bit overkill here, this could be reduced to just updating the drawPacket specific info
-                        // It's also going to cause m_cullableNeedsUpdate to be set, which will execute next frame, which we don't need
-                        modelHandle.BuildCullable();
+                if (r_meshInstancingEnabled)
+                {
+                    for (auto& instanceGroupDataIter : instanceGroupsNeedUpdate)
+                    {
+                        // default values for when r_enablePerMeshShaderOptionFlags was set from true to false
+                        bool shaderOptionFlagsChanged = true;
+                        uint32_t shaderOptionFlagMask = 0; // 0 means disable all shader options
+
+                        if (r_enablePerMeshShaderOptionFlags)
+                        {
+                            shaderOptionFlagsChanged = instanceGroupDataIter->UpdateShaderOptionFlags();
+                            shaderOptionFlagMask = instanceGroupDataIter->m_shaderOptionFlagMask;
+                        }
+
+                        if (shaderOptionFlagsChanged)
+                        {
+                            // Set shader optioins here
+                            m_flagRegistry->VisitTags(
+                                [&](AZ::Name shaderOption, FlagRegistry::TagType tag)
+                                {
+                                    if ((shaderOptionFlagMask & tag.GetIndex()) > 0)
+                                    {
+                                        bool shaderOptionValue = (instanceGroupDataIter->m_shaderOptionFlags & tag.GetIndex()) > 0;
+                                        instanceGroupDataIter->m_drawPacket.SetShaderOption(
+                                            shaderOption, AZ::RPI::ShaderOptionValue(shaderOptionValue));
+                                    }
+                                    else
+                                    {
+                                        instanceGroupDataIter->m_drawPacket.UnsetShaderOption(shaderOption); 
+                                    }
+                                });
+                            instanceGroupDataIter->UpdateDrawPacket(*GetParentScene(), true);
+
+                            // Note, we don't need to call CacheRootConstantInterval() here because the root constant layout won't change
+                            // when switch shader variants.
+                        }
                     }
                 }
             }
 
+            m_enablePerMeshShaderOptionFlags = r_enablePerMeshShaderOptionFlags;
         }
 
         void MeshFeatureProcessor::OnEndPrepareRender()
@@ -1686,25 +1721,14 @@ namespace AZ
             {
                 // Remove all the meshes from the MeshInstanceManager
                 MeshInstanceManager& meshInstanceManager = meshFeatureProcessor->GetMeshInstanceManager();
-                AZ_Assert(
-                    m_postCullingInstanceDataByLod.size() == m_updateDrawPacketEventHandlersByLod.size(),
-                    "MeshFeatureProcessor: InstanceGroup handles and update draw packet event handlers do not match.");
 
                 for (size_t lodIndex = 0; lodIndex < m_postCullingInstanceDataByLod.size(); ++lodIndex)
                 {
                     PostCullingInstanceDataList& postCullingInstanceDataList = m_postCullingInstanceDataByLod[lodIndex];
-                    UpdateDrawPacketHandlerList& updateDrawPacketHandlers = m_updateDrawPacketEventHandlersByLod[lodIndex];
-                    AZ_Assert(
-                        postCullingInstanceDataList.size() == updateDrawPacketHandlers.size(),
-                        "MeshFeatureProcessor: InstanceGroup handles and update draw packet event handlers do not match.");
                     size_t meshIndex = 0;
                     for (PostCullingInstanceData& postCullingData : postCullingInstanceDataList)
                     {
-                        {
-                            // Disconnect the event handlers
-                            AZStd::scoped_lock<AZStd::mutex> scopedLock(postCullingData.m_instanceGroupHandle->m_eventLock);
-                            updateDrawPacketHandlers[meshIndex].Disconnect();
-                        }
+                        postCullingData.m_instanceGroupHandle->RemoveAssociatedInstance(this);
                         
                         // Remove instance will decrement the use-count of the instance group, and only release the instance group
                         // if nothing else is referring to it.
@@ -1712,10 +1736,8 @@ namespace AZ
                         ++meshIndex;
                     }
                     postCullingInstanceDataList.clear();
-                    updateDrawPacketHandlers.clear();
                 }
                 m_postCullingInstanceDataByLod.clear();
-                m_updateDrawPacketEventHandlersByLod.clear();
             }
 
             m_customMaterials.clear();
@@ -1751,7 +1773,6 @@ namespace AZ
             else
             {
                 m_postCullingInstanceDataByLod.resize(modelLodCount);
-                m_updateDrawPacketEventHandlersByLod.resize(modelLodCount);
             }
             
             for (size_t modelLodIndex = 0; modelLodIndex < modelLodCount; ++modelLodIndex)
@@ -1966,18 +1987,9 @@ namespace AZ
                     postCullingData.m_instanceGroupHandle->m_isTransparent = instancingSupport.m_isTransparent;
                     m_postCullingInstanceDataByLod[modelLodIndex].push_back(postCullingData);
 
-                    // Add an update draw packet event handler for the current mesh
-                    m_updateDrawPacketEventHandlersByLod[modelLodIndex].push_back(AZ::Event<>::Handler{
-                        [this]()
-                        {
-                            HandleDrawPacketUpdate();
-                        }});
-                    // Connect to the update draw packet event
-                    {
-                        AZStd::scoped_lock<AZStd::mutex> scopedLock(instanceGroupInsertResult.m_handle->m_eventLock);
-                        m_updateDrawPacketEventHandlersByLod[modelLodIndex].back().Connect(
-                            instanceGroupInsertResult.m_handle->m_updateDrawPacketEvent);
-                    }
+                    // The instaceGroup needs to keep a reference of this ModelDataInstance so it can
+                    // notify the ModelDataInstance when the MeshDrawPacket is changed or get the cullable's flags 
+                    instanceGroupInsertResult.m_handle->AddAssociatedInstance(this);
                 }
 
                 // If this condition is true, we're dealing with a new, uninitialized draw packet, either because instancing is disabled
@@ -2914,3 +2926,5 @@ namespace AZ
     } // namespace Render
 } // namespace AZ
 
+
+#pragma optimize("", on)

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -46,8 +46,6 @@
 
 #include <algorithm>
 
-#pragma optimize("", off)
-
 namespace AZ
 {
     namespace Render
@@ -2926,5 +2924,3 @@ namespace AZ
     } // namespace Render
 } // namespace AZ
 
-
-#pragma optimize("", on)

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshInstanceGroupList.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshInstanceGroupList.cpp
@@ -30,7 +30,7 @@ namespace AZ::Render
 
     bool MeshInstanceGroupData::UpdateShaderOptionFlags()
     {
-        uint32_t newShaderOptionFlagMask = 0;
+        uint32_t newShaderOptionFlagMask = 0;   // defaults to 0 so no shader options are specified.
         uint32_t newShaderOptionFlags = m_shaderOptionFlags;
 
         if (m_associatedInstances.size() > 0)
@@ -40,10 +40,13 @@ namespace AZ::Render
 
         for (auto modelDataInstance : m_associatedInstances)
         {
+            // If the shader option flag of different intances are different, the mask for the flag is 0, which means the flag is unspecified.
             newShaderOptionFlagMask = ~(newShaderOptionFlags ^ modelDataInstance->GetCullable().m_shaderOptionFlags);
+            // if the option flag has same value, keep the value.
             newShaderOptionFlags &= modelDataInstance->GetCullable().m_shaderOptionFlags;
         }
 
+        // return ture if the shader option flags or mask changed. 
         if (newShaderOptionFlags != m_shaderOptionFlags || newShaderOptionFlagMask != m_shaderOptionFlagMask)
         {
             m_shaderOptionFlags = newShaderOptionFlags;

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshInstanceGroupList.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshInstanceGroupList.h
@@ -57,7 +57,7 @@ namespace AZ::Render
         bool m_isTransparent = false;
 
         // For per-mesh shader options
-        // If all the ModelDataInstances which use this group are using same shader option value, then we may apply the mesh shader options to the draw packet.
+        // If all the ModelDataInstances within this group are using the same shader option value, then we can apply the mesh shader options to the draw packet.
         // These are two variables which are used to indicate which shader option should be applied and which value is applied.
         // combined shader options from any ModelDataInstance which use this group
         uint32_t m_shaderOptionFlags = 0;

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshInstanceGroupList.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshInstanceGroupList.h
@@ -18,6 +18,8 @@
 
 namespace AZ::Render
 {
+    class ModelDataInstance;
+
     //! This struct contains all the data for a group of meshes that are capable of being rendered
     //! with a single instanced draw call
     struct MeshInstanceGroupData
@@ -42,9 +44,10 @@ namespace AZ::Render
         // or store it with the data for each individual instance
         MeshInstanceGroupKey m_key;
 
-        // Event to signal to any data instance that refers to this InstanceGroup that the draw packet has been updated
-        AZ::Event<> m_updateDrawPacketEvent;
-        // Connecting to an AZ::Event is not thread safe, so we need to protect that with a lock
+        // A list of ModelDataInstances which are referencing this instace group
+        AZStd::set<ModelDataInstance*> m_associatedInstances;
+
+        // Mutex for adding/removing associated ModelDataInstance
         AZStd::mutex m_eventLock;
 
         // Enable draw motion or not. Set to true if any of mesh instance use this group has the same flag set in their ModelDataInstance
@@ -52,6 +55,28 @@ namespace AZ::Render
 
         // If the group is transparent, sort depth in reverse
         bool m_isTransparent = false;
+
+        // For per-mesh shader options
+        // If all the ModelDataInstances which use this group are using same shader option value, then we may apply the mesh shader options to the draw packet.
+        // These are two variables which are used to indicate which shader option should be applied and which value is applied.
+        // combined shader options from any ModelDataInstance which use this group
+        uint32_t m_shaderOptionFlags = 0;
+
+        // flag shader option flags which are in use
+        uint32_t m_shaderOptionFlagMask = 0;
+
+        // Update mesh draw packet
+        // Return true the DrawPacket was rebuilt
+        bool UpdateDrawPacket(const RPI::Scene& parentScene, bool forceUpdate);
+
+        // Update shader option flags for the instance group
+        // It goes through the cullable's m_shaderOptionFlags of each associated ModelDataInstance and get combined m_shaderOptionFlags and m_shaderOptionFlagMask
+        // Return true if flags or mask changed.
+        bool UpdateShaderOptionFlags();
+
+        // Add/remove an associated ModelDataInstance (thread safe)
+        void AddAssociatedInstance(ModelDataInstance* instance);
+        void RemoveAssociatedInstance(ModelDataInstance* instance);
     };
 
     //! Manages all the instance groups used by mesh instancing.

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshInstanceGroupList.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshInstanceGroupList.h
@@ -66,7 +66,7 @@ namespace AZ::Render
         uint32_t m_shaderOptionFlagMask = 0;
 
         // Update mesh draw packet
-        // Return true the DrawPacket was rebuilt
+        // Return true if DrawPacket was rebuilt
         bool UpdateDrawPacket(const RPI::Scene& parentScene, bool forceUpdate);
 
         // Update shader option flags for the instance group

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshInstanceGroupList.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshInstanceGroupList.h
@@ -44,7 +44,7 @@ namespace AZ::Render
         // or store it with the data for each individual instance
         MeshInstanceGroupKey m_key;
 
-        // A list of ModelDataInstances which are referencing this instace group
+        // A list of ModelDataInstances which are referencing this instance group
         AZStd::set<ModelDataInstance*> m_associatedInstances;
 
         // Mutex for adding/removing associated ModelDataInstance

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/MeshDrawPacket.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/MeshDrawPacket.h
@@ -17,6 +17,7 @@
 #include <AzCore/Math/Obb.h>
 #include <AzCore/std/containers/fixed_vector.h>
 
+#define DEBUG_MESH_SHADERVARIANTS
 
 namespace AZ
 {
@@ -78,6 +79,8 @@ namespace AZ
             const ModelLod::Mesh& GetMesh() const;
             const ShaderList& GetActiveShaderList() const { return m_activeShaders; }
 
+            void DebugOutputShaderVariants();
+
         private:
             bool DoUpdate(const Scene& parentScene);
             void ForValidShaderOptionName(const Name& shaderOptionName, const AZStd::function<bool(const ShaderCollection::Item&, ShaderOptionIndex)>& callback);
@@ -135,6 +138,12 @@ namespace AZ
 
             //! A flag to indicate if the DrawPacket need to be rebuild when updating
             bool m_needUpdate = true;
+
+#ifdef DEBUG_MESH_SHADERVARIANTS
+            // For debug shader variants
+            // The list of shader variant asset names used by the DrawPackets
+            AZStd::vector<AZStd::string_view> m_shaderVariantNames;
+#endif
         };
         
         using MeshDrawPacketList = AZStd::vector<RPI::MeshDrawPacket>;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/MeshDrawPacket.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/MeshDrawPacket.h
@@ -17,7 +17,9 @@
 #include <AzCore/Math/Obb.h>
 #include <AzCore/std/containers/fixed_vector.h>
 
-#define DEBUG_MESH_SHADERVARIANTS
+// Enable this define to print the shader variants used by MeshDrawPacket every time the draw packet get rebuilt.
+// Note: the log can be extremely long if there are too many mesh instances (for example, >5K).  
+// #define DEBUG_MESH_SHADERVARIANTS
 
 namespace AZ
 {

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
@@ -17,8 +17,6 @@
 #include <AzCore/Console/Console.h>
 #include <Atom/RPI.Public/Shader/ShaderReloadDebugTracker.h>
 
-#pragma optimize("", off)
-
 namespace AZ
 {
     namespace RPI
@@ -532,4 +530,3 @@ namespace AZ
     } // namespace RPI
 } // namespace AZ
 
-#pragma optimize("", on)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
@@ -17,6 +17,8 @@
 #include <AzCore/Console/Console.h>
 #include <Atom/RPI.Public/Shader/ShaderReloadDebugTracker.h>
 
+#pragma optimize("", off)
+
 namespace AZ
 {
     namespace RPI
@@ -216,6 +218,8 @@ namespace AZ
                 DoUpdate(parentScene);
                 m_materialChangeId = m_material->GetCurrentChangeId();
                 m_needUpdate = false;
+
+                DebugOutputShaderVariants();
                 return true;
             }
 
@@ -225,6 +229,22 @@ namespace AZ
         static bool HasRootConstants(const RHI::ConstantsLayout* rootConstantsLayout)
         {
             return rootConstantsLayout && rootConstantsLayout->GetDataSize() > 0;
+        }
+
+        void MeshDrawPacket::DebugOutputShaderVariants()
+        {
+#ifdef DEBUG_MESH_SHADERVARIANTS
+            uint32_t index = 0;
+
+            AZ::Data::AssetInfo assetInfo;
+            AZ::Data::AssetCatalogRequestBus::BroadcastResult(assetInfo, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetInfoById, m_modelLod->GetAssetId());
+
+            AZ_TracePrintf("MeshDrawPacket", "Mesh: %s", assetInfo.m_relativePath.data());
+            for (const auto& variant : m_shaderVariantNames)
+            {
+                AZ_TracePrintf("MeshDrawPacket", "%d: %s", index++, variant.data());
+            }
+#endif
         }
 
         bool MeshDrawPacket::DoUpdate(const Scene& parentScene)
@@ -265,6 +285,10 @@ namespace AZ
             bool isFirstShaderItem = true;
 
             m_perDrawSrgs.clear();
+
+#ifdef DEBUG_MESH_SHADERVARIANTS
+            m_shaderVariantNames.clear();
+#endif
 
             auto appendShader = [&](const ShaderCollection::Item& shaderItem, const Name& materialPipelineName)
             {
@@ -348,6 +372,10 @@ namespace AZ
 
                 const ShaderVariantId requestedVariantId = shaderOptions.GetShaderVariantId();
                 const ShaderVariant& variant = r_forceRootShaderVariantUsage ? shader->GetRootVariant() : shader->GetVariant(requestedVariantId);
+
+#ifdef DEBUG_MESH_SHADERVARIANTS
+                m_shaderVariantNames.push_back(variant.GetShaderVariantAsset().GetHint());
+#endif
 
                 RHI::PipelineStateDescriptorForDraw pipelineStateDescriptor;
                 variant.ConfigurePipelineState(pipelineStateDescriptor);
@@ -503,3 +531,5 @@ namespace AZ
         }
     } // namespace RPI
 } // namespace AZ
+
+#pragma optimize("", on)


### PR DESCRIPTION
[PerMeshShaderOption.zip](https://github.com/carbonated-dev/o3de/files/14594863/PerMeshShaderOption.zip)
## What does this PR do?

When mesh instancing is enabled, r_enablePerMeshShaderOptionFlags was ignored previously. 
With the change in this PR, when r_enablePerMeshShaderOptionFlags is enabled, the per mesh shader options can be applied the instance group's shared MeshDrawPacket. If all the ModelDataInstances which use the same instance group are using same shader option value, then we may apply the mesh shader options to the instance group's draw packet. 

## How was this PR tested?

Editor with grubber project (and the updated shader variant lists: https://github.com/carbonated-dev/o3de-gruber/pull/572). 
r_enablePerMeshShaderOptionFlags set to true
r_directionalShadowFilteringMethod set to 1
r_directionalShadowFilteringSampleCountMode set to 0
