### PR TITLE
Restore visibility for force-update actors

### DIFF
--- a/Gems/EMotionFX/Code/Include/Integration/ActorComponentBus.h
+++ b/Gems/EMotionFX/Code/Include/Integration/ActorComponentBus.h
@@ -92,6 +92,7 @@ namespace EMotionFX
 
 #if defined(CARBONATED)
             virtual void SetForceJointUpdate(bool force) = 0;
+            virtual bool GetForceJointUpdate() = 0;
 #endif
 
             /// Returns skinning method used by the actor.

--- a/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.cpp
@@ -629,12 +629,6 @@ namespace EMotionFX
                     const bool updateTransforms = AZ::RHI::CheckBitsAny(m_configuration.m_renderFlags, s_requireUpdateTransforms);
                     m_actorInstance->SetIsVisible(isInCameraFrustum && updateTransforms);
                 }
-#if defined(CARBONATED)
-                else
-                {
-                    m_actorInstance->SetIsVisible(true);
-                }
-#endif
             }
         }
 

--- a/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.cpp
@@ -380,6 +380,10 @@ namespace EMotionFX
                 m_actorInstance->SetIsVisible(true);
             }
         }
+        bool ActorComponent::GetForceJointUpdate()
+        {
+            return m_configuration.m_forceUpdateJointsOOV;
+        }
 #endif
 
         //////////////////////////////////////////////////////////////////////////

--- a/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.cpp
@@ -375,6 +375,10 @@ namespace EMotionFX
         void ActorComponent::SetForceJointUpdate(bool force)
         {
             m_configuration.m_forceUpdateJointsOOV = force;
+            if (force && m_actorInstance)
+            {
+                m_actorInstance->SetIsVisible(true);
+            }
         }
 #endif
 
@@ -621,6 +625,12 @@ namespace EMotionFX
                     const bool updateTransforms = AZ::RHI::CheckBitsAny(m_configuration.m_renderFlags, s_requireUpdateTransforms);
                     m_actorInstance->SetIsVisible(isInCameraFrustum && updateTransforms);
                 }
+#if defined(CARBONATED)
+                else
+                {
+                    m_actorInstance->SetIsVisible(true);
+                }
+#endif
             }
         }
 

--- a/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.h
+++ b/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.h
@@ -121,6 +121,7 @@ namespace EMotionFX
             void SetRenderCharacter(bool enable) override;
 #if defined(CARBONATED)
             void SetForceJointUpdate(bool force) override;
+            bool GetForceJointUpdate() override;
 #endif
             bool GetRenderActorVisible() const override;
             SkinningMethod GetSkinningMethod() const override;

--- a/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
@@ -278,6 +278,10 @@ namespace EMotionFX
                 m_actorInstance->SetIsVisible(true);
             }
         }
+        bool EditorActorComponent::GetForceJointUpdate()
+        {
+            return m_forceUpdateJointsOOV;
+        }
 #endif
 
         size_t EditorActorComponent::GetNumJoints() const

--- a/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
@@ -273,6 +273,10 @@ namespace EMotionFX
         void EditorActorComponent::SetForceJointUpdate(bool force)
         {
             m_forceUpdateJointsOOV = force;
+            if (force && m_actorInstance)
+            {
+                m_actorInstance->SetIsVisible(true);
+            }
         }
 #endif
 

--- a/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.h
+++ b/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.h
@@ -62,6 +62,7 @@ namespace EMotionFX
             bool GetRenderActorVisible() const override;
 #if defined(CARBONATED)
             void SetForceJointUpdate(bool force) override;
+            bool GetForceJointUpdate() override;
 #endif
             size_t GetNumJoints() const override;
             SkinningMethod GetSkinningMethod() const override;


### PR DESCRIPTION
## What does this PR do?

Set visibility flag in several places for force-update actors

## How was this PR tested?

Local test on Windows standalone client, sniper scope mode with weapon debug draw mode
