### PR TITLE
[MAD-14323] Implement missing MW-added methods in CharacterControllerComponent

### DIFF
--- a/Gems/PhysX/Code/Include/PhysX/CharacterControllerBus.h
+++ b/Gems/PhysX/Code/Include/PhysX/CharacterControllerBus.h
@@ -59,7 +59,8 @@ namespace PhysX
         /// @param halfForwardExtent The new half forward extent for the controller.
         virtual void SetHalfForwardExtent(float halfForwardExtent) = 0;
 
-#if defined(CARBONATED) // Methods added to setup character collider so that to differentiate character collisions from other collisions
+#if defined(CARBONATED)
+        // Methods added to setup character collider so that to differentiate character collisions from other collisions
         /// Changes collider layer and group to given names.
         virtual void SetCharacterCollisions(const AZStd::string& layer, const AZStd::string& group) = 0;
 

--- a/Gems/PhysX/Code/Include/PhysX/CharacterControllerBus.h
+++ b/Gems/PhysX/Code/Include/PhysX/CharacterControllerBus.h
@@ -10,6 +10,10 @@
 
 #include <AzCore/Component/ComponentBus.h>
 
+#if defined(CARBONATED)
+#include <PhysX/Material/PhysXMaterial.h>
+#endif // defined(CARBONATED)
+
 namespace AZ
 {
     class Vector3;
@@ -55,14 +59,18 @@ namespace PhysX
         /// @param halfForwardExtent The new half forward extent for the controller.
         virtual void SetHalfForwardExtent(float halfForwardExtent) = 0;
 
-        // carbonated begin enable_carbonated_1: Methods called from o3de-gruber
-#if defined(CARBONATED)
+#if defined(CARBONATED) // Methods added to setup character collider so that to differentiate character collisions from other collisions
+        /// Changes collider layer and group to given names.
         virtual void SetCharacterCollisions(const AZStd::string& layer, const AZStd::string& group) = 0;
 
+        /// Changes Physics::MaterialAsset in the slot referenced by index. Index 0 usually correponds to "Entire object" slot.
+        virtual void SetMaterial(uint32_t index, const AZ::Data::Asset<Physics::MaterialAsset>& materialAsset) = 0;
+        [[deprecated("Use SetMaterial(uint32_t,).const AZ::Data::Asset<Physics::MaterialAsset>&")]]
         virtual void SetMaterialByName(uint32_t index, const AZStd::string& name) = 0;
+
+        /// Changes collider Tag to given AZ::Crc32(AZStd::string tagName).
         virtual void SetTag(const AZ::Crc32& tag) = 0;
-#endif
-        // carbonated end enable_carbonated_1
+#endif // defined(CARBONATED)
     };
     using CharacterControllerRequestBus = AZ::EBus<CharacterControllerRequests>;
 } // namespace PhysX

--- a/Gems/PhysX/Code/Include/PhysX/CharacterControllerBus.h
+++ b/Gems/PhysX/Code/Include/PhysX/CharacterControllerBus.h
@@ -65,7 +65,7 @@ namespace PhysX
 
         /// Changes Physics::MaterialAsset in the slot referenced by index. Index 0 usually correponds to "Entire object" slot.
         virtual void SetMaterial(uint32_t index, const AZ::Data::Asset<Physics::MaterialAsset>& materialAsset) = 0;
-        [[deprecated("Use SetMaterial(uint32_t,).const AZ::Data::Asset<Physics::MaterialAsset>&")]]
+        [[deprecated("Use SetMaterial(uint32_t, const AZ::Data::Asset<Physics::MaterialAsset>&")]]
         virtual void SetMaterialByName(uint32_t index, const AZStd::string& name) = 0;
 
         /// Changes collider Tag to given AZ::Crc32(AZStd::string tagName).

--- a/Gems/PhysX/Code/Source/PhysXCharacters/API/CharacterController.cpp
+++ b/Gems/PhysX/Code/Source/PhysXCharacters/API/CharacterController.cpp
@@ -377,7 +377,7 @@ namespace PhysX
         }
     }
 
