### PR TITLE
Fix some exit crash

### DIFF
--- a/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Module/DynamicModuleHandle_WinAPI.cpp
+++ b/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Module/DynamicModuleHandle_WinAPI.cpp
@@ -102,9 +102,8 @@ namespace AZ
             if (wcharResult == 0)
             {
                 // If module already open, return false, it was not loaded.
-                m_handle = GetModuleHandleW(fileNameW);
-                alreadyLoaded = NULL != m_handle;
-                if (!noLoad)
+                alreadyLoaded = NULL != GetModuleHandleW(fileNameW);
+                if (alreadyLoaded || !noLoad)
                 {
                     m_handle = LoadLibraryW(fileNameW);
                 }

--- a/Gems/Atom/RHI/Vulkan/Code/CMakeLists.txt
+++ b/Gems/Atom/RHI/Vulkan/Code/CMakeLists.txt
@@ -59,6 +59,7 @@ ly_add_target(
     BUILD_DEPENDENCIES
         PRIVATE
             AZ::AzCore
+            AZ::AzFramework
             Gem::Atom_RHI.Reflect
             Gem::Atom_RHI_Vulkan.Glad.Static
 )

--- a/Gems/Atom/RHI/Vulkan/Code/Include/Atom/RHI.Reflect/VkAllocator.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Include/Atom/RHI.Reflect/VkAllocator.h
@@ -25,7 +25,7 @@ namespace AZ
             VkSystemAllocator();
             ~VkSystemAllocator();
 
-            VkAllocationCallbacks m_allocationCallbacks;
+            VkAllocationCallbacks m_allocationCallbacks{};
         };
     }
 }

--- a/Gems/Atom/RHI/Vulkan/Code/Include/Atom/RHI.Reflect/VkAllocator.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Include/Atom/RHI.Reflect/VkAllocator.h
@@ -9,6 +9,7 @@
 #pragma once
 #include <AzCore/base.h>
 #include <AzCore/PlatformIncl.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <vulkan/vulkan.h>
 
 namespace AZ
@@ -25,7 +26,7 @@ namespace AZ
             VkSystemAllocator();
             ~VkSystemAllocator();
 
-            VkAllocationCallbacks m_allocationCallbacks{};
+            AZStd::unique_ptr<VkAllocationCallbacks> m_allocationCallbacks;
         };
     }
 }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Reflect/VkAllocator.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Reflect/VkAllocator.cpp
@@ -50,6 +50,8 @@ namespace AZ
                 m_allocationCallbacks->pfnFree = RHI_vkFreeFunction;
                 m_allocationCallbacks->pfnReallocation = RHI_vkReallocationFunction;
                 m_allocationCallbacks->pfnAllocation = RHI_vkAllocationFunction;
+                m_allocationCallbacks->pfnInternalAllocation = nullptr;
+                m_allocationCallbacks->pfnInternalFree = nullptr;
             }
         }
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Reflect/VkAllocator.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Reflect/VkAllocator.cpp
@@ -46,9 +46,10 @@ namespace AZ
             // Because of this we deactivate callbacks when using Renderdoc.
             if (!RHI::GraphicsProfilerBus::HasHandlers())
             {
-                m_allocationCallbacks.pfnFree = RHI_vkFreeFunction;
-                m_allocationCallbacks.pfnReallocation = RHI_vkReallocationFunction;
-                m_allocationCallbacks.pfnAllocation = RHI_vkAllocationFunction;
+                m_allocationCallbacks = AZStd::make_unique<VkAllocationCallbacks>();
+                m_allocationCallbacks->pfnFree = RHI_vkFreeFunction;
+                m_allocationCallbacks->pfnReallocation = RHI_vkReallocationFunction;
+                m_allocationCallbacks->pfnAllocation = RHI_vkAllocationFunction;
             }
         }
 
@@ -59,7 +60,7 @@ namespace AZ
         VkAllocationCallbacks* VkSystemAllocator::Get()
         {
             static VkSystemAllocator allocator;
-            return &allocator.m_allocationCallbacks;
+            return allocator.m_allocationCallbacks.get();
         }
     }
 }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Reflect/VkAllocator.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Reflect/VkAllocator.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <Atom/RHI.Reflect/VkAllocator.h>
+#include <Atom/RHI.Profiler/GraphicsProfilerBus.h>
 #include <AzCore/Memory/SystemAllocator.h>
 
 namespace AZ
