### PR TITLE
Print Warning When Using Legacy Asset IDs

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetCatalog.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetCatalog.cpp
@@ -189,17 +189,18 @@ namespace AzFramework
         AZ::Data::AssetId legacyMapping = m_registry->GetAssetIdByLegacyAssetId(id);
         if (legacyMapping.IsValid())
         {
+            const AZStd::string legacyAssetPath = GetAssetPathByIdInternal(legacyMapping);
             AZ_Warning(
                 "O3DE_DEPRECATION_NOTICE(GHI-17861)",
                 false,
-                "Deprecated asset id warning! GetAssetInfoByIdInternal could not find asset id \"%s\" and so fell back to using the legacy "
-                "asset id. \"%s\". Please look up these asset ids in AssetProcessor to find their source asset. Recreate the asset and "
-                "update any other assets referencing this asset in order to generate a modern asset id.",
-                id.ToFixedString().c_str(),
+                "Deprecated asset id warning! GetAssetInfoByIdInternal could not find modern asset id for \"%s\" and so fell back to using "
+                "the legacy asset id \"%s\"."
+                "Please recreate the asset and update any other assets referencing this asset in order to generate a modern asset id.",
+                legacyAssetPath.c_str(),
                 legacyMapping.ToFixedString().c_str()
             );
 
-            return GetAssetPathByIdInternal(legacyMapping);
+            return legacyAssetPath;
         }
 
         return AZStd::string();
@@ -235,17 +236,18 @@ namespace AzFramework
         AZ::Data::AssetId legacyMapping = m_registry->GetAssetIdByLegacyAssetId(id);
         if (legacyMapping.IsValid())
         {
+            const AZ::Data::AssetInfo legacyAssetInfo = GetAssetInfoByIdInternal(legacyMapping);
             AZ_Warning(
                 "O3DE_DEPRECATION_NOTICE(GHI-17861)",
                 false,
-                "Deprecated asset id warning! GetAssetInfoByIdInternal could not find asset id \"%s\" and so fell back to using the legacy "
-                "asset id. \"%s\". Please look up these asset ids in AssetProcessor to find their source asset. Recreate the asset and update "
-                "any other assets referencing this asset in order to generate a modern asset id."
-                id.ToFixedString().c_str(),
+                "Deprecated asset id warning! GetAssetInfoByIdInternal could not the modern asset id for \"%s\" and so fell back to using "
+                "the legacy asset id \"%s\"."
+                "Please recreate the asset and update any other assets referencing this asset in order to generate a modern asset id.",
+                legacyAssetInfo.m_relativePath.c_str(),
                 legacyMapping.ToFixedString().c_str()
             );
 
-            return GetAssetInfoByIdInternal(legacyMapping);
+            return legacyAssetInfo;
         }
 
         return AZ::Data::AssetInfo();

--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetCatalog.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetCatalog.cpp
@@ -189,6 +189,16 @@ namespace AzFramework
         AZ::Data::AssetId legacyMapping = m_registry->GetAssetIdByLegacyAssetId(id);
         if (legacyMapping.IsValid())
         {
+            AZ_Warning(
+                "O3DE_DEPRECATION_NOTICE(GHI-17861)",
+                false,
+                "Deprecated asset id warning! GetAssetInfoByIdInternal could not find asset id \"%s\" and so fell back to using the legacy "
+                "asset id. \"%s\". Please look up these asset ids in AssetProcessor to find their source asset. Recreate the asset and "
+                "update any other assets referencing this asset in order to generate a modern asset id.",
+                id.ToFixedString().c_str(),
+                legacyMapping.ToFixedString().c_str()
+            );
+
             return GetAssetPathByIdInternal(legacyMapping);
         }
 
@@ -225,6 +235,16 @@ namespace AzFramework
         AZ::Data::AssetId legacyMapping = m_registry->GetAssetIdByLegacyAssetId(id);
         if (legacyMapping.IsValid())
         {
+            AZ_Warning(
+                "O3DE_DEPRECATION_NOTICE(GHI-17861)",
+                false,
+                "Deprecated asset id warning! GetAssetInfoByIdInternal could not find asset id \"%s\" and so fell back to using the legacy "
+                "asset id. \"%s\". Please look up these asset ids in AssetProcessor to find their source asset. Recreate the asset and update "
+                "any other assets referencing this asset in order to generate a modern asset id."
+                id.ToFixedString().c_str(),
+                legacyMapping.ToFixedString().c_str()
+            );
+
             return GetAssetInfoByIdInternal(legacyMapping);
         }
 

--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetRegistry.h
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetRegistry.h
@@ -37,7 +37,10 @@ namespace AzFramework
         void RegisterAsset(AZ::Data::AssetId id, const AZ::Data::AssetInfo& assetInfo);
         void UnregisterAsset(AZ::Data::AssetId id);
 
+        // O3DE_DEPRECATION_NOTICE(GHI-17861)
         void RegisterLegacyAssetMapping(const AZ::Data::AssetId& legacyId, const AZ::Data::AssetId& newId);
+
+        // O3DE_DEPRECATION_NOTICE(GHI-17861)
         void UnregisterLegacyAssetMappingsForAsset(const AZ::Data::AssetId& id);
 
         void SetAssetDependencies(const AZ::Data::AssetId& id, const AZStd::vector<AZ::Data::ProductDependency>& dependencies);
@@ -55,9 +58,11 @@ namespace AzFramework
 
         void Clear();
 
+        // O3DE_DEPRECATION_NOTICE(GHI-17861)
         // see if the asset ID has been remapped to a new Id:
         AZ::Data::AssetId GetAssetIdByLegacyAssetId(const AZ::Data::AssetId& legacyAssetId) const;
 
+        // O3DE_DEPRECATION_NOTICE(GHI-17861)
         using LegacyAssetIdToRealAssetIdMap = AZStd::unordered_map<AZ::Data::AssetId, AZ::Data::AssetId>;
         LegacyAssetIdToRealAssetIdMap GetLegacyMappingSubsetFromRealIds(const AZStd::vector<AZ::Data::AssetId>& realIds) const;
 

--- a/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.cpp
@@ -1715,6 +1715,15 @@ namespace AssetProcessor
         AssetId legacyMapping = registryToUse.GetAssetIdByLegacyAssetId(assetId);
         if (legacyMapping.IsValid())
         {
+            AZ_Error(
+                "O3DE_DEPRECATION_NOTICE(GHI-17861)",
+                false,
+                "Deprecated asset id warning! GetAssetInfoByIdInternal could not find asset id \"%s\" and so fell back to using the legacy "
+                "asset id. \"%s\". Please look up these asset ids in AssetProcessor and recreate the asset in order to generate a new "
+                "asset id.",
+                assetId.ToFixedString().c_str(),
+                legacyMapping.ToFixedString().c_str());
+
             return GetProductAssetInfo(platformName, legacyMapping);
         }
 


### PR DESCRIPTION
Adding a warning whenever a legacy asset id is used. This will help developers track which assets are old and need to be updated to the modern asset id.

Allows developers to catch and fix old assets before the legacy asset table is removed entirely.
See https://github.com/o3de/o3de/issues/17861