### PR TITLE
Fix a crash that when a spot light was removed from the level.

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/MultiIndexedDataVector.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/MultiIndexedDataVector.h
@@ -224,6 +224,18 @@ namespace AZ
                 }
             }
 
+            template<typename LambdaType>
+            void ForEach(LambdaType lambda) const
+            {
+                for (auto& elementIdx : m_dataToIndices)
+                {
+                    if (!lambda(elementIdx))
+                    {
+                        break;
+                    }
+                }
+            }
+
         private:
             using Fn = void(&)(AZStd::vector<Ts>& ...);
 


### PR DESCRIPTION
## What does this PR do?
This PR fixed a crash when a simple spot light was removed from the level. 

## How was this PR tested?

Editor. Create a level with few simple spot lights. Delete one of them which was created first. No crash happens.