-#if defined(CARBONATED) // called from CharacterControllerComponent::SetTag(const AZ::Crc32& tag) used in Gruber
+#if defined(CARBONATED) // provide means for custom collider setup in a game
     void CharacterController::SetTag(const AZ::Crc32& tag)
     {
         m_colliderTag = tag;

--- a/Gems/PhysX/Code/Source/PhysXCharacters/API/CharacterController.cpp
+++ b/Gems/PhysX/Code/Source/PhysXCharacters/API/CharacterController.cpp
@@ -377,6 +377,13 @@ namespace PhysX
         }
     }
 
+#if defined(CARBONATED) // called from CharacterControllerComponent::SetTag(const AZ::Crc32& tag) used in Gruber
+    void CharacterController::SetTag(const AZ::Crc32& tag)
+    {
+        m_colliderTag = tag;
+    }
+#endif // defined(CARBONATED)
+
     void CharacterController::SetTag(const AZStd::string& tag)
     {
         m_colliderTag = AZ::Crc32(tag);

--- a/Gems/PhysX/Code/Source/PhysXCharacters/API/CharacterController.h
+++ b/Gems/PhysX/Code/Source/PhysXCharacters/API/CharacterController.h
@@ -232,6 +232,10 @@ namespace PhysX
         float GetHalfForwardExtent() const;
         void SetHalfForwardExtent(float halfForwardExtent);
 
+#if defined(CARBONATED) // called from CharacterControllerComponent::SetTag(const AZ::Crc32& tag) used in Gruber
+        void SetTag(const AZ::Crc32& tag);
+#endif // defined(CARBONATED)
+
     private:
         void SetFilterDataAndShape(const Physics::CharacterConfiguration& characterConfig);
         void SetUserData(const Physics::CharacterConfiguration& characterConfig);

--- a/Gems/PhysX/Code/Source/PhysXCharacters/API/CharacterController.h
+++ b/Gems/PhysX/Code/Source/PhysXCharacters/API/CharacterController.h
@@ -232,7 +232,7 @@ namespace PhysX
         float GetHalfForwardExtent() const;
         void SetHalfForwardExtent(float halfForwardExtent);
 
-#if defined(CARBONATED) // called from CharacterControllerComponent::SetTag(const AZ::Crc32& tag) used in Gruber
+#if defined(CARBONATED) // provide means for custom collider setup in a game
         void SetTag(const AZ::Crc32& tag);
 #endif // defined(CARBONATED)
 

--- a/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterControllerComponent.cpp
+++ b/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterControllerComponent.cpp
@@ -366,7 +366,9 @@ namespace PhysX
         }
     }
 
- #if defined(CARBONATED) // Methods added to differentiate character collisions from other collisions
+ #if defined(CARBONATED)
+    // Methods added to differentiate character collisions from other collisions
+
     //This exists solely to help differentiate the character collider from the other colliders we use for vision/touch/etc
     void CharacterControllerComponent::SetCharacterCollisions(const AZStd::string& layer, const AZStd::string& group)
     {
@@ -391,9 +393,9 @@ namespace PhysX
 
     void CharacterControllerComponent::SetTag(const AZ::Crc32& tag)
     {
-        if (auto controller = GetController())
+        if (auto pController = GetController())
         {
-            controller->SetTag(tag);
+            pController->SetTag(tag);
         }
     }
 #endif // defined(CARBONATED)

--- a/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterControllerComponent.cpp
+++ b/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterControllerComponent.cpp
@@ -386,7 +386,6 @@ namespace PhysX
             , "SetMaterial(): Invalid materialAsset passed for Entity %s.", GetEntityId().ToString().c_str());
         AZ_Warning("CharacterControllerComponent", index < m_characterConfig->m_materialSlots.GetSlotsCount()
             , "SetMaterial(): Invalid index %li passed for Entity %s.", index, GetEntityId().ToString().c_str());
-        return;
         m_characterConfig->m_materialSlots.SetMaterialAsset(index, materialAsset);
     }
 

--- a/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterControllerComponent.cpp
+++ b/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterControllerComponent.cpp
@@ -366,58 +366,38 @@ namespace PhysX
         }
     }
 
-    // carbonated begin enable_carbonated_1: Methods called from o3de-gruber
- #if defined(CARBONATED)
+ #if defined(CARBONATED) // Methods added to differentiate character collisions from other collisions
     //This exists solely to help differentiate the character collider from the other colliders we use for vision/touch/etc
     void CharacterControllerComponent::SetCharacterCollisions(const AZStd::string& layer, const AZStd::string& group)
     {
         SetCollisionLayer(layer, AZ::Crc32());
         SetCollisionGroup(group, AZ::Crc32());
     }
