### PR TITLE
Added detection of iOS screen resolution

### DIFF
--- a/Code/Framework/AzFramework/Platform/iOS/AzFramework/Windowing/NativeWindow_ios.mm
+++ b/Code/Framework/AzFramework/Platform/iOS/AzFramework/Windowing/NativeWindow_ios.mm
@@ -10,6 +10,10 @@
 #include <AzFramework/Windowing/NativeWindow.h>
 #include <AzFramework/Components/NativeUISystemComponent.h>
 
+#if defined(CARBONATED)
+#include <AzCore/Console/IConsole.h>
+#endif
+
 #include <UIKit/UIKit.h>
 @class NSWindow;
 
@@ -64,11 +68,21 @@ namespace AzFramework
         {
             AZStd::swap(m_width, m_height);
         }
-        // Make sure that the window width does not exceed the one of the geometry.
-        if (geometry.m_width < m_width)
+        
+        uint32_t resolutionMode = 0;
+        AZ::IConsole* console = AZ::Interface<AZ::IConsole>::Get();
+        if (console)
         {
-            m_height = static_cast<uint32_t>((static_cast<float>(m_height) / m_width) * geometry.m_width);
-            m_width = geometry.m_width;
+            console->GetCvarValue("r_resolutionMode", resolutionMode);
+        }
+        if (resolutionMode == 1)
+        {
+            // Make sure that the window width does not exceed the given geometry width.
+            if (geometry.m_width < m_width)
+            {
+                m_height = static_cast<uint32_t>((static_cast<float>(m_height) / m_width) * geometry.m_width);
+                m_width = geometry.m_width;
+            }
         }
 #else
         m_width = geometry.m_width;

--- a/Code/Framework/AzFramework/Platform/iOS/AzFramework/Windowing/NativeWindow_ios.mm
+++ b/Code/Framework/AzFramework/Platform/iOS/AzFramework/Windowing/NativeWindow_ios.mm
@@ -45,15 +45,28 @@ namespace AzFramework
     }
     
     void NativeWindowImpl_Ios::InitWindow([[maybe_unused]]const AZStd::string& title,
+#if defined(CARBONATED)
+                                          [[maybe_unused]]const WindowGeometry& geometry,
+#else
                                           const WindowGeometry& geometry,
+#endif
                                           [[maybe_unused]]const WindowStyleMasks& styleMasks)
     {
         CGRect screenBounds = [[UIScreen mainScreen] bounds];
         m_nativeWindow = [[UIWindow alloc] initWithFrame: screenBounds];
         [m_nativeWindow makeKeyAndVisible];
 
-        m_width = geometry.m_width;
-        m_height = geometry.m_height;
+#if defined(CARBONATED)
+        m_width = [UIScreen mainScreen].nativeBounds.size.width;
+        m_height = [UIScreen mainScreen].nativeBounds.size.height;
+        if (m_width < m_height)
+        {
+            AZStd::swap(m_width, m_height);
+        }
+#else
+        m_width = geometry.width;
+        m_height = geometry.height;
+#endif
         m_mainDisplayRefreshRate = [[UIScreen mainScreen] maximumFramesPerSecond];
     }
     

--- a/Code/Framework/AzFramework/Platform/iOS/AzFramework/Windowing/NativeWindow_ios.mm
+++ b/Code/Framework/AzFramework/Platform/iOS/AzFramework/Windowing/NativeWindow_ios.mm
@@ -48,11 +48,7 @@ namespace AzFramework
     }
     
     void NativeWindowImpl_Ios::InitWindow([[maybe_unused]]const AZStd::string& title,
-#if defined(CARBONATED)
-                                          [[maybe_unused]]const WindowGeometry& geometry,
-#else
                                           const WindowGeometry& geometry,
-#endif
                                           [[maybe_unused]]const WindowStyleMasks& styleMasks)
     {
         CGRect screenBounds = [[UIScreen mainScreen] bounds];
@@ -68,9 +64,15 @@ namespace AzFramework
         {
             AZStd::swap(m_width, m_height);
         }
+        // Make sure that the window width does not exceed the one of the geometry.
+        if (geometry.m_width < m_width)
+        {
+            m_height = static_cast<uint32_t>((static_cast<float>(m_height) / m_width) * geometry.m_width);
+            m_width = geometry.m_width;
+        }
 #else
-        m_width = geometry.width;
-        m_height = geometry.height;
+        m_width = geometry.m_width;
+        m_height = geometry.m_height;
 #endif
         m_mainDisplayRefreshRate = [[UIScreen mainScreen] maximumFramesPerSecond];
     }

--- a/Registry/Platform/iOS/window.setreg
+++ b/Registry/Platform/iOS/window.setreg
@@ -4,7 +4,7 @@
             "ConsoleCommands": {
                 "r_fullscreen": 1,
                 "sys_PakLogInvalidFileAccess" : 1,
-                "r_resolutionMode" : 1
+                "r_resolutionMode" : 0
             }
         }
     }

--- a/Registry/Platform/iOS/window.setreg
+++ b/Registry/Platform/iOS/window.setreg
@@ -4,7 +4,7 @@
             "ConsoleCommands": {
                 "r_fullscreen": 1,
                 "sys_PakLogInvalidFileAccess" : 1,
-                "r_resolutionMode" : 0
+                "r_resolutionMode" : 1
             }
         }
     }


### PR DESCRIPTION
## What does this PR do?

1. The value `r_resolutionMode` should be 0 to auto detect the screen size.
It is processed in `\o3de\Gems\Atom\Bootstrap\Code\Source\BootstrapSystemComponent.cpp`.
Otherwise O3DE will try to get screen size from `r_width` and `r_height`.
If these values (defaults: 1920, 1080) mismatch the device proportion, the screen content will be distorted.

2. Added detection of iOS screen resolution.

Both changes are similar to the existing Android implementation.

## How was this PR tested?

Tested on iPhone 15
