### PR TITLE
Disable APK compression on pak files

### DIFF
--- a/Code/Tools/Android/ProjectBuilder/build.gradle.in
+++ b/Code/Tools/Android/ProjectBuilder/build.gradle.in
@@ -65,6 +65,10 @@ ${OVERRIDE_JAVA_SOURCESET}
         pickFirst '**/*.so'
     }
 
+    aaptOptions {
+        noCompress 'pak'
+    }
+
 }
 
 // Inject the zip64 option into package task to allow 4GiB apks


### PR DESCRIPTION
## What does this PR do?

Disable APK compression on pak files because the AAsset_seek is very slow for compressed files.

## How was this PR tested?

Run Android with pak files on APK