-    
-    // Pilfered/inspired from SystemComponent::UpdateMaterialSelection
-    void CharacterControllerComponent::SetMaterialByName(uint32_t /*index*/, const AZStd::string& /*name*/) // Parameters are temporary commented to prevent warning
+
+    // Pilfered/inspired from LY's SystemComponent::UpdateMaterialSelection
+    void CharacterControllerComponent::SetMaterial(uint32_t index, const AZ::Data::Asset<Physics::MaterialAsset>& materialAsset)
     {
-        AZ_Assert(m_characterConfig, "Character Config is null!");
-
-        // This code is commented because not compatible with o3de
-        /*
-        Physics::MaterialAsset::MaterialFromAssetConfiguration materialConfig;
-        const Physics::MaterialLibraryAsset* materialLibrary = m_characterConfig->m_materialSelection.GetMaterialLibraryAssetData();
-        
-        if (materialLibrary == nullptr)
+        if (!m_characterConfig)
         {
-            AZ::Data::AssetId materialLibraryAssetId = m_characterConfig->m_materialSelection.GetMaterialLibraryAssetId();
-            m_characterConfig->m_materialSelection.SetMaterialLibrary(materialLibraryAssetId);
-
-            // Try again
-            materialLibrary = m_characterConfig->m_materialSelection.GetMaterialLibraryAssetData();
+            AZ_Error("CharacterControllerComponent", false, "SetMaterial(): Null Character Config for Entity %s.", GetEntityId().ToString().c_str());
+            return;
         }
-
-        if (materialLibrary && materialLibrary->GetDataForMaterialName(name, materialConfig))
-        {
-            m_characterConfig->m_materialSelection.SetMaterialId(materialConfig.m_id, index);
-            m_controller->SetMaterial(m_characterConfig->m_materialSelection);
-        }
-        else
-        {
-            AZ_TracePrintf(
-                "CharacterControllerComponent",
-                "SetMaterialByName failed!  Could not load the Material Library or get the material data for '%s'",
-                name.c_str());
-        }
-        */
+        AZ_Warning("CharacterControllerComponent", materialAsset
+            , "SetMaterial(): Invalid materialAsset passed for Entity %s.", GetEntityId().ToString().c_str());
+        AZ_Warning("CharacterControllerComponent", index < m_characterConfig->m_materialSlots.GetSlotsCount()
+            , "SetMaterial(): Invalid index %li passed for Entity %s.", index, GetEntityId().ToString().c_str());
+        return;
+        m_characterConfig->m_materialSlots.SetMaterialAsset(index, materialAsset);
     }
 
-    void CharacterControllerComponent::SetTag(const AZ::Crc32& /*tag*/) // Parameter name is temporary commented to prevent warning
+    void CharacterControllerComponent::SetTag(const AZ::Crc32& tag)
     {
-        // This code is commented because not compatible with o3de
-        /*
-        m_controller->SetColliderTag(tag);
-        */
+        if (auto controller = GetController())
+        {
+            controller->SetTag(tag);
+        }
     }
-#endif
-    // carbonated end enable_carbonated_1
+#endif // defined(CARBONATED)
 
     // TransformNotificationBus
     void CharacterControllerComponent::OnTransformChanged(const AZ::Transform& /*local*/, const AZ::Transform& world)

--- a/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterControllerComponent.h
+++ b/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterControllerComponent.h
@@ -125,7 +125,8 @@ namespace PhysX
         float GetHalfForwardExtent() override;
         void SetHalfForwardExtent(float halfForwardExtent) override;
 
-#if defined(CARBONATED) // Methods added to setup character collider so that to differentiate character collisions from other collisions
+#if defined(CARBONATED)
+        // Methods added to setup character collider so that to differentiate character collisions from other collisions
         // Changes collider layer and group to given names.
         void SetCharacterCollisions(const AZStd::string& layer, const AZStd::string& group) override;
         // Changes Physics::MaterialAsset in the slot referenced by index. Index 0 usually correponds to "Entire object" slot.