@@ -40,16 +41,19 @@ namespace AZ
 
         VkSystemAllocator::VkSystemAllocator()
         {
-            m_allocationCallbacks.pfnFree = RHI_vkFreeFunction;
-            m_allocationCallbacks.pfnReallocation = RHI_vkReallocationFunction;
-            m_allocationCallbacks.pfnAllocation = RHI_vkAllocationFunction;
-            m_allocationCallbacks.pfnInternalAllocation = nullptr;
-            m_allocationCallbacks.pfnInternalFree = nullptr;
+            // For instance creation/destruction use nullptr for VkAllocationCallbacks* as using VkSystemAllocator::Get() crashes RenderDoc
+            // when used with openxr enabled projects. We think it's because RenderDoc is maybe injecting something when doing allocations.
+            // Because of this we deactivate callbacks when using Renderdoc.
+            if (!RHI::GraphicsProfilerBus::HasHandlers())
+            {
+                m_allocationCallbacks.pfnFree = RHI_vkFreeFunction;
+                m_allocationCallbacks.pfnReallocation = RHI_vkReallocationFunction;
+                m_allocationCallbacks.pfnAllocation = RHI_vkAllocationFunction;
+            }
         }
 
         VkSystemAllocator::~VkSystemAllocator()
         {
-
         }
 
         VkAllocationCallbacks* VkSystemAllocator::Get()

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Instance.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Instance.cpp
@@ -159,10 +159,7 @@ namespace AZ
             m_instanceCreateInfo.enabledExtensionCount = static_cast<uint32_t>(m_descriptor.m_requiredExtensions.size());
             m_instanceCreateInfo.ppEnabledExtensionNames = m_descriptor.m_requiredExtensions.data();
 
-            // For instance creation/destruction use nullptr for VkAllocationCallbacks* as using VkSystemAllocator::Get() crashes RenderDoc when used with openxr
-            // enabled projects. We think it's because RenderDoc is maybe injecting something when doing allocations. Using nullptr when USE_RENDERDOC or enableRenderDoc
-            // is enabled is another option but it will not work for Android easily and will require further work, not to mention manually enabling this for Android RenderDoc.
-            VkResult result = GetContext().CreateInstance(&m_instanceCreateInfo, nullptr, &m_instance);
+            VkResult result = GetContext().CreateInstance(&m_instanceCreateInfo, VkSystemAllocator::Get(), &m_instance);
 
             if (validation != RHI::ValidationMode::Disabled &&
                 (result == VK_ERROR_LAYER_NOT_PRESENT || result == VK_ERROR_EXTENSION_NOT_PRESENT))

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Instance.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Instance.cpp
@@ -159,7 +159,7 @@ namespace AZ
             m_instanceCreateInfo.enabledExtensionCount = static_cast<uint32_t>(m_descriptor.m_requiredExtensions.size());
             m_instanceCreateInfo.ppEnabledExtensionNames = m_descriptor.m_requiredExtensions.data();
 
-            VkResult result = GetContext().CreateInstance(&m_instanceCreateInfo, VkSystemAllocator::Get(), &m_instance);
+            VkResult result = GetContext().CreateInstance( &m_instanceCreateInfo, VkSystemAllocator::Get(), &m_instance);
 
             if (validation != RHI::ValidationMode::Disabled &&
                 (result == VK_ERROR_LAYER_NOT_PRESENT || result == VK_ERROR_EXTENSION_NOT_PRESENT))

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Instance.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Instance.h
@@ -52,8 +52,6 @@ namespace AZ
                 return m_loaderContext->GetContext();
             }
             const Descriptor& GetDescriptor() const;
-            StringList GetInstanceLayerNames() const;
-            StringList GetInstanceExtensionNames(const char* layerName = nullptr) const;
             RHI::PhysicalDeviceList GetSupportedDevices() const;
             AZ::RHI::ValidationMode GetValidationMode() const;
 

--- a/Gems/AtomLyIntegration/AtomFont/Code/Source/AtomFont.cpp
+++ b/Gems/AtomLyIntegration/AtomFont/Code/Source/AtomFont.cpp
@@ -486,7 +486,10 @@ FontFamilyPtr AZ::AtomFont::LoadFontFamily(const char* fontFamilyName)
                     fontFamily.reset(new FontFamily(),
                         [this](FontFamily* fontFamily)
                     {
-                        ReleaseFontFamily(fontFamily);
+                        if (AZ::Interface<AzFramework::FontQueryInterface>::Get())
+                        {
+                            ReleaseFontFamily(fontFamily);
+                        }
                     });
 
                     // Map the font family name both by path and by name defined
@@ -532,7 +535,10 @@ FontFamilyPtr AZ::AtomFont::LoadFontFamily(const char* fontFamilyName)
             fontFamily.reset(new FontFamily(),
                 [this](FontFamily* fontFamily)
             {
-                ReleaseFontFamily(fontFamily);
+                if (AZ::Interface<AzFramework::FontQueryInterface>::Get())
+                {
+                    ReleaseFontFamily(fontFamily);
+                }
             });
 
             // Use filepath as familyName so font loading/unloading doesn't break with duplicate file names


### PR DESCRIPTION
## What does this PR do?

Fix some crashes when exiting the app.
Remove Vulkan memory callbacks when using Renderdoc due to a crash and exception raised by the driver.

## How was this PR tested?

Run PC Vulkan