### PR TITLE
Added a call to execute deferred commands to settings registration

### DIFF
--- a/Code/Editor/Settings.cpp
+++ b/Code/Editor/Settings.cpp
@@ -834,6 +834,7 @@ void SEditorSettings::PostInitApply()
     CCryEditApp::instance()->KeepEditorActive(keepEditorActive > 0);
 
 #if defined(CARBONATED)
+    //This was added because these are registered so late that the deferred commands have already been ran, so they do not get set via setreg. Will be creating o3de issue to solve this better for all cvars that are registered late
     const auto pConsole = AZ::Interface<AZ::IConsole>::Get();
     AZ_Assert(pConsole, "Editor Settings is attempting to register console commands before AZ::Console is available.");
     pConsole->ExecuteDeferredConsoleCommands();

--- a/Code/Editor/Settings.cpp
+++ b/Code/Editor/Settings.cpp
@@ -832,6 +832,12 @@ void SEditorSettings::PostInitApply()
     REGISTER_CVAR2("g_TemporaryLevelName", &g_TemporaryLevelName, "temp_level", VF_NULL, "Temporary level named used for experimental levels.");
 
     CCryEditApp::instance()->KeepEditorActive(keepEditorActive > 0);
+
+#if defined(CARBONATED)
+    const auto pConsole = AZ::Interface<AZ::IConsole>::Get();
+    AZ_Assert(pConsole, "Multiplayer system is attempting to register console commands before AZ::Console is available.");
+    pConsole->ExecuteDeferredConsoleCommands();
+#endif
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/Settings.cpp
+++ b/Code/Editor/Settings.cpp
@@ -835,7 +835,7 @@ void SEditorSettings::PostInitApply()
 
 #if defined(CARBONATED)
     const auto pConsole = AZ::Interface<AZ::IConsole>::Get();
-    AZ_Assert(pConsole, "Multiplayer system is attempting to register console commands before AZ::Console is available.");
+    AZ_Assert(pConsole, "Editor Settings is attempting to register console commands before AZ::Console is available.");
     pConsole->ExecuteDeferredConsoleCommands();
 #endif
 }


### PR DESCRIPTION
The settings view registers cvars late, and there are deferred commands from setregs that would like to update those cvars but arent executed. I plan on also creating a o3de issue about this so they can solve it in a more holistic approach
