### PR TITLE
Fix Animation Event Node Tooltip Recording Crash

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TrackDataWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/TimeView/TrackDataWidget.cpp
@@ -2585,7 +2585,7 @@ namespace EMStudio
                 EMotionFX::AnimGraphNode* curNode = node->GetParentNode();
                 while (curNode)
                 {
-                    nodePath.emplace(0, curNode);
+                    nodePath.emplace(nodePath.begin(), curNode);
                     curNode = curNode->GetParentNode();
                 }
 


### PR DESCRIPTION
Fixes a crash when trying to emplace animation event node data into a vector. 
AZStd::vector::emplace first parameter an iterator, not an index into the vector

Fixes #17635

Note: standard c++ doesn't support passing '0' into std::vector::emplace.