### PR TITLE
Convert UI colorization ARGB to ABGR for IOS platform

### DIFF
--- a/Gems/LyShine/Code/Source/Draw2d.cpp
+++ b/Gems/LyShine/Code/Source/Draw2d.cpp
@@ -29,7 +29,8 @@ namespace
     // Color to u32 => 0xAARRGGBB
     AZ::u32 PackARGB8888(const AZ::Color& color)
     {
-#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS) // support ABGR color on iOS
+#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS)
+        // support ABGR color on iOS
         return (color.GetA8() << 24) | (color.GetB8() << 16) | (color.GetG8() << 8) | color.GetR8();
 #else
         return (color.GetA8() << 24) | (color.GetR8() << 16) | (color.GetG8() << 8) | color.GetB8();

--- a/Gems/LyShine/Code/Source/Draw2d.cpp
+++ b/Gems/LyShine/Code/Source/Draw2d.cpp
@@ -29,7 +29,7 @@ namespace
     // Color to u32 => 0xAARRGGBB
     AZ::u32 PackARGB8888(const AZ::Color& color)
     {
-#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS) // support ABGR color on IOS
+#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS) // support ABGR color on iOS
         return (color.GetA8() << 24) | (color.GetB8() << 16) | (color.GetG8() << 8) | color.GetR8();
 #else
         return (color.GetA8() << 24) | (color.GetR8() << 16) | (color.GetG8() << 8) | color.GetB8();

--- a/Gems/LyShine/Code/Source/Draw2d.cpp
+++ b/Gems/LyShine/Code/Source/Draw2d.cpp
@@ -29,8 +29,8 @@ namespace
     // Color to u32 => 0xAARRGGBB
     AZ::u32 PackARGB8888(const AZ::Color& color)
     {
-#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS)
-        // support ABGR color on iOS
+#if defined(CARBONATED) && AZ_TRAIT_OS_PLATFORM_APPLE
+        // support ABGR colorization
         return (color.GetA8() << 24) | (color.GetB8() << 16) | (color.GetG8() << 8) | color.GetR8();
 #else
         return (color.GetA8() << 24) | (color.GetR8() << 16) | (color.GetG8() << 8) | color.GetB8();

--- a/Gems/LyShine/Code/Source/Draw2d.cpp
+++ b/Gems/LyShine/Code/Source/Draw2d.cpp
@@ -29,7 +29,11 @@ namespace
     // Color to u32 => 0xAARRGGBB
     AZ::u32 PackARGB8888(const AZ::Color& color)
     {
+#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS) // support ABGR color on IOS
+        return (color.GetA8() << 24) | (color.GetB8() << 16) | (color.GetG8() << 8) | color.GetR8();
+#else
         return (color.GetA8() << 24) | (color.GetR8() << 16) | (color.GetG8() << 8) | color.GetB8();
+#endif
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Gems/LyShine/Code/Source/UiImageComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiImageComponent.cpp
@@ -374,7 +374,7 @@ void UiImageComponent::Render(LyShine::IRenderGraph* renderGraph)
         {
             color = color.GammaToLinear();   // the colors are specified in sRGB but we want linear colors in the shader
         }
-#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS) // support ABGR color on IOS
+#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS) // support ABGR color on iOS
         uint32 packedColor = (desiredPackedAlpha << 24) | (color.GetB8() << 16) | (color.GetG8() << 8) | color.GetR8();
 #else
         uint32 packedColor = (desiredPackedAlpha << 24) | (color.GetR8() << 16) | (color.GetG8() << 8) | color.GetB8();

--- a/Gems/LyShine/Code/Source/UiImageComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiImageComponent.cpp
@@ -374,7 +374,11 @@ void UiImageComponent::Render(LyShine::IRenderGraph* renderGraph)
         {
             color = color.GammaToLinear();   // the colors are specified in sRGB but we want linear colors in the shader
         }
+#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS) // support ABGR color on IOS
+        uint32 packedColor = (desiredPackedAlpha << 24) | (color.GetB8() << 16) | (color.GetG8() << 8) | color.GetR8();
+#else
         uint32 packedColor = (desiredPackedAlpha << 24) | (color.GetR8() << 16) | (color.GetG8() << 8) | color.GetB8();
+#endif
 
         ImageType imageType = m_imageType;
 

--- a/Gems/LyShine/Code/Source/UiImageComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiImageComponent.cpp
@@ -374,8 +374,8 @@ void UiImageComponent::Render(LyShine::IRenderGraph* renderGraph)
         {
             color = color.GammaToLinear();   // the colors are specified in sRGB but we want linear colors in the shader
         }
-#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS)
-        // support ABGR color on iOS
+#if defined(CARBONATED) && AZ_TRAIT_OS_PLATFORM_APPLE
+        // support ABGR colorization
         uint32 packedColor = (desiredPackedAlpha << 24) | (color.GetB8() << 16) | (color.GetG8() << 8) | color.GetR8();
 #else
         uint32 packedColor = (desiredPackedAlpha << 24) | (color.GetR8() << 16) | (color.GetG8() << 8) | color.GetB8();

--- a/Gems/LyShine/Code/Source/UiImageComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiImageComponent.cpp
@@ -374,7 +374,8 @@ void UiImageComponent::Render(LyShine::IRenderGraph* renderGraph)
         {
             color = color.GammaToLinear();   // the colors are specified in sRGB but we want linear colors in the shader
         }
-#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS) // support ABGR color on iOS
+#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS)
+        // support ABGR color on iOS
         uint32 packedColor = (desiredPackedAlpha << 24) | (color.GetB8() << 16) | (color.GetG8() << 8) | color.GetR8();
 #else
         uint32 packedColor = (desiredPackedAlpha << 24) | (color.GetR8() << 16) | (color.GetG8() << 8) | color.GetB8();

--- a/Gems/LyShine/Code/Source/UiTextComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiTextComponent.cpp
@@ -1842,7 +1842,11 @@ void UiTextComponent::Render(LyShine::IRenderGraph* renderGraph)
         auto systemImage = AZ::RPI::ImageSystemInterface::Get()->GetSystemImage(AZ::RPI::SystemImage::White);
         bool isClampTextureMode = true;
 
+#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS) // support ABGR color on IOS
+        uint32 packedColor = (m_textSelectionColor.GetA8() << 24) | (m_textSelectionColor.GetB8() << 16) | (m_textSelectionColor.GetG8() << 8) | m_textSelectionColor.GetR8();
+#else
         uint32 packedColor = (m_textSelectionColor.GetA8() << 24) | (m_textSelectionColor.GetR8() << 16) | (m_textSelectionColor.GetG8() << 8) | m_textSelectionColor.GetB8();
+#endif
 
         for (UiTransformInterface::RectPoints& rect : rectPoints)
         {
@@ -4183,7 +4187,12 @@ void UiTextComponent::RenderToCache(float alpha)
             elemSize.GetY());
     }
 
+#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS) // support ABGR color on IOS
+    std::swap(fontContext.m_colorOverride.b, fontContext.m_colorOverride.r); // swap R and B
+#endif
+
     m_renderCache.m_fontContext = fontContext;
+
     AZ::Vector2 pos = CalculateAlignedPositionWithYOffset(points);
     RenderDrawBatchLines(drawBatchLines, pos, points, transform, fontContext);
 }

--- a/Gems/LyShine/Code/Source/UiTextComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiTextComponent.cpp
@@ -1842,7 +1842,7 @@ void UiTextComponent::Render(LyShine::IRenderGraph* renderGraph)
         auto systemImage = AZ::RPI::ImageSystemInterface::Get()->GetSystemImage(AZ::RPI::SystemImage::White);
         bool isClampTextureMode = true;
 
-#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS) // support ABGR color on IOS
+#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS) // support ABGR color on iOS
         uint32 packedColor = (m_textSelectionColor.GetA8() << 24) | (m_textSelectionColor.GetB8() << 16) | (m_textSelectionColor.GetG8() << 8) | m_textSelectionColor.GetR8();
 #else
         uint32 packedColor = (m_textSelectionColor.GetA8() << 24) | (m_textSelectionColor.GetR8() << 16) | (m_textSelectionColor.GetG8() << 8) | m_textSelectionColor.GetB8();
@@ -4187,7 +4187,7 @@ void UiTextComponent::RenderToCache(float alpha)
             elemSize.GetY());
     }
 
