### PR TITLE
Fix sprite texture existance check

### DIFF
--- a/Gems/LyShine/Code/Source/Sprite.cpp
+++ b/Gems/LyShine/Code/Source/Sprite.cpp
@@ -750,7 +750,9 @@ bool CSprite::DoesSpriteTextureAssetExist(const AZStd::string& pathname)
     }
 
     // Check if the texture asset exists
-    bool textureExists = CheckIfFileExists(spritePath, texturePath);
+    const AZStd::string cacheRelativePath = AZStd::string::format("%s.%s", pathname.c_str(), streamingImageExtension);
+    bool textureExists = CheckIfFileExists(/* sourceRelativePath = */ pathname, cacheRelativePath);
+
     return textureExists;
 }
 


### PR DESCRIPTION
## What does this PR do?

Fix sprite texture existence check.
The original call used both parameters wrong.

Target function:
bool CheckIfFileExists(const AZStd::string& sourceRelativePath, const AZStd::string& cacheRelativePath)

Params provided before the fix:
sprite name (.sprite) that typically does not exist,
cache path for the original texture name (like .png) that cannot be in the cache unprocessed.

## How was this PR tested?

Local text with Windows standalone build, synthetic call with particular png texture name.
