### PR TITLE
[MAD-14953] Fix O3DE crashes in DecalTextureArray::GetRawImageData() when texures in material have different MIP levels

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArray.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArray.cpp
@@ -298,10 +298,17 @@ namespace AZ
             {
                 return {};
             }
-            AZ_Assert(
-                mip < image->GetImageDescriptor().m_mipLevels,
-                "It is expected that all decals in a texture array must have the same number of mips which may not be the case here. "
-                "Please ensure that all the materials within m_materials are pointing to textures with same mips.");
+            // Gruber patch begin // STA : detailed error log and exit to prevent crash
+            if (mip >= image->GetImageDescriptor().m_mipLevels)
+            {
+                AZ_Error("DecalTextureArray", false,
+                    "It is expected that all decals in a texture array must have the same number of mips which may not be the case here. "
+                    "Please ensure that all the materials within m_materials are pointing to textures with same mips.\n"
+                    "Needed mip #%i, max mip #%i, asset '%s'."
+                    , mip, image->GetImageDescriptor().m_mipLevels - 1, m_materials[arrayLevel].m_materialAssetData.GetHint().c_str());
+                return {};
+            }
+            // Gruber patch end // STA
 
             const auto srcData = image->GetSubImageData(mip, 0);
             return srcData;

--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArray.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArray.cpp
@@ -298,7 +298,7 @@ namespace AZ
             {
                 return {};
             }
-            // Gruber patch begin // STA : detailed error log and exit to prevent crash
+#if defined(CARBONATED) // detailed error log and exit to prevent crash
             if (mip >= image->GetImageDescriptor().m_mipLevels)
             {
                 AZ_Error("DecalTextureArray", false,
@@ -308,7 +308,12 @@ namespace AZ
                     , mip, image->GetImageDescriptor().m_mipLevels - 1, m_materials[arrayLevel].m_materialAssetData.GetHint().c_str());
                 return {};
             }
-            // Gruber patch end // STA
+#else 
+            AZ_Assert(
+                mip < image->GetImageDescriptor().m_mipLevels,
+                "It is expected that all decals in a texture array must have the same number of mips which may not be the case here. "
+                "Please ensure that all the materials within m_materials are pointing to textures with same mips.");
+#endif // defined(CARBONATED)
 
             const auto srcData = image->GetSubImageData(mip, 0);
             return srcData;


### PR DESCRIPTION
### Ticket : [MAD-14953](https://jira.carbonated.com:8443/browse/MAD-14953)

## What does this PR do?
* Fixes O3DE crashes in DecalTextureArray::GetRawImageData() by not simply checking for valid MIP levels number, but returning the valid `{}` result in case of invalid MIP levels in a texture;
* Also changes `AZ_Assert()` to `AZ_Error()` with detailed description of the problem including the involved asset path.

## How was this PR tested?
Newly ported Urban_01 level loaded in Editor, related Errors noted in the log.

## Note for Artisits:
Number of MIP levels in all textures in a Decal material should be equal, so please carefully set `.assetinfo`.