### PR TITLE
Fix Mac OS SDK 14 deprecated items or suppress warnings

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Utilities/ScreenGrabber_mac.mm
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Utilities/ScreenGrabber_mac.mm
@@ -57,8 +57,10 @@ namespace AzQtComponents
         QRect region({}, m_size);
         region.moveCenter(point);
         CGRect bounds = CGRectMake(region.x(), region.y(), region.width(), region.height());
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         CGImageRef cgImage = CGWindowListCreateImageFromArray(bounds, windows, kCGWindowImageNominalResolution);
+#pragma clang diagnostic pop
         CFRelease(windows);
 
         QImage result = QtMac::fromCGImageRef(cgImage).toImage();

--- a/Code/Framework/AzQtComponents/AzQtComponents/Utilities/ScreenGrabber_mac.mm
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Utilities/ScreenGrabber_mac.mm
@@ -57,10 +57,16 @@ namespace AzQtComponents
         QRect region({}, m_size);
         region.moveCenter(point);
         CGRect bounds = CGRectMake(region.x(), region.y(), region.width(), region.height());
+
+#if defined(CARBONATED)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
         CGImageRef cgImage = CGWindowListCreateImageFromArray(bounds, windows, kCGWindowImageNominalResolution);
+#if defined(CARBONATED)
 #pragma clang diagnostic pop
+#endif
+
         CFRelease(windows);
 
         QImage result = QtMac::fromCGImageRef(cgImage).toImage();

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/ArgumentBuffer.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/ArgumentBuffer.cpp
@@ -138,7 +138,7 @@ namespace AZ
                 MTLArgumentDescriptor* samplerArgDescriptor = [[[MTLArgumentDescriptor alloc] init] autorelease];
                 samplerArgDescriptor.dataType = MTLDataTypeSampler;
                 samplerArgDescriptor.index = shaderInputSampler.m_registerId;
-                samplerArgDescriptor.access = MTLArgumentAccessReadOnly;
+                samplerArgDescriptor.access = MTLBindingAccessReadOnly;
                 samplerArgDescriptor.arrayLength = shaderInputSampler.m_count > 1 ? shaderInputSampler.m_count:0;
                 [argBufferDecriptors addObject:samplerArgDescriptor];
                 resourceAdded = true;
@@ -149,7 +149,7 @@ namespace AZ
                 MTLArgumentDescriptor* staticSamplerArgDescriptor = [[[MTLArgumentDescriptor alloc] init] autorelease];
                 staticSamplerArgDescriptor.dataType = MTLDataTypeSampler;
                 staticSamplerArgDescriptor.index = staticSamplerInput.m_registerId;
-                staticSamplerArgDescriptor.access = MTLArgumentAccessReadOnly;
+                staticSamplerArgDescriptor.access = MTLBindingAccessReadOnly;
                 [argBufferDecriptors addObject:staticSamplerArgDescriptor];
                 resourceAdded = true;
             }
@@ -161,7 +161,7 @@ namespace AZ
                 MTLArgumentDescriptor* constBufferArgDescriptor = [[[MTLArgumentDescriptor alloc] init] autorelease];
                 constBufferArgDescriptor.dataType = MTLDataTypePointer;
                 constBufferArgDescriptor.index = shaderInputConstant.m_registerId;
-                constBufferArgDescriptor.access = MTLArgumentAccessReadOnly;
+                constBufferArgDescriptor.access = MTLBindingAccessReadOnly;
                 [argBufferDecriptors addObject:constBufferArgDescriptor];
                 resourceAdded = true;
             }

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/BindlessArgumentBuffer.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/BindlessArgumentBuffer.cpp
@@ -48,7 +48,7 @@ namespace AZ::Metal
             MTLArgumentDescriptor* argDescriptor = [[MTLArgumentDescriptor alloc]init];
             argDescriptor.dataType = MTLDataTypeTexture;
             argDescriptor.index = 0;
-            argDescriptor.access = MTLArgumentAccessReadOnly;
+            argDescriptor.access = MTLBindingAccessReadOnly;
             argDescriptor.textureType = MTLTextureType2D;
             argDescriptor.arrayLength = RHI::Limits::Pipeline::UnboundedArraySize;
             argBufferDescriptors.push_back(argDescriptor);
@@ -57,14 +57,14 @@ namespace AZ::Metal
             mtlArgBufferOffsets.push_back(m_bindlessTextureArgBuffer->GetOffset());
 
             //Unbounded read write textures
-            argDescriptor.access = MTLArgumentAccessReadWrite;
+            argDescriptor.access = MTLBindingAccessReadWrite;
             argBufferDescriptors[0] = argDescriptor;
             m_bindlessRWTextureArgBuffer->Init(device, argBufferDescriptors, "ArgumentBuffer_BindlessRWTextures");
             mtlArgBuffers.push_back(m_bindlessRWTextureArgBuffer->GetArgEncoderBuffer());
             mtlArgBufferOffsets.push_back(m_bindlessRWTextureArgBuffer->GetOffset());
             
             //Unbounded read cube textures
