### PR TITLE
Change shader option indices container

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/ShaderCollection.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/ShaderCollection.h
@@ -15,6 +15,7 @@
 #include <Atom/RHI.Reflect/NameIdReflectionMap.h>
 #include <Atom/RHI.Reflect/Handle.h>
 
+
 namespace AZ
 {
     class ReflectContext;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/ShaderCollection.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/ShaderCollection.h
@@ -141,12 +141,7 @@ namespace AZ
                 // Returns true if was able to initialized the non-serialized @m_shaderOptionGroup.
                 // Only returns false if @m_shaderAsset is not ready.
                 bool InitializeShaderOptionGroup();
-                /*
-                const AZStd::unordered_set<ShaderOptionIndex>& GetShaderOptionIndices() const
-                {
-                    return m_ownedShaderOptionIndices;
-                }
-                */
+
             private:
                 Data::Asset<ShaderAsset> m_shaderAsset;
                 ShaderVariantId m_shaderVariantId;       //!< Temporarily holds the ShaderVariantId, used for serialization. This will be copied to/from m_shaderOptionGroup.

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialTypeAssetCreator.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialTypeAssetCreator.cpp
@@ -162,7 +162,11 @@ namespace AZ
                     ShaderOptionIndex index = shaderItem.GetShaderOptions()->FindShaderOptionIndex(shaderOptionName);
                     if (index.IsValid())
                     {
+#if defined(CARBONATED)
+                        shaderItem.m_ownedShaderOptionIndices.set(index.GetIndex());
+#else
                         shaderItem.m_ownedShaderOptionIndices.insert(index);
+#endif
                         optionFound = true;
                     }
                     return true;
@@ -433,8 +437,11 @@ namespace AZ
                     outputId.m_itemIndex = RHI::Handle<uint32_t>{optionIndex.GetIndex()};
 
                     m_wipMaterialProperty.m_outputConnections.push_back(outputId);
-
+#if defined(CARBONATED)
+                    shaderItem.m_ownedShaderOptionIndices.set(optionIndex.GetIndex());
+#else
                     shaderItem.m_ownedShaderOptionIndices.insert(optionIndex);
+#endif
                 }
 
                 return true;

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/ShaderCollection.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/ShaderCollection.cpp
@@ -16,6 +16,18 @@ namespace AZ
 {
     namespace RPI
     {
+#if defined(CARBONATED)
+        void EffectiveBitset::Reflect(AZ::ReflectContext* context)
+        {
+            if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+            {
+                serializeContext->Class<EffectiveBitset>()
+                    ->Version(1)
+                    ->Field("bits", &EffectiveBitset::m_bits);
+                    ;
+            }
+        }
+#endif
         //! This allows ShaderCollection::Item to serialize only a ShaderVariantId rather than the ShaderOptionsGroup object,
         //! but still provide the corresponding ShaderOptionsGroup for use at runtime.
         //! RenderStates will be modified at runtime as well. It will be merged into the RenderStates stored in the corresponding ShaderVariant.
@@ -61,7 +73,7 @@ namespace AZ
             if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
             {
                 serializeContext->Class<ShaderCollection>()
-                    ->Version(5)
+                    ->Version(6)
                     ->Field("ShaderItems", &ShaderCollection::m_shaderItems)
                     ->Field("ShaderTagIndexMap", &ShaderCollection::m_shaderTagIndexMap)
                     ;
@@ -70,6 +82,9 @@ namespace AZ
 
         void ShaderCollection::Item::Reflect(AZ::ReflectContext* context)
         {
+#if defined(CARBONATED)
+            EffectiveBitset::Reflect(context);
+#endif
             if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
             {
                 serializeContext->Class<ShaderCollection::Item>()
@@ -218,7 +233,7 @@ namespace AZ
         {
 #if defined(CARBONATED)
             ShaderOptionIndex index = m_shaderOptionGroup.FindShaderOptionIndex(shaderOptionName);
-            if (index.IsNull())
+            if (!index.IsValid())
             {
                 return false;
             }
@@ -231,7 +246,7 @@ namespace AZ
         bool ShaderCollection::Item::MaterialOwnsShaderOption(ShaderOptionIndex shaderOptionIndex) const
         {
 #if defined(CARBONATED)
-            if (shaderOptionIndex.IsNull())
+            if (!shaderOptionIndex.IsValid())
             {
                 return false;
             }

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/ShaderCollection.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/ShaderCollection.cpp
@@ -73,7 +73,7 @@ namespace AZ
             if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
             {
                 serializeContext->Class<ShaderCollection>()
-                    ->Version(6)
+                    ->Version(5)
                     ->Field("ShaderItems", &ShaderCollection::m_shaderItems)
                     ->Field("ShaderTagIndexMap", &ShaderCollection::m_shaderTagIndexMap)
                     ;


### PR DESCRIPTION
## Change description

Change shader option indices container to a more effective version.
It does not allocate memory.
It works much faster.
The capacity is limited, it supports indices up to 128. Typically in the game it is under 64. The index grows sequentially.

## Tested

Local tests on PC standalone build.