-#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS) // support ABGR color on IOS
+#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS) // support ABGR color on iOS
     AZStd::swap(fontContext.m_colorOverride.b, fontContext.m_colorOverride.r); // swap R and B
 #endif
     m_renderCache.m_fontContext = fontContext;

--- a/Gems/LyShine/Code/Source/UiTextComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiTextComponent.cpp
@@ -1842,7 +1842,8 @@ void UiTextComponent::Render(LyShine::IRenderGraph* renderGraph)
         auto systemImage = AZ::RPI::ImageSystemInterface::Get()->GetSystemImage(AZ::RPI::SystemImage::White);
         bool isClampTextureMode = true;
 
-#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS) // support ABGR color on iOS
+#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS)
+        // support ABGR color on iOS
         uint32 packedColor = (m_textSelectionColor.GetA8() << 24) | (m_textSelectionColor.GetB8() << 16) | (m_textSelectionColor.GetG8() << 8) | m_textSelectionColor.GetR8();
 #else
         uint32 packedColor = (m_textSelectionColor.GetA8() << 24) | (m_textSelectionColor.GetR8() << 16) | (m_textSelectionColor.GetG8() << 8) | m_textSelectionColor.GetB8();
@@ -4187,7 +4188,8 @@ void UiTextComponent::RenderToCache(float alpha)
             elemSize.GetY());
     }
 
