### PR TITLE
Disable CopyToSwapchain pass for Mobile pipeline

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/Mobile/DisplayMapper.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/Mobile/DisplayMapper.pass
@@ -1,0 +1,43 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "MobileDisplayMapperTemplate",
+            "PassClass": "DisplayMapperPass",
+            "Slots": [
+                {
+                    "Name": "Input",
+                    "SlotType": "Input",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                // SwapChain here is only used to reference the frame height and format
+                {
+                    "Name": "PipelineOutput",
+                    "SlotType": "InputOutput"
+                },
+                {
+                    "Name": "Output",
+                    "SlotType": "Output",
+                    "ScopeAttachmentUsage": "RenderTarget",
+                    "LoadStoreAction": {
+                        "LoadAction": "DontCare"
+                    }
+                }
+            ],
+            "FallbackConnections": [
+                {
+                    "Input" : "Input",
+                    "Output" : "Output"
+                }
+            ],
+            "PassData": {
+                "$type": "FullscreenTrianglePassData",
+                "ShaderAsset": {
+                    "FilePath": "Shaders/PostProcessing/DisplayMapper.shader"
+                }
+            }
+        }
+    }
+}

--- a/Gems/Atom/Feature/Common/Assets/Passes/Mobile/Pipeline.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/Mobile/Pipeline.pass
@@ -266,6 +266,7 @@
                 {
                     "Name": "CopyToSwapChain",
                     "TemplateName": "FullscreenCopyTemplate",
+                    "Enabled": false,
                     "Connections": [
                         {
                             "LocalSlot": "Input",

--- a/Gems/Atom/Feature/Common/Assets/Passes/Mobile/PostProcessParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/Mobile/PostProcessParent.pass
@@ -74,7 +74,7 @@
                 },
                 {
                     "Name": "DisplayMapperPass",
-                    "TemplateName": "DisplayMapperTemplate",
+                    "TemplateName": "MobileDisplayMapperTemplate",
                     "Enabled": true,
                     "Connections": [
                         {
@@ -86,6 +86,13 @@
                         },
                         {
                             "LocalSlot": "PipelineOutput",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "PipelineOutput"
+                            }
+                        },
+                        {
+                            "LocalSlot": "Output",
                             "AttachmentRef": {
                                 "Pass": "Parent",
                                 "Attachment": "PipelineOutput"

--- a/Gems/Atom/Feature/Common/Assets/Passes/PassTemplates.azasset
+++ b/Gems/Atom/Feature/Common/Assets/Passes/PassTemplates.azasset
@@ -581,6 +581,10 @@
                 "Path": "Passes/Mobile/PostProcessParent.pass"
             },
             {
+                "Name": "MobileDisplayMapperTemplate",
+                "Path": "Passes/Mobile/DisplayMapper.pass"
+            },
+            {
                 "Name": "KawaseShadowBlurTemplate",
                 "Path": "Passes/KawaseShadowBlur.pass"
             },

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/SwapChainPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/SwapChainPass.cpp
@@ -109,8 +109,7 @@ namespace AZ
                 m_pipelinOutputAttachment->m_descriptor = outputImageDesc;
                 m_pipelinOutputAttachment->m_name = "PipelineOutput";
                 m_pipelinOutputAttachment->ComputePathName(GetPathName());
-                // Note: do not add m_pipelinOutputAttachment to m_ownedAttachments so it won't be imported to frame graph's attachment database. 
-                // This is because this attachment is only used for pass reference, but not used for RHI frame graph
+                m_ownedAttachments.push_back(m_pipelinOutputAttachment);
 
                 // use the intermediate attachment as pipeline's output
                 pipelineOutput->SetAttachment(m_pipelinOutputAttachment);
@@ -143,6 +142,7 @@ namespace AZ
                 RPI::Ptr<RPI::Pass> copyPass = RPI::PassSystemInterface::Get()->FindFirstPass(passFilter);
                 if (copyPass)
                 {
+                    copyPass->SetEnabled(true);
                     auto outputBinding = copyPass->FindAttachmentBinding(Name("Output"));
                     outputBinding->SetAttachment(m_swapChainAttachment);
                     // set connected binding to nullptr so it won't use the output attachment specified in the pipeline's pass template


### PR DESCRIPTION
## What does this PR do?

Disable extra pass CopyToSwapchain from mobile pipeline. The MobileDisplayMapper pass renders directly to the swapchain so there's no need for a copy. It's only needed if there's a need for upscaling.

## How was this PR tested?

Run PC DX12 and Vulkan. Run Android.