-            argDescriptor.access = MTLArgumentAccessReadOnly;
+            argDescriptor.access = MTLBindingAccessReadOnly;
             argDescriptor.textureType = MTLTextureTypeCube;
             argBufferDescriptors[0] = argDescriptor;
             m_bindlessCubeTextureArgBuffer->Init(device, argBufferDescriptors, "ArgumentBuffer_BindlessCubeROTextures");
@@ -73,14 +73,14 @@ namespace AZ::Metal
 
             //Unbounded read only buffers
             argDescriptor.dataType = MTLDataTypePointer;
-            argDescriptor.access = MTLArgumentAccessReadOnly;
+            argDescriptor.access = MTLBindingAccessReadOnly;
             argBufferDescriptors[0] = argDescriptor;
             m_bindlessBufferArgBuffer->Init(device, argBufferDescriptors, "ArgumentBuffer_BindlessROBuffers");
             mtlArgBuffers.push_back(m_bindlessBufferArgBuffer->GetArgEncoderBuffer());
             mtlArgBufferOffsets.push_back(m_bindlessBufferArgBuffer->GetOffset());
 
             //Unbounded read write buffers
-            argDescriptor.access = MTLArgumentAccessReadWrite;
+            argDescriptor.access = MTLBindingAccessReadWrite;
             argBufferDescriptors[0] = argDescriptor;
             m_bindlessRWBufferArgBuffer->Init(device, argBufferDescriptors, "ArgumentBuffer_BindlessRWBuffers");
             mtlArgBuffers.push_back(m_bindlessRWBufferArgBuffer->GetArgEncoderBuffer());
@@ -89,7 +89,7 @@ namespace AZ::Metal
             //Container Argument buffer for all the unbounded arrays
             argDescriptor.dataType = MTLDataTypePointer;
             argDescriptor.index = 0;
-            argDescriptor.access = MTLArgumentAccessReadOnly;
+            argDescriptor.access = MTLBindingAccessReadOnly;
             argDescriptor.arrayLength = static_cast<uint32_t>(RHI::BindlessResourceType::Count) - 1;
             argBufferDescriptors[0] = argDescriptor;
             m_rootArgBuffer->Init(device, argBufferDescriptors, "ArgumentBuffer_BindlessRoot");
@@ -111,7 +111,7 @@ namespace AZ::Metal
                 
                 resourceArgDescriptor.arrayLength = RHI::Limits::Pipeline::UnboundedArraySize;
                 resourceArgDescriptor.dataType = MTLDataTypeTexture;
-                resourceArgDescriptor.access = MTLArgumentAccessReadOnly;
+                resourceArgDescriptor.access = MTLBindingAccessReadOnly;
 
                 if(i == m_bindlessSrgDesc.m_roTextureIndex)
                 {
@@ -122,7 +122,7 @@ namespace AZ::Metal
                 {
                     resourceArgDescriptor.index = RHI::Limits::Pipeline::UnboundedArraySize * m_bindlessSrgDesc.m_rwTextureIndex;
                     resourceArgDescriptor.textureType = MTLTextureType2D;
-                    resourceArgDescriptor.access = MTLArgumentAccessReadWrite;
+                    resourceArgDescriptor.access = MTLBindingAccessReadWrite;
                 }
                 else if(i == m_bindlessSrgDesc.m_roTextureCubeIndex)
                 {
@@ -138,7 +138,7 @@ namespace AZ::Metal
                 {
                     resourceArgDescriptor.index = RHI::Limits::Pipeline::UnboundedArraySize * m_bindlessSrgDesc.m_rwBufferIndex;
                     resourceArgDescriptor.dataType = MTLDataTypePointer;
-                    resourceArgDescriptor.access = MTLArgumentAccessReadWrite;
+                    resourceArgDescriptor.access = MTLBindingAccessReadWrite;
                 }
                 argBufferDescriptors.push_back(resourceArgDescriptor);
             }

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Conversions.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Conversions.cpp
@@ -956,12 +956,12 @@ namespace AZ
             {
                 case RHI::ShaderInputImageAccess::Read:
                 {
-                    imgArgDescriptor.access = MTLArgumentAccessReadOnly;
+                    imgArgDescriptor.access = MTLBindingAccessReadOnly;
                     break;
                 }
                 case RHI::ShaderInputImageAccess::ReadWrite:
                 {
-                    imgArgDescriptor.access = MTLArgumentAccessReadWrite;
+                    imgArgDescriptor.access = MTLBindingAccessReadWrite;
                     break;
                 }
                 default:
@@ -1029,12 +1029,12 @@ namespace AZ
                 case RHI::ShaderInputBufferAccess::Constant:
                 case RHI::ShaderInputBufferAccess::Read:
                 {
-                    bufferArgDescriptor.access = MTLArgumentAccessReadOnly;
+                    bufferArgDescriptor.access = MTLBindingAccessReadOnly;
                     break;
                 }
                 case RHI::ShaderInputBufferAccess::ReadWrite:
                 {
-                    bufferArgDescriptor.access = MTLArgumentAccessReadWrite;
+                    bufferArgDescriptor.access = MTLBindingAccessReadWrite;
                     break;
                 }
                 default:


### PR DESCRIPTION
## What does this PR do?

Change / mask Mac OS SDK 14 deprecated calls.

## How was this PR tested?

Local test with building mac binaries.
