### PR TITLE
Build/aefimov1/mad 14995 suspend resume

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.cpp
@@ -146,17 +146,21 @@ namespace AZ
 
             AZ::SystemTickBus::Handler::BusConnect();
             AZ::RHI::RHISystemNotificationBus::Handler::BusConnect();
+#if defined(CARBONATED)
             AzFramework::ApplicationLifecycleEvents::Bus::Handler::BusConnect();
+#endif
         }
 
         void RPISystemComponent::Deactivate()
         {
+#if defined(CARBONATED)
             AzFramework::ApplicationLifecycleEvents::Bus::Handler::BusDisconnect();
+#endif
             AZ::SystemTickBus::Handler::BusDisconnect();
             m_rpiSystem.Shutdown();
             AZ::RHI::RHISystemNotificationBus::Handler::BusDisconnect();
         }
-
+#if defined(CARBONATED)
         void RPISystemComponent::OnApplicationSuspended(ApplicationLifecycleEvents::Event)
         {
             m_suspended = true;
@@ -165,14 +169,15 @@ namespace AZ
         {
             m_suspended = false;
         }
-    
+#endif
         void RPISystemComponent::OnSystemTick()
         {
+#if defined(CARBONATED)
             if (m_suspended)
             {
                 return;
             }
-            
+#endif
             if (m_performanceCollector)
             {
                 if (m_gpuPassProfiler && !m_performanceCollector->IsWaitingBeforeCapture() && m_gpuPassProfiler->IsGpuTimeMeasurementEnabled())

--- a/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.cpp
@@ -146,17 +146,33 @@ namespace AZ
 
             AZ::SystemTickBus::Handler::BusConnect();
             AZ::RHI::RHISystemNotificationBus::Handler::BusConnect();
+            AzFramework::ApplicationLifecycleEvents::Bus::Handler::BusConnect();
         }
 
         void RPISystemComponent::Deactivate()
         {
+            AzFramework::ApplicationLifecycleEvents::Bus::Handler::BusDisconnect();
             AZ::SystemTickBus::Handler::BusDisconnect();
             m_rpiSystem.Shutdown();
             AZ::RHI::RHISystemNotificationBus::Handler::BusDisconnect();
         }
 
+        void RPISystemComponent::OnApplicationSuspended(ApplicationLifecycleEvents::Event)
+        {
+            m_suspended = true;
+        }
+        void RPISystemComponent::OnApplicationResumed(ApplicationLifecycleEvents::Event)
+        {
+            m_suspended = false;
+        }
+    
         void RPISystemComponent::OnSystemTick()
         {
+            if (m_suspended)
+            {
+                return;
+            }
+            
             if (m_performanceCollector)
             {
                 if (m_gpuPassProfiler && !m_performanceCollector->IsWaitingBeforeCapture() && m_gpuPassProfiler->IsGpuTimeMeasurementEnabled())

--- a/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.h
+++ b/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.h
@@ -44,7 +44,9 @@ namespace AZ
             , public AZ::RHI::RHISystemNotificationBus::Handler
             , public XRRegisterInterface::Registrar
             , public PerformanceCollectorOwner::Registrar
+#if defined(CARBONATED)
             , public AzFramework::ApplicationLifecycleEvents::Bus::Handler
+#endif
         {
         public:
             AZ_COMPONENT(RPISystemComponent, "{83E301F3-7A0C-4099-B530-9342B91B1BC0}");
@@ -65,13 +67,13 @@ namespace AZ
             void RegisterXRInterface(XRRenderingInterface* xrSystemInterface) override;
             void UnRegisterXRInterface() override;
             ///////////////////////////////////////////////////////////////////
-
+#if defined(CARBONATED)
             ///////////////////////////////////////////////////////////////////
             // ApplicationLifecycleEvents overrides
             void OnApplicationSuspended(Event lastEvent) override;
             void OnApplicationResumed(Event lastEvent) override;
             ///////////////////////////////////////////////////////////////////
-
+#endif
         private:
             RPISystemComponent(const RPISystemComponent&) = delete;
 
@@ -111,8 +113,9 @@ namespace AZ
             RPISystemDescriptor m_rpiDescriptor;
 
             MaterialFunctorSourceDataRegistration* m_materialFunctorRegistration = nullptr;
-            
+#if defined(CARBONATED)
             bool m_suspended = false;
+#endif
         };
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.h
+++ b/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.h
@@ -21,7 +21,9 @@
 #include <Atom/RPI.Public/GpuQuery/GpuPassProfiler.h>
 #include <Atom/RPI.Public/XR/XRRenderingInterface.h>
 
+#if defined(CARBONATED)
 #include <AzFramework/API/ApplicationAPI.h>
+#endif
 
 #include "PerformanceCVarManager.h"
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.h
+++ b/Gems/Atom/RPI/Code/Source/RPI.Private/RPISystemComponent.h
@@ -21,6 +21,8 @@
 #include <Atom/RPI.Public/GpuQuery/GpuPassProfiler.h>
 #include <Atom/RPI.Public/XR/XRRenderingInterface.h>
 
+#include <AzFramework/API/ApplicationAPI.h>
+
 #include "PerformanceCVarManager.h"
 
 namespace AZ
@@ -42,6 +44,7 @@ namespace AZ
             , public AZ::RHI::RHISystemNotificationBus::Handler
             , public XRRegisterInterface::Registrar
             , public PerformanceCollectorOwner::Registrar
+            , public AzFramework::ApplicationLifecycleEvents::Bus::Handler
         {
         public:
             AZ_COMPONENT(RPISystemComponent, "{83E301F3-7A0C-4099-B530-9342B91B1BC0}");
@@ -61,6 +64,12 @@ namespace AZ
             // IXRRegisterInterface overrides
             void RegisterXRInterface(XRRenderingInterface* xrSystemInterface) override;
             void UnRegisterXRInterface() override;
+            ///////////////////////////////////////////////////////////////////
+
+            ///////////////////////////////////////////////////////////////////
+            // ApplicationLifecycleEvents overrides
+            void OnApplicationSuspended(Event lastEvent) override;
+            void OnApplicationResumed(Event lastEvent) override;
             ///////////////////////////////////////////////////////////////////
 
         private:
@@ -102,6 +111,8 @@ namespace AZ
             RPISystemDescriptor m_rpiDescriptor;
 
             MaterialFunctorSourceDataRegistration* m_materialFunctorRegistration = nullptr;
+            
+            bool m_suspended = false;
         };
     } // namespace RPI
 } // namespace AZ


### PR DESCRIPTION
## What does this PR do?

Fix suspend /resume on iOS because the apps tries to render while being in background that cause to abort call.

## How was this PR tested?

Tested locally on iOS. Tested Jenkins build on iOS. Android cannot be tested it crashes with null pointer exception, which cannot be caused by this PR.

No thourough review required, the code was approved, I just added CARBONATED fence before making Jenkins build.
