### PR TITLE
MAD-15164 fix viewport cvars

### DIFF
--- a/Code/Framework/AzFramework/Platform/iOS/AzFramework/Windowing/NativeWindow_ios.mm
+++ b/Code/Framework/AzFramework/Platform/iOS/AzFramework/Windowing/NativeWindow_ios.mm
@@ -84,6 +84,12 @@ namespace AzFramework
                 m_width = geometry.m_width;
             }
         }
+        if (console)
+        {
+            // screen to world uses default viewport's size, which is based on these cvars, so we should keep them in sync
+            console->PerformCommand(AZStd::string::format("r_width %d", m_width).c_str());
+            console->PerformCommand(AZStd::string::format("r_height %d", m_height).c_str());
+        }
 #else
         m_width = geometry.m_width;
         m_height = geometry.m_height;


### PR DESCRIPTION
## What does this PR do?

Update screen size cvars to match window size, this fixes default viewport size used for camera space calculations

## How was this PR tested?

Local iOS only build due to time constraints
