### PR TITLE
[MAD-15059] Temporary fix for Log cluttering with errors on unknown EditorOnly Components

### DIFF
--- a/Code/Framework/AzCore/AzCore/Serialization/ObjectStream.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/ObjectStream.cpp
@@ -489,32 +489,6 @@ namespace AZ
                         if ((m_filterDesc.m_flags & FILTERFLAG_IGNORE_UNKNOWN_CLASSES) == 0)
                         {
                             // we're not ignoring unknown classes.
-#if defined(CARBONATED)
-                            // Detecting dependencies on UI slices for parent objects is buried deep inside AssetProcessor scanning algorithm.
-                            // UI slices can have EditorOnlyEntityComponent, which is removed from dynamic slices, and which is unknown in a standalone product.
-                            // So do not clutter Log with detailed reports and printed stream stack.
-                            constexpr const char* EditorOnlyEntityComponentUuid = "{22A16F1D-6D49-422D-AAE9-91AE45B5D3E7}";
-                            if (element.m_id.ToString<AZStd::string>().c_str() == AZStd::string(EditorOnlyEntityComponentUuid))
-                            {
-                                // Report this feature to keep track on the issue possible fixes, yet report once not to clutter Log
-                                AZ_ErrorOnce("ObjectStream", false,
-                                    "LoadClass(%s): Object references EditorOnlyEntityComponent. Error reported only once, other occurrences skipped.",
-                                    GetStreamFilename())
-                            }
-                            else
-                            {
-                                AZStd::string error = AZStd::string::format(
-                                    "Element '%s'(0x%x) with class ID '%s' found in '%s' is not registered with the serializer!\n"
-                                    "If this class was removed, consider using serializeContext->ClassDeprecate(...) to register classes "
-                                    "as having been deprecated to avoid this error.  File %s\n",
-                                    element.m_name ? element.m_name : "NULL", element.m_nameCrc, element.m_id.ToString<AZStd::string>().c_str(), parentClassInfo ? parentClassInfo->m_name : "ROOT",
-                                    GetStreamFilename());
-                                m_errorLogger.ReportError(error.c_str());
-
-                                // its not just a deprecated class.  Its unregistered
-                                result = result && ((m_filterDesc.m_flags & FILTERFLAG_STRICT) == 0);  // in strict mode, this is a complete failure.
-                            }
-#else // defined(CARBONATED)
                             AZStd::string error = AZStd::string::format(
                                 "Element '%s'(0x%x) with class ID '%s' found in '%s' is not registered with the serializer!\n"
                                 "If this class was removed, consider using serializeContext->ClassDeprecate(...) to register classes as having been deprecated to avoid this error.  File %s\n",
@@ -524,7 +498,6 @@ namespace AZ
 
                             // its not just a deprecated class.  Its unregistered
                             result = result && ((m_filterDesc.m_flags & FILTERFLAG_STRICT) == 0);  // in strict mode, this is a complete failure.
-#endif // defined(CARBONATED)
                         }
                     }
 

--- a/Code/Framework/AzFramework/AzFramework/Entity/BehaviorEntity.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Entity/BehaviorEntity.cpp
@@ -144,7 +144,7 @@ namespace AzFramework
                 //    somehow the longer term kind of implies the shorter terms are kind of throwaway or temp
                 // 
                 // This component was selected to insert below patch just because it is always serialized and safe.
-                // TODO: remove this patch when  AP / UI compiler pipeline is fixed.
+                // TODO: remove this patch when  AP / UI compiler pipeline is fixed. See https://jira.carbonated.com:8443/browse/MAD-15198
                 serializeContext->ClassDeprecate("EditorOnlyEntityComponent", AZ::Uuid("{22A16F1D-6D49-422D-AAE9-91AE45B5D3E7}"));
                 serializeContext->ClassDeprecate("ScriptEditorComponent", AZ::Uuid("{B5FC8679-FA2A-4C7C-AC42-DCC279EA613A}"));
                 serializeContext->ClassDeprecate("EditorEntitySortComponent", AZ::Uuid("{6EA1E03D-68B2-466D-97F7-83998C8C27F0}"));

--- a/Code/Framework/AzFramework/AzFramework/Entity/BehaviorEntity.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Entity/BehaviorEntity.cpp
@@ -136,9 +136,9 @@ namespace AzFramework
                 // Refs:
                 // - MAD-15059
                 // - https://discord.com/channels/805939474655346758/1222658661604659270/1233132847745990777
-                //   Nick_L — 04/25/24 10:09 PM
+                //   Nick_L (04/25/24 10:09 PM)
                 //   so summary here
