### PR TITLE
Fix to incorrect calculation of number of anim samples on IOS in EmotionFX gem

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionData/MotionData.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionData/MotionData.cpp
@@ -96,7 +96,12 @@ namespace EMotionFX
             return 2;
         }
 
+#if defined(CARBONATED)
+        // Fixed incorrect rounding. Sometimes we calculated a value like 14.9999999 and it was erroneously casted to 14 instead of 15 on some platforms.
+        return static_cast<size_t>(AZStd::lround(duration / sampleSpacing)) + 1;
+#else
         return static_cast<size_t>(duration / sampleSpacing) + 1;
+#endif
     }
 
     void MotionData::CalculateSampleInformation(float duration, float& inOutSampleRate, size_t& numSamples, float& sampleSpacing)


### PR DESCRIPTION
Ticket 15066

## What does this PR do?

Issue in the last line of MotionData::CalculateNumRequiredSamples on iOS (not on PC).
When duration is 0.5 and sampleSpasing is 1/30, the value (duration / sampleSpacing) is 14.9999999 on iOS and it is casted to 14 instead 15 as expected. It reduced the calculated animation duration in the game to one sample and breaks the game actions based on animation events.

IMPORTANT: this PR changes AP process. I deleted the folder (****see name of the folder in the ticket****) and reprocess it. I don't know how to do the same on Jenkins to deliver this changes to QA team.

## How was this PR tested?

Verified locally on PC and on iPhone14

Compilation has been verified on Jenkins http://10.0.1.100:8080/job/MadWorld/job/Client-O3DE/job/build%252Fvmedn%252Fverify-inO3DE-fix-to-incorrect-calculation-of-number-of-anim-samples-on-IOS-0001/
