### PR TITLE
Introduce a dedicated definition to start memory trace at app start

### DIFF
--- a/Code/Framework/AzCore/AzCore/Memory/AllocatorManager.cpp
+++ b/Code/Framework/AzCore/AzCore/Memory/AllocatorManager.cpp
@@ -71,7 +71,7 @@ AllocatorManager::AllocatorManager()
     m_numAllocators = 0;
     m_isAllocatorLeaking = false;
 #if defined(CARBONATED)
-#if defined(AZ_ENABLE_TRACING) && !defined(_RELEASE)
+#if defined(AZ_ENABLE_TRACING) && defined(AZ_START_MEMORY_TRACING) && !defined(_RELEASE)
     m_defaultTrackingRecordMode = Debug::AllocationRecords::RECORD_STACK_IF_NO_FILE_LINE;
     m_defaultProfilingState = true;
 #else

--- a/Code/Framework/AzCore/AzCore/Memory/MemoryMarker.cpp
+++ b/Code/Framework/AzCore/AzCore/Memory/MemoryMarker.cpp
@@ -6,10 +6,10 @@
  *
  */
 
-#include <AzCore/Memory/MemoryMarker.h>
-#include <AzCore/Memory/AllocatorManager.h>
-
 #if defined(AZ_ENABLE_TRACING) && !defined(_RELEASE) && defined(CARBONATED)  // without tracing definition engine's memory tracking is off
+
+#include <AzCore/Memory/AllocatorManager.h>
+#include <AzCore/Memory/MemoryMarker.h>
 
 void AZ::MemoryAllocationMarker::Init(const char* name, const char* file, int line, bool isLiteral)
 {


### PR DESCRIPTION
## What does this PR do?

Use a dedicated definition to turn on memory tracing at startup

## How was this PR tested?

Local test
