### PR TITLE
Removed "from" from Script Canvas Input Value Source UI

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Variable/GraphVariable.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Variable/GraphVariable.cpp
@@ -146,8 +146,8 @@ namespace ScriptCanvas
 
     const char* GraphVariable::s_InitialValueSourceNames[VariableFlags::InitialValueSource::COUNT] =
     {
-        "From Graph",
-        "From Component"
+        "Graph",
+        "Component"
     };
 
     const char* GraphVariable::s_ScopeNames[static_cast<int>(VariableFlags::Scope::COUNT)] =


### PR DESCRIPTION
## What does this PR do?

Initial value source variables strings included the word From which didnt improve clarity and took up extra space.

![image](https://github.com/carbonated-dev/o3de/assets/29128124/014fd21b-7ae8-4fca-8513-70bc590ac5b2)
to
![image](https://github.com/carbonated-dev/o3de/assets/29128124/0d789a11-61cf-442f-b48b-cd5765a98397)



## How was this PR tested?

Checked output in editor UI
