### PR TITLE
Converted sys_assert definition from REGISTER_CVAR2_CB to AZ_CVAR

### DIFF
--- a/Code/Framework/AzCore/AzCore/Debug/Trace.cpp
+++ b/Code/Framework/AzCore/AzCore/Debug/Trace.cpp
@@ -90,7 +90,7 @@ namespace AZ::Debug
     AZ_CVAR_SCOPED(int, bg_traceLogLevel, static_cast<int>(LogLevel::Info), &TraceLevelChanged, ConsoleFunctorFlags::Null, "Enable trace message logging in release mode.  0=disabled, 1=errors, 2=warnings, 3=info, 4=debug, 5=trace.");
     AZ_CVAR_SCOPED(bool, bg_alwaysShowCallstack, false, &AlwaysShowCallstackChanged, ConsoleFunctorFlags::Null, "Force stack trace output without allowing ebus interception.");
 #if defined(CARBONATED)
-    AZ_CVAR_SCOPED(int, bg_assertDialogReady, 0, nullptr, ConsoleFunctorFlags::Null, "Show assertion popup dialog: 0=disabled, 1=enabled.");
+    AZ_CVAR(int, bg_assertDialogReady, 0, nullptr, ConsoleFunctorFlags::Null, "Show assertion popup dialog: 0=disabled, 1=enabled.");
 #endif
     // Allow redirection of trace raw output writes to stdout, stderr or to /dev/null
     static constexpr const char* fileStreamIdentifier = "raw_c_stream";
@@ -390,9 +390,15 @@ namespace AZ::Debug
             }
 
             bool assertsAutoBreak = false;
+#if defined(CARBONATED)
+            int assertDialogReady = 0;
+#endif
             if (auto* console = Interface<IConsole>::Get())
             {
                 console->GetCvarValue("bg_assertsAutoBreak", assertsAutoBreak);
+#if defined(CARBONATED)
+                console->GetCvarValue("bg_assertDialogReady", assertDialogReady);
+#endif
             }
             if (assertsAutoBreak && IsDebuggerPresent())
             {
@@ -404,7 +410,7 @@ namespace AZ::Debug
             //display native UI dialogs at verbosity level 2 or higher
             else if (currentLevel >= assertLevel_nativeUI
 #if defined(CARBONATED)
-                && bg_assertDialogReady != 0
+                && assertDialogReady != 0
 #endif
                 )
             {

--- a/Code/Legacy/CrySystem/System.cpp
+++ b/Code/Legacy/CrySystem/System.cpp
@@ -977,7 +977,11 @@ void CSystem::WarningV(EValidatorModule module, EValidatorSeverity severity, int
     }
     m_env.pLog->LogWithType(ltype, flags | VALIDATOR_FLAG_SKIP_VALIDATOR, "%s", fmt.c_str());
 
+#if defined(CARBONATED)
+    if (bDbgBreak && Legacy::System::CVars::sys_error_debugbreak)
+#else
     if (bDbgBreak && g_cvars.sys_error_debugbreak)
+#endif
     {
         AZ::Debug::Trace::Instance().Break();
     }
@@ -1203,10 +1207,12 @@ void CSystem::SetAssertLevel(int _assertlevel)
     }
 }
 
+#if !defined(CARBONATED)
 void CSystem::OnAssertLevelCvarChanged(ICVar* pArgs)
 {
     SetAssertLevel(pArgs->GetIVal());
 }
+#endif
 
 void CSystem::SetLogLevel(int _loglevel)
 {

--- a/Code/Legacy/CrySystem/System.h
+++ b/Code/Legacy/CrySystem/System.h
@@ -19,6 +19,10 @@
 #include <AzFramework/Archive/ArchiveVars.h>
 #include <CryCommon/LoadScreenBus.h>
 
+#if defined(CARBONATED)
+#include <AzCore/Console/IConsole.h>
+#endif
+
 #include <AzCore/Module/DynamicModuleHandle.h>
 #include <AzCore/Math/Crc.h>
 
@@ -99,13 +103,25 @@ struct SSystemCVars
     float sys_update_profile_time;
     int sys_MaxFPS;
     float sys_maxTimeStepForMovieSystem;
-    
+
+#if defined(CARBONATED)
+    // Moved to Legacy::System::CVars
+#else
     int sys_asserts;
     int sys_error_debugbreak;
+#endif
 
     AZ::IO::ArchiveVars archiveVars;
 };
 extern SSystemCVars g_cvars;
+
+#if defined(CARBONATED)
+namespace Legacy::System::CVars
+{
+    AZ_CVAR_EXTERNED(int, sys_asserts);
+    AZ_CVAR_EXTERNED(int, sys_error_debugbreak);
+} // namespace Legacy::System::CVars
+#endif
 
 class CSystem;
 
@@ -134,7 +150,9 @@ public:
     static void OnLanguageCVarChanged(ICVar* language);
     static void OnLocalizationFolderCVarChanged(ICVar* const pLocalizationFolder);
     // adding CVAR to toggle assert verbosity level
+#if !defined(CARBONATED)
     static void OnAssertLevelCvarChanged(ICVar* pArgs);
+#endif
     static void SetAssertLevel(int _assertlevel);
     static void OnLogLevelCvarChanged(ICVar* pArgs);
     static void SetLogLevel(int _logLevel);

