### PR TITLE
Fix for randomly culled decals in O3DE

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
@@ -629,8 +629,12 @@ namespace AZ
             AZStd::vector<uint32_t> sortedDecals(dataVector.size());
             // Initialize with all the decals indices
             std::iota(sortedDecals.begin(), sortedDecals.end(), 0);
+#if !defined(CARBONATED)
             // Only sort if we are going to limit the number of visible decals
             if (numVisibleDecals < dataVector.size())
+#else
+            // Sort always due to the render pipeline can have its own limit for visible decals. And that limit can be much less than numVisibleDecals.
+#endif
             {
                 AZ::Vector3 viewPos = view->GetViewToWorldMatrix().GetTranslation();
                 AZStd::sort(


### PR DESCRIPTION
## What does this PR do?

Ticket [14242]

Issue does not related to frustum, frustum works fine.

Reason of issue:
O3DE has the settings for max number of decals "r_maxVisibleDecals", now it is -1 and it enables infinite number of decals (on main level we have 49 decals for example).
When r_maxVisibleDecals is -1, decals are not sorted by distance. O3DE assumes, they all will be render (all, which have passed frustum test).

But somewhere deeper in the pipeline, the pipeline has another internal settings which cuts the number of decals significantly. And in this cases the render skips other decals. Due to decals are unsorted, it skips them randomly (it looks randomly for human).

It is good to do one or two things for fix in the DecalTextureArrayFeatureProcessor::CullDecals due to we don't know how specific pipeline cuts decals.
1) sort decals by the distance always (it fixes issue fine, only very far decals may disappear) <-- included in this PR
2) optional, make frustum test first and then sort decals by the distance (i.e. swap frustum test step and sort step) <-- not included in this PR

## How was this PR tested?

Locally on PC Editor

SEE VIDEO IN THE TICKET [^fix-for-decals-culling-20240428_004040.mp4] 

Verification job http://10.0.1.100:8080/job/MadWorld/job/Client-O3DE/job/build%252Fvmedn%252Ftest-for-o3de-fix-of-randomly-culling-decals-0001/
