### PR TITLE
Resolve ImGui toolbar overlapping (the game toolbar items are overlapped with O3DE toolbar items)

### DIFF
--- a/Gems/ImGui/Code/Source/LYCommonMenu/ImGuiLYCommonMenu.cpp
+++ b/Gems/ImGui/Code/Source/LYCommonMenu/ImGuiLYCommonMenu.cpp
@@ -233,8 +233,10 @@ namespace ImGui
                 ImGui::SetCursorPosX(prevCursorPos);
             }
 
+#if !defined(CARBONATED) // the line below resets toolbar position to the beginning and causes overlapping with the previously added toolbar items from the game. This line was absent in LY.
             // Add some space before the first menu so it won't overlap with view control buttons
             ImGui::SetCursorPosX(dpiAwareSizeFn(40.0f + viewportBorderPadding.m_left));
+#endif // !defined(CARBONATED)
 
             // Main Open 3D Engine menu
             if (ImGui::BeginMenu("O3DE"))


### PR DESCRIPTION
## What does this PR do?

Changes: exclude the line which resets ImGui toolbar position to the beginning and causes overlapping with the previously added toolbar items from the game. This line was absent in LY in the same method.

See PR result in the first ticket comment (no overlapping)

## How was this PR tested?

Locally (PC/Editor)