--- a/Code/Legacy/CrySystem/System.h
+++ b/Code/Legacy/CrySystem/System.h
@@ -149,8 +149,8 @@ public:
 
     static void OnLanguageCVarChanged(ICVar* language);
     static void OnLocalizationFolderCVarChanged(ICVar* const pLocalizationFolder);
-    // adding CVAR to toggle assert verbosity level
 #if !defined(CARBONATED)
+    // adding CVAR to toggle assert verbosity level
     static void OnAssertLevelCvarChanged(ICVar* pArgs);
 #endif
     static void SetAssertLevel(int _assertlevel);

--- a/Code/Legacy/CrySystem/SystemInit.cpp
+++ b/Code/Legacy/CrySystem/SystemInit.cpp
@@ -1162,9 +1162,7 @@ bool CSystem::Init(const SSystemInitParams& startupParams)
     }
 
     m_bInitializedSuccessfully = true;
-#if defined(CARBONATED)
-    AZ::Interface<AZ::IConsole>::Get()->PerformCommand("bg_assertDialogReady 1");
-#endif
+
     return true;
 }
 

--- a/Code/Legacy/CrySystem/SystemInit.cpp
+++ b/Code/Legacy/CrySystem/SystemInit.cpp
@@ -1006,6 +1006,9 @@ bool CSystem::Init(const SSystemInitParams& startupParams)
 #else
         if (g_cvars.sys_asserts == 2)
 #endif
+        {
+            gEnv->bNoAssertDialog = true;
+        }
 
         LogBuildInfo();
 

--- a/Code/Legacy/CrySystem/SystemInit.cpp
+++ b/Code/Legacy/CrySystem/SystemInit.cpp
@@ -1193,6 +1193,26 @@ static AZStd::string ConcatPath(const char* szPart1, const char* szPart2)
     return ret;
 }
 
+#if defined(CARBONATED)
+static void cvar_OnAssertLevelCvarChanged(const int& assertLevel)
+{
+    CSystem::SetAssertLevel(assertLevel);
+}
+
+AZ_CVAR(
+    int,
+    sys_asserts,
+    1,
+    cvar_OnAssertLevelCvarChanged,
+    AZ::ConsoleFunctorFlags::IsCheat,
+    "0 = Suppress Asserts\n"
+    "1 = Log Asserts\n"
+    "2 = Show Assert Dialog\n"
+    "3 = Crashes the Application on Assert\n"
+    "Note: when set to '0 = Suppress Asserts', assert expressions are still evaluated. To turn asserts into a no-op, undefine "
+    "AZ_ENABLE_TRACING and recompile.");
+#endif
+
 //////////////////////////////////////////////////////////////////////////
 void CSystem::CreateSystemVars()
 {
@@ -1433,6 +1453,8 @@ void CSystem::CreateSystemVars()
 
     // adding CVAR to toggle assert verbosity level
     const int defaultAssertValue = 1;
+
+#if !defined(CARBONATED)
     REGISTER_CVAR2_CB(
         "sys_asserts",
         &g_cvars.sys_asserts,
@@ -1445,6 +1467,8 @@ void CSystem::CreateSystemVars()
         "Note: when set to '0 = Suppress Asserts', assert expressions are still evaluated. To turn asserts into a no-op, undefine "
         "AZ_ENABLE_TRACING and recompile.",
         OnAssertLevelCvarChanged);
+#endif
+
     CSystem::SetAssertLevel(defaultAssertValue);
 
     REGISTER_CVAR2(

--- a/Gems/ImGui/Code/Source/LYCommonMenu/ImGuiLYCommonMenu.cpp
+++ b/Gems/ImGui/Code/Source/LYCommonMenu/ImGuiLYCommonMenu.cpp
@@ -664,6 +664,22 @@ namespace ImGui
                 if (ImGui::BeginMenu("Misc."))
                 {
                     // Assert Level
+#if defined(CARBONATED)
+                    if (console != nullptr)
+                    {
+                        int assertLevelValue = 0;
+                        if (console->GetCvarValue("sys_asserts", assertLevelValue) == AZ::GetValueResult::Success)
+                        {
+                            int dragIntVal = assertLevelValue;
+                            ImGui::Text("sys_asserts: %d ( 0-off | 1-log | 2-popup | 3-crash )", assertLevelValue);
+                            ImGui::SliderInt("##sys_asserts", &dragIntVal, 0, 3);
+                            if (dragIntVal != assertLevelValue)
+                            {
+                                console->PerformCommand(AZStd::string::format("sys_asserts %d", dragIntVal).c_str());
+                            }
+                        }
+                    }
+#else
                     static ICVar* gAssertLevelCVAR = gEnv->pConsole->GetCVar("sys_asserts");
                     if (gAssertLevelCVAR)
                     {
@@ -676,6 +692,7 @@ namespace ImGui
                             gAssertLevelCVAR->Set(dragIntVal);
                         }
                     }
+#endif
 
                     // End Misc Options Menu
                     ImGui::EndMenu();


### PR DESCRIPTION
## What does this PR do?

Converted sys_assert definition from REGISTER_CVAR2_CB to AZ_CVAR to make sure that the callback that sets the respective AZ::Environment variable is invoked.

## How was this PR tested?

Tested locally
