### PR TITLE
[MAD-15000] Enable UI text input when Editor runs game (2)

### DIFF
--- a/Code/Editor/Platform/Windows/Editor/Core/QtEditorApplication_windows.cpp
+++ b/Code/Editor/Platform/Windows/Editor/Core/QtEditorApplication_windows.cpp
@@ -118,10 +118,28 @@ namespace Editor
                 }
                 return true;
             }
+#if defined(CARBONATED)
+            else if (msg->message == WM_KEYDOWN || msg->message == WM_KEYUP)
+            {
+                return false; // pass through unhandled so that WM_CHAR is generated
+            }
+            else if (msg->message == WM_CHAR)
+            {
+                if (filterInputEvents)
+                {
+                    // Process raw WM_CHAR event sending keycode to a LyShine UiTextInputComponent in Editor game mode
+                    AzFramework::RawInputNotificationBusWindows::Broadcast(
+                        &AzFramework::RawInputNotificationsWindows::OnRawInputCodeUnitUTF16Event, msg->wParam);
+                    return true; // mark as handled to avoid doubling a character which will pass through Editor handlers
+                }
+                return false; // pass through unhandled to get to lower priority handlers like Editor console input
+            }
+#else
             else if (msg->message == WM_KEYDOWN || msg->message == WM_KEYUP || msg->message == WM_CHAR)
             {
                 return filterInputEvents;
             }
+#endif // defined(CARBONATED)
 
             // allow all other Qt event types to pass through
             // which are needed for focusing, etc.


### PR DESCRIPTION
## What does this PR do?
Enables UI text input when Editor runs game first returning `WM_KEYDOWN` and `WM_KEYUP` events back to default procedure, and then sending keycode of `WM_CHAR` event as a `raw UTF16 Event`, thus ensuring input into a focused `UiTextInputComponent`.

Changes by the pevious PR #228 were reverted, as it introduced the side-effect : inability to type into Editor console.

The only 2 differences from the previous PR #228 are:
- Code evaluating `WM_CHAR` event sends a `raw UTF16 Event` to an active `UiTextInputComponent` only in case system cursor is constrained (IMGUI menu is inactive), so that character input into Editor console is not typed into an active `UiTextInputComponent`; then `WM_CHAR` event is marked as handled returning `true`, as was in the previous PR,  -  to avoid doubling characters, which can pass other Editor event filters and finally be sent as `raw UTF16 Events`;
- Otherwise code returns `false` thus passing `WM_CHAR` event through as undandled, so it can reach succeeding event filters, - this enables input into Editor console. Previous PR was returning true always, thus blocking input into console.

## How was this PR tested?
Worldmap level run in Editor.
Input into Editor console is allowed with O3DE changes only when IMGUI menu is activated (system cursor is not constrained)
