### PR TITLE
Fix for RELEASE build

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Spawnable/AssetPlatformComponentRemover.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Spawnable/AssetPlatformComponentRemover.cpp
@@ -70,6 +70,9 @@ namespace AzToolsFramework::Prefab::PrefabConversionUtils
                         {
                             if (entity->EvaluateDependencies() == AZ::Entity::DependencySortResult::MissingRequiredService)
                             {
+#if defined(CARBONATED)
+                                (void)prefab; // suppress 'warning as error' for unused variable from capture list in Release
+#endif
                                 AZ_Error( "AssetPlatformComponentRemover", false,
                                     "Processing prefab '%s' failed! Removing components on entity '%s' has broken component "
                                     "dependency. Make sure you also remove any dependent components. If dependent component is actually required, "


### PR DESCRIPTION
## What does this PR do?

Variable 'prefab' is enumerated in the lambda capture list but it is unused in the Release.
It causes 'warning as error' issue.

## How was this PR tested?

Verified locally on PC. 

Related ticket 14321.
