### PR TITLE
Safer code in AZ::AllocatorStorage::Allocator to prevent crashes on app exit

### DIFF
--- a/Code/Framework/AzCore/AzCore/Memory/AllocatorInstance.h
+++ b/Code/Framework/AzCore/AzCore/Memory/AllocatorInstance.h
@@ -33,14 +33,14 @@ namespace AZ::AllocatorStorage
                     m_allocator = Environment::CreateVariable<Allocator>(AzTypeInfo<Allocator>::Name());
                 }
 #if defined(CARBONATED)
-                s_AllocatorEnvironmentVariable = &m_allocator;
+                s_allocated = true;
 #endif
             }
 
 #if defined(CARBONATED)
             ~AllocatorEnvironmentVariable()
             {
-                s_AllocatorEnvironmentVariable = nullptr;
+                s_allocated = false;
             }
 #endif
 
@@ -50,7 +50,7 @@ namespace AZ::AllocatorStorage
             }
 
 #if defined(CARBONATED)
-            inline static EnvironmentVariable<Allocator>* s_AllocatorEnvironmentVariable{};
+            inline static bool s_allocated = false;
 #endif
         private:
             EnvironmentVariable<Allocator> m_allocator;
@@ -60,21 +60,14 @@ namespace AZ::AllocatorStorage
 #if defined(CARBONATED)
         static bool HasAllocator()
         {
-            static AllocatorEnvironmentVariable s_allocator;
-            return AllocatorEnvironmentVariable::s_AllocatorEnvironmentVariable != nullptr;
+            return AllocatorEnvironmentVariable::s_allocated;
         }
-        AZ_FORCE_INLINE static IAllocator& GetAllocator()
-        {
-            HasAllocator();
-            return **AllocatorEnvironmentVariable::s_AllocatorEnvironmentVariable;
-        }
-#else
+#endif
         static IAllocator& GetAllocator()
         {
             static AllocatorEnvironmentVariable s_allocator;
             return *s_allocator;
         }
-#endif
     };
 } // namespace AZ::AllocatorStorage
 

--- a/Code/Framework/AzCore/AzCore/std/allocator.cpp
+++ b/Code/Framework/AzCore/AzCore/std/allocator.cpp
@@ -19,6 +19,13 @@ namespace AZStd
 
     void allocator::deallocate(pointer ptr, size_type byteSize, size_type alignment)
     {
+#if defined(CARBONATED)
+        if (!AZ::AllocatorInstance<AZ::SystemAllocator>::HasAllocator())
+        {
+            // Avoid the crash on app exit when deallocate is invoked after the allocator object deleted.
+            return;
+        }
+#endif
         AZ::AllocatorInstance<AZ::SystemAllocator>::Get().deallocate(ptr, byteSize, alignment);
     }
 


### PR DESCRIPTION
## What does this PR do?

Depending on the order of destroying of static objects, it may occur a late access to delete memory allocated by an `AZ::AllocatorStorage::Allocator` instance.

To prevent the crash, this PR adds an extra check on the allocator's existence.

## How was this PR tested?

Tested locally on Windows
