### PR TITLE
[MAD-15000] Enable UI text input when Editor runs game

### DIFF
--- a/Code/Editor/Platform/Windows/Editor/Core/QtEditorApplication_windows.cpp
+++ b/Code/Editor/Platform/Windows/Editor/Core/QtEditorApplication_windows.cpp
@@ -34,8 +34,6 @@ namespace Editor
         return new EditorQtApplicationWindows(argc, argv);
     }
 
-#pragma optimize("", off)
-
     bool EditorQtApplicationWindows::nativeEventFilter([[maybe_unused]] const QByteArray& eventType, void* message, long* result)
     {
         MSG* msg = (MSG*)message;
@@ -143,8 +141,6 @@ namespace Editor
 
         return false;
     }
-
-#pragma optimize("", on)
 
     bool EditorQtApplicationWindows::eventFilter(QObject* object, QEvent* event)
     {

--- a/Code/Editor/Platform/Windows/Editor/Core/QtEditorApplication_windows.cpp
+++ b/Code/Editor/Platform/Windows/Editor/Core/QtEditorApplication_windows.cpp
@@ -118,22 +118,24 @@ namespace Editor
                 }
                 return true;
             }
+#if defined(CARBONATED)
+            else if (msg->message == WM_KEYDOWN || msg->message == WM_KEYUP)
+            {
+                return false; // pass through unhandled so that WM_CHAR is generated
+            }
+            else if (msg->message == WM_CHAR)
+            {
+                // Process raw WM_CHAR event sending keycode to a LyShine UiTextInputComponent in Editor game mode
+                AzFramework::RawInputNotificationBusWindows::Broadcast(
+                    &AzFramework::RawInputNotificationsWindows::OnRawInputCodeUnitUTF16Event, msg->wParam);
+                return true;
+            }
+#else
             else if (msg->message == WM_KEYDOWN || msg->message == WM_KEYUP || msg->message == WM_CHAR)
             {
-#if defined(CARBONATED)
-                // Process raw WM_CHAR event sending keycode to a LyShine UiTextInputComponent in Editor game mode
-                if (filterInputEvents && msg->message == WM_CHAR)
-                {
-                   AzFramework::RawInputNotificationBusWindows::Broadcast(
-                        &AzFramework::RawInputNotificationsWindows::OnRawInputCodeUnitUTF16Event, msg->wParam);
-                    return true;
-                }
-                // Returning true filters out all keyboard events in Editor game mode, thus preventing input to a LyShine UiTextInputComponent
-                return false;
-#else
                 return filterInputEvents;
-#endif // defined(CARBONATED)
             }
+#endif // defined(CARBONATED)
 
             // allow all other Qt event types to pass through
             // which are needed for focusing, etc.


### PR DESCRIPTION
## What does this PR do?
Enables UI text input when Editor runs game first returning `WM_KEYDOWN` and `WM_KEYUP` events back to default procedure, and then sending keycode of `WM_CHAR` event as a `raw UTF16 Event`, thus ensuring input into a focused `UiTextInputComponent`.

#### Ticket: 
https://jira.carbonated.com:8443/browse/MAD-15000
The issue reported to [Discord](https://discord.com/channels/805939474655346758/1222658661604659270/1232317695064801371).

#### Prehistory:
* The https://github.com/o3de/o3de/commit/2cec52726e13d1be827b1750b428e509ce2dd49a commit 
filtered out Qt key events in game mode, with description:
> QAction keyboard shortcuts were enabled while in game mode, allowing the user to create new levels, save and other potentially dangerous actions when input should only go to the game
* This effectively prevented any keyboard input into UI text elements, as `WM_KEYDOWN`, `WM_KEYUP` and `WM_CHAR` events were marked as resolved, and nowhere in code the `RawInputNotificationsWindows::OnRawInputCodeUnitUTF16Event` was triggered.
* Simple returning `false` on the above mentioned events did not solve the problem of text input in Editor in game mode, as many raw keys were further filtered out as resolved Editor hotkeys (e.g. 1,2,3,p ...).
* Sending raw keycode with the `RawInputNotificationsWindows::OnRawInputCodeUnitUTF16Event` solves the above problem yet it is a sort of a hack.

## How was this PR tested?
WorldMap level run in Editor with clean user data, new user name typed in.