-                //    - ultra short term, may have to use classdeprecate to hack around the errors
+                //    - ultra short term, may have to use classdeprecate to hack around the errors      
                 //    - short term, gotta pass the slice files from ui thru the ui compiler somehow so it does the same process
                 //    - longer term,  gotta move the ui stuff off slices and onto prefabs
                 //    somehow the longer term kind of implies the shorter terms are kind of throwaway or temp

--- a/Code/Framework/AzFramework/AzFramework/Entity/BehaviorEntity.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Entity/BehaviorEntity.cpp
@@ -126,6 +126,33 @@ namespace AzFramework
                     ->DataElement(AZ::Edit::UIHandlers::Default, &BehaviorEntity::m_entityId, "EntityId", "")
                     ;
             }
+#if defined(CARBONATED)
+            else // No EditContext found - standalone product is running
+            {
+                // Deprecate Editor-only components' classes until AsserProcessor logic is changed to avoid serialization attempts
+                // for Editor-only components in dependent UI slices (not dynamic slices),
+                // thus ensuring that Log is not cluttered with somewhat obsolete reports, originated in AP / UI compiler bug.
+                // 
+                // Refs:
+                // - MAD-15059
+                // - https://discord.com/channels/805939474655346758/1222658661604659270/1233132847745990777
+                //   Nick_L — 04/25/24 10:09 PM
+                //   so summary here
+                //    - ultra short term, may have to use classdeprecate to hack around the errors
+                //    - short term, gotta pass the slice files from ui thru the ui compiler somehow so it does the same process
+                //    - longer term,  gotta move the ui stuff off slices and onto prefabs
+                //    somehow the longer term kind of implies the shorter terms are kind of throwaway or temp
+                // 
+                // This component was selected to insert below patch just because it is always serialized and safe.
+                // TODO: remove this patch when  AP / UI compiler pipeline is fixed.
+                serializeContext->ClassDeprecate("EditorOnlyEntityComponent", AZ::Uuid("{22A16F1D-6D49-422D-AAE9-91AE45B5D3E7}"));
+                serializeContext->ClassDeprecate("ScriptEditorComponent", AZ::Uuid("{B5FC8679-FA2A-4C7C-AC42-DCC279EA613A}"));
+                serializeContext->ClassDeprecate("EditorEntitySortComponent", AZ::Uuid("{6EA1E03D-68B2-466D-97F7-83998C8C27F0}"));
+                serializeContext->ClassDeprecate("EditorDisabledCompositionComponent", AZ::Uuid("{E77AE6AC-897D-4035-8353-637449B6DCFB}"));
+                serializeContext->ClassDeprecate("EditorInspectorComponent", AZ::Uuid("{47DE3DDA-50C5-4F50-B1DB-BA4AE66AB056}"));
+                serializeContext->ClassDeprecate("EditorPendingCompositionComponent", AZ::Uuid("{D40FCB35-153D-45B3-AF6D-7BA576D8AFBB}"));
+            }
+#endif // defined(CARBONATED)
         }
 
         if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))


### PR DESCRIPTION
## What does this PR do?
When running a standalone game and loading UI canvases and dependant UI slices, or when explicitly instantiating UI dynamic slices, some of dependant UI `.slice`s can have the `Editor Only` components, which are not filtered out by AssetBuilder and UI compiler in` .slice`s (not converting these to dynamic slices).
As in standalone game such components are "unknown", the `ObjectStreamImpl::LoadClass()` clutters Log with errors starting with
> (Serialize) - Element 'element'(0x41405e39) with class ID '{XXXX-XXXX-4XXXX-XXXX-XXXXXXX}' found in ....

and including full `ObjectStream` stack.

This PR provides a temporary fix for the Log cluttering, - declaring major `Editor Only` classes as deprecated in Non-Editor builds .

### Discord messages
- [describing original issue](https://discord.com/channels/805939474655346758/1222658661604659270/1233086132921827409).
- [summary of possible remedies](https://discord.com/channels/805939474655346758/1222658661604659270/1233132847745990777)

#### This PR implements "ultra short term" fix.
#### Tracking ticket for removing the patch when the long-term solution is implemented:
https://jira.carbonated.com:8443/browse/MAD-15198

## How was this PR tested?
Standalone Game run, Log checked to have no error messages on the missing classes (those, that are declared as deprecated).

The only error message left refers to `VideoPlaybackBinkEditorComponent` in `UI/WorldMap/Subtitles/slices/SubtitlesOverlay.slice`, 
where this component is to be substituted with the `VideoPlaybackNativeEditorComponent`
(and also conversion / serializing  `VideoPlaybackNativeEditorComponent` -> `VideoPlaybackNativeGameComponent` is to be fixed - @aefimov3 FYI).