-#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS) // support ABGR color on iOS
+#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS)
+    // support ABGR color on iOS
     AZStd::swap(fontContext.m_colorOverride.b, fontContext.m_colorOverride.r); // swap R and B
 #endif
     m_renderCache.m_fontContext = fontContext;

--- a/Gems/LyShine/Code/Source/UiTextComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiTextComponent.cpp
@@ -4188,11 +4188,9 @@ void UiTextComponent::RenderToCache(float alpha)
     }
 
 #if defined(CARBONATED) && defined(AZ_PLATFORM_IOS) // support ABGR color on IOS
-    std::swap(fontContext.m_colorOverride.b, fontContext.m_colorOverride.r); // swap R and B
+    AZStd::swap(fontContext.m_colorOverride.b, fontContext.m_colorOverride.r); // swap R and B
 #endif
-
     m_renderCache.m_fontContext = fontContext;
-
     AZ::Vector2 pos = CalculateAlignedPositionWithYOffset(points);
     RenderDrawBatchLines(drawBatchLines, pos, points, transform, fontContext);
 }

--- a/Gems/LyShine/Code/Source/UiTextComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiTextComponent.cpp
@@ -1842,8 +1842,8 @@ void UiTextComponent::Render(LyShine::IRenderGraph* renderGraph)
         auto systemImage = AZ::RPI::ImageSystemInterface::Get()->GetSystemImage(AZ::RPI::SystemImage::White);
         bool isClampTextureMode = true;
 
-#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS)
-        // support ABGR color on iOS
+#if defined(CARBONATED) && AZ_TRAIT_OS_PLATFORM_APPLE
+        // support ABGR colorization
         uint32 packedColor = (m_textSelectionColor.GetA8() << 24) | (m_textSelectionColor.GetB8() << 16) | (m_textSelectionColor.GetG8() << 8) | m_textSelectionColor.GetR8();
 #else
         uint32 packedColor = (m_textSelectionColor.GetA8() << 24) | (m_textSelectionColor.GetR8() << 16) | (m_textSelectionColor.GetG8() << 8) | m_textSelectionColor.GetB8();
@@ -4188,8 +4188,8 @@ void UiTextComponent::RenderToCache(float alpha)
             elemSize.GetY());
     }
 
-#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS)
-    // support ABGR color on iOS
+#if defined(CARBONATED) && AZ_TRAIT_OS_PLATFORM_APPLE
+    // support ABGR colorization
     AZStd::swap(fontContext.m_colorOverride.b, fontContext.m_colorOverride.r); // swap R and B
 #endif
     m_renderCache.m_fontContext = fontContext;

--- a/Gems/LyShineExamples/Code/Source/UiCustomImageComponent.cpp
+++ b/Gems/LyShineExamples/Code/Source/UiCustomImageComponent.cpp
@@ -354,7 +354,7 @@ namespace LyShineExamples
         AZ::Color color = AZ::Color::CreateFromVector3AndFloat(m_overrideColor.GetAsVector3(), desiredAlpha);
         color = color.GammaToLinear();   // the colors are specified in sRGB but we want linear colors in the shader
 