--- a/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterControllerComponent.h
+++ b/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterControllerComponent.h
@@ -130,8 +130,8 @@ namespace PhysX
         void SetCharacterCollisions(const AZStd::string& layer, const AZStd::string& group) override;
         // Changes Physics::MaterialAsset in the slot referenced by index. Index 0 usually correponds to "Entire object" slot.
         void SetMaterial(uint32_t index, const AZ::Data::Asset<Physics::MaterialAsset>& materialAsset) override;
-        [[deprecated("Use SetMaterial(uint32_t,).const AZ::Data::Asset<Physics::MaterialAsset>&")]] void SetMaterialByName(
-            [[maybe_unused]] uint32_t index, [[maybe_unused]] const AZStd::string& name) override{};
+        [[deprecated("Use SetMaterial(uint32_t, const AZ::Data::Asset<Physics::MaterialAsset>&")]]
+        void SetMaterialByName([[maybe_unused]] uint32_t index, [[maybe_unused]] const AZStd::string& name) override {};
         // Changes collider Tag to given AZ::Crc32(AZStd::string tagName).
         void SetTag(const AZ::Crc32& tag) override;
 #endif // defined(CARBONATED)

--- a/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterControllerComponent.h
+++ b/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterControllerComponent.h
@@ -125,13 +125,16 @@ namespace PhysX
         float GetHalfForwardExtent() override;
         void SetHalfForwardExtent(float halfForwardExtent) override;
 
-        // carbonated begin enable_carbonated_1: Methods called from o3de-gruber
-#if defined(CARBONATED)
+#if defined(CARBONATED) // Methods added to setup character collider so that to differentiate character collisions from other collisions
+        // Changes collider layer and group to given names.
         void SetCharacterCollisions(const AZStd::string& layer, const AZStd::string& group) override;
-        void SetMaterialByName(uint32_t index, const AZStd::string& name) override;
+        // Changes Physics::MaterialAsset in the slot referenced by index. Index 0 usually correponds to "Entire object" slot.
+        void SetMaterial(uint32_t index, const AZ::Data::Asset<Physics::MaterialAsset>& materialAsset) override;
+        [[deprecated("Use SetMaterial(uint32_t,).const AZ::Data::Asset<Physics::MaterialAsset>&")]] void SetMaterialByName(
+            [[maybe_unused]] uint32_t index, [[maybe_unused]] const AZStd::string& name) override{};
+        // Changes collider Tag to given AZ::Crc32(AZStd::string tagName).
         void SetTag(const AZ::Crc32& tag) override;
-#endif
-        // carbonated end enable_carbonated_1
+#endif // defined(CARBONATED)
 
         // TransformNotificationBus
         void OnTransformChanged(const AZ::Transform& local, const AZ::Transform& world) override;


### PR DESCRIPTION
### Ticket:
[MAD-14323](https://jira.carbonated.com:8443/browse/MAD-14323)

## What does this PR do?
Implements commented-out methods, which were added to `CharacterControllerRequestBus` and  `CharacterControllerComponent`, - in order to to setup Character collider so that to differentiate Character collisions from other collisions. 
* Implements `SetTag(const AZ::Crc32& tag)`; in order to change the needed private member `CharacterController::m_colliderTag`  this PR also adds public  `CharacterController::SetTag(const AZ::Crc32& tag);` method;
* In order to simplify patched code of O3DE PhysX Gem, - moving significant part of code emulating deprecated  `Physics::MaterialLibraryAsset` to client/game side, this PR:
* * Flags `CharacterControllerRequestBus::SetMaterialByName` method as deprecated until it can be totally removed;
* * Adds `CharacterControllerRequestBus::SetMaterial` method to be used instead, with 2nd parameter representing ready pointer to `Physics::MaterialAsset`;
* * Flags `CharacterControllerComponent::SetMaterialByName` handler method as deprecated and makes it `{}`;
* * Adds now trivial `CharacterControllerComponent::SetMaterial` method implementation.

## How was this PR tested?
Game was run in Editor with refactored client code using `SetMaterial()` method,
materials for Character Collider Capsule were replaced.
Additional check was made to ensure that requesting deprecated `SetMaterialByName()` does nothing.

Related PR to Gruber: [here](https://github.com/carbonated-dev/o3de-gruber/pull/628).
