### PR TITLE
Removing the AZ::RPI::Image check as it's not an asset.

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
@@ -873,10 +873,15 @@ namespace AZ
             {
                 return AZStd::any(AZStd::any_cast<AZ::Data::Asset<AZ::RPI::ImageAsset>>(value).GetId());
             }
+#if defined(CARBONATED)
+            // AZ::RPI::Image is not an asset.
+#else
             if (value.is<AZ::Data::Instance<AZ::RPI::Image>>())
             {
                 return AZStd::any(AZStd::any_cast<AZ::Data::Instance<AZ::RPI::Image>>(value)->GetAssetId());
             }
+#endif
+
             return value;
         }
 


### PR DESCRIPTION
## What does this PR do?

Fixes an issue whereby we cannot set an Image property.  It removes and incorrect check for the RPI::Image which return the asset id.

## How was this PR tested?

Locally, on windows, with a custom shader that required an AttachmentImage to be set to the property of a material