-#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS) // support ABGR color on IOS
+#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS) // support ABGR color on iOS
         uint32 packedColor = (color.GetA8() << 24) | (color.GetB8() << 16) | (color.GetG8() << 8) | color.GetR8();
 #else
         uint32 packedColor = (color.GetA8() << 24) | (color.GetR8() << 16) | (color.GetG8() << 8) | color.GetB8();

--- a/Gems/LyShineExamples/Code/Source/UiCustomImageComponent.cpp
+++ b/Gems/LyShineExamples/Code/Source/UiCustomImageComponent.cpp
@@ -354,8 +354,8 @@ namespace LyShineExamples
         AZ::Color color = AZ::Color::CreateFromVector3AndFloat(m_overrideColor.GetAsVector3(), desiredAlpha);
         color = color.GammaToLinear();   // the colors are specified in sRGB but we want linear colors in the shader
 
-#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS)
-        // support ABGR color on iOS
+#if defined(CARBONATED) && AZ_TRAIT_OS_PLATFORM_APPLE
+        // support ABGR colorization
         uint32 packedColor = (color.GetA8() << 24) | (color.GetB8() << 16) | (color.GetG8() << 8) | color.GetR8();
 #else
         uint32 packedColor = (color.GetA8() << 24) | (color.GetR8() << 16) | (color.GetG8() << 8) | color.GetB8();

--- a/Gems/LyShineExamples/Code/Source/UiCustomImageComponent.cpp
+++ b/Gems/LyShineExamples/Code/Source/UiCustomImageComponent.cpp
@@ -354,7 +354,11 @@ namespace LyShineExamples
         AZ::Color color = AZ::Color::CreateFromVector3AndFloat(m_overrideColor.GetAsVector3(), desiredAlpha);
         color = color.GammaToLinear();   // the colors are specified in sRGB but we want linear colors in the shader
 
+#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS) // support ABGR color on IOS
+        uint32 packedColor = (color.GetA8() << 24) | (color.GetB8() << 16) | (color.GetG8() << 8) | color.GetR8();
+#else
         uint32 packedColor = (color.GetA8() << 24) | (color.GetR8() << 16) | (color.GetG8() << 8) | color.GetB8();
+#endif
         IDraw2d::Rounding pixelRounding = IsPixelAligned() ? IDraw2d::Rounding::Nearest : IDraw2d::Rounding::None;
 
         const int numVertices = 4;

--- a/Gems/LyShineExamples/Code/Source/UiCustomImageComponent.cpp
+++ b/Gems/LyShineExamples/Code/Source/UiCustomImageComponent.cpp
@@ -354,7 +354,8 @@ namespace LyShineExamples
         AZ::Color color = AZ::Color::CreateFromVector3AndFloat(m_overrideColor.GetAsVector3(), desiredAlpha);
         color = color.GammaToLinear();   // the colors are specified in sRGB but we want linear colors in the shader
 
-#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS) // support ABGR color on iOS
+#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS)
+        // support ABGR color on iOS
         uint32 packedColor = (color.GetA8() << 24) | (color.GetB8() << 16) | (color.GetG8() << 8) | color.GetR8();
 #else
         uint32 packedColor = (color.GetA8() << 24) | (color.GetR8() << 16) | (color.GetG8() << 8) | color.GetB8();


### PR DESCRIPTION
## What does this PR do?

Tickets [14957] [15065]

#Issue:
The Red and Blue colors are mismatched in iPhone UI render in O3DE.
Where we see Red on PC UI, we see Blue on iPhone UI.
Where we see Blue on PC UI, we see Red on iPhone UI.
Where we see Yellow on PC UI, we see Cyan on iPhone UI. 
Where we see Cyan on PC UI, we see Yellow on iPhone UI. (see titles of any UI menu for example)
This is common UI issue for texts, images, 2d UI primitives.

#Changes: 
Convert UI colorization ARGB to ABGR for IOS platform

#In additional: 
changed the same issue in example code, was not verified

## How was this PR tested?

Verified locally on iPhone14 and on PC

See screenshots in the ticket [14957]

Link to Jenkins build verification (in progress) http://10.0.1.100:8080/job/MadWorld/job/Client-O3DE/job/build%252Fvmedn%252Fverify-ARGB-to-ABGR-IOS-issue-fix-compilation/