### PR TITLE
Adds support to allow the render pipeline to write to swapchain in the tonemap pass.

### DIFF
--- a/Gems/Atom/RHI/Metal/Code/Source/Platform/iOS/RHI/Metal_RHI_iOS.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/Platform/iOS/RHI/Metal_RHI_iOS.cpp
@@ -79,8 +79,7 @@ namespace Platform
 
     void ResizeInternal(RHIMetalView* metalView, CGSize viewSize)
     {
-        AZ_UNUSED(metalView);
-        AZ_UNUSED(viewSize);
+        [metalView.metalLayer setDrawableSize: viewSize];
     }
 
     RHIMetalView* GetMetalView(NativeWindowType* nativeWindow)

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/ArgumentBuffer.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/ArgumentBuffer.cpp
@@ -117,6 +117,7 @@ namespace AZ
         {
             bool resourceAdded = false;
 
+            
             for (const RHI::ShaderInputBufferDescriptor& shaderInputBuffer : m_srgLayout->GetShaderInputListForBuffers())
             {
                 MTLArgumentDescriptor* bufferArgDescriptor = [[[MTLArgumentDescriptor alloc] init] autorelease];
@@ -138,7 +139,7 @@ namespace AZ
                 MTLArgumentDescriptor* samplerArgDescriptor = [[[MTLArgumentDescriptor alloc] init] autorelease];
                 samplerArgDescriptor.dataType = MTLDataTypeSampler;
                 samplerArgDescriptor.index = shaderInputSampler.m_registerId;
-                samplerArgDescriptor.access = MTLBindingAccessReadOnly;
+                samplerArgDescriptor.access = GetBindingAccess(RHI::ShaderInputImageAccess::Read);
                 samplerArgDescriptor.arrayLength = shaderInputSampler.m_count > 1 ? shaderInputSampler.m_count:0;
                 [argBufferDecriptors addObject:samplerArgDescriptor];
                 resourceAdded = true;
@@ -149,7 +150,7 @@ namespace AZ
                 MTLArgumentDescriptor* staticSamplerArgDescriptor = [[[MTLArgumentDescriptor alloc] init] autorelease];
                 staticSamplerArgDescriptor.dataType = MTLDataTypeSampler;
                 staticSamplerArgDescriptor.index = staticSamplerInput.m_registerId;
-                staticSamplerArgDescriptor.access = MTLBindingAccessReadOnly;
+                staticSamplerArgDescriptor.access = GetBindingAccess(RHI::ShaderInputImageAccess::Read);
                 [argBufferDecriptors addObject:staticSamplerArgDescriptor];
                 resourceAdded = true;
             }
@@ -161,7 +162,7 @@ namespace AZ
                 MTLArgumentDescriptor* constBufferArgDescriptor = [[[MTLArgumentDescriptor alloc] init] autorelease];
                 constBufferArgDescriptor.dataType = MTLDataTypePointer;
                 constBufferArgDescriptor.index = shaderInputConstant.m_registerId;
-                constBufferArgDescriptor.access = MTLBindingAccessReadOnly;
+                constBufferArgDescriptor.access = GetBindingAccess(RHI::ShaderInputImageAccess::Read);
                 [argBufferDecriptors addObject:constBufferArgDescriptor];
                 resourceAdded = true;
             }

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/BindlessArgumentBuffer.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/BindlessArgumentBuffer.cpp
@@ -48,7 +48,7 @@ namespace AZ::Metal
             MTLArgumentDescriptor* argDescriptor = [[MTLArgumentDescriptor alloc]init];
             argDescriptor.dataType = MTLDataTypeTexture;
             argDescriptor.index = 0;
-            argDescriptor.access = MTLBindingAccessReadOnly;
+            argDescriptor.access = GetBindingAccess(RHI::ShaderInputImageAccess::Read);
             argDescriptor.textureType = MTLTextureType2D;
             argDescriptor.arrayLength = RHI::Limits::Pipeline::UnboundedArraySize;
             argBufferDescriptors.push_back(argDescriptor);
@@ -64,7 +64,7 @@ namespace AZ::Metal
             mtlArgBufferOffsets.push_back(m_bindlessRWTextureArgBuffer->GetOffset());
             
             //Unbounded read cube textures
-            argDescriptor.access = MTLBindingAccessReadOnly;
+            argDescriptor.access = GetBindingAccess(RHI::ShaderInputImageAccess::Read);
             argDescriptor.textureType = MTLTextureTypeCube;
             argBufferDescriptors[0] = argDescriptor;
             m_bindlessCubeTextureArgBuffer->Init(device, argBufferDescriptors, "ArgumentBuffer_BindlessCubeROTextures");
@@ -73,7 +73,7 @@ namespace AZ::Metal
 
             //Unbounded read only buffers
             argDescriptor.dataType = MTLDataTypePointer;
-            argDescriptor.access = MTLBindingAccessReadOnly;
+            argDescriptor.access = GetBindingAccess(RHI::ShaderInputImageAccess::Read);
             argBufferDescriptors[0] = argDescriptor;
             m_bindlessBufferArgBuffer->Init(device, argBufferDescriptors, "ArgumentBuffer_BindlessROBuffers");
             mtlArgBuffers.push_back(m_bindlessBufferArgBuffer->GetArgEncoderBuffer());
@@ -89,7 +89,7 @@ namespace AZ::Metal
             //Container Argument buffer for all the unbounded arrays
             argDescriptor.dataType = MTLDataTypePointer;
             argDescriptor.index = 0;
-            argDescriptor.access = MTLBindingAccessReadOnly;
+            argDescriptor.access = GetBindingAccess(RHI::ShaderInputImageAccess::Read);
             argDescriptor.arrayLength = static_cast<uint32_t>(RHI::BindlessResourceType::Count) - 1;
             argBufferDescriptors[0] = argDescriptor;
             m_rootArgBuffer->Init(device, argBufferDescriptors, "ArgumentBuffer_BindlessRoot");
@@ -111,7 +111,7 @@ namespace AZ::Metal
                 
                 resourceArgDescriptor.arrayLength = RHI::Limits::Pipeline::UnboundedArraySize;
                 resourceArgDescriptor.dataType = MTLDataTypeTexture;
-                resourceArgDescriptor.access = MTLBindingAccessReadOnly;
+                resourceArgDescriptor.access = GetBindingAccess(RHI::ShaderInputImageAccess::Read);
 
                 if(i == m_bindlessSrgDesc.m_roTextureIndex)
                 {

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Conversions.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Conversions.cpp
@@ -365,6 +365,7 @@ namespace AZ
             mtlTextureDesc.hazardTrackingMode = resourceDescriptor.m_mtlHazardTrackingMode;
             
             mtlTextureDesc.sampleCount = resourceDescriptor.m_sampleCount;
+            //NSLog(@"ConvertImageDescriptor %p\n", mtlTextureDesc);
             return mtlTextureDesc;
         }
     
@@ -948,27 +949,50 @@ namespace AZ
             }
         }
 
+        MTLBindingAccess GetBindingAccess(RHI::ShaderInputImageAccess accessType)
+        {
+#if defined(__IPHONE_17_0) || defined(__MAC_14_0)
+            MTLBindingAccess mtlBindingAccess = MTLBindingAccessReadOnly;
+#else
+            MTLBindingAccess mtlBindingAccess = MTLArgumentAccessReadOnly;
+#endif
+            
+            if(accessType == RHI::ShaderInputImageAccess::ReadWrite)
+            {
+#if defined(__IPHONE_17_0) || defined(__MAC_14_0)
+            mtlBindingAccess = MTLBindingAccessReadWrite;
+#else
+            mtlBindingAccess = MTLArgumentAccessReadWrite;
+#endif
+            }
+            return mtlBindingAccess;
+        }
+    
+        MTLBindingAccess GetBindingAccess(RHI::ShaderInputBufferAccess accessType)
+        {
+#if defined(__IPHONE_17_0) || defined(__MAC_14_0)
+            MTLBindingAccess mtlBindingAccess = MTLBindingAccessReadOnly;
+#else
+            MTLBindingAccess mtlBindingAccess = MTLArgumentAccessReadOnly;
+#endif
+            
+            if(accessType == RHI::ShaderInputBufferAccess::ReadWrite)
+            {
+#if defined(__IPHONE_17_0) || defined(__MAC_14_0)
+            mtlBindingAccess = MTLBindingAccessReadWrite;
+#else
+            mtlBindingAccess = MTLArgumentAccessReadWrite;
+#endif
+            }
+            return mtlBindingAccess;
+        }
+    
         void ConvertImageArgumentDescriptor(MTLArgumentDescriptor* imgArgDescriptor, const RHI::ShaderInputImageDescriptor& shaderInputImage)
         {
             imgArgDescriptor.dataType = MTLDataTypeTexture;
             imgArgDescriptor.index = shaderInputImage.m_registerId;
-            switch(shaderInputImage.m_access)
-            {
-                case RHI::ShaderInputImageAccess::Read:
-                {
-                    imgArgDescriptor.access = MTLBindingAccessReadOnly;
-                    break;
-                }
-                case RHI::ShaderInputImageAccess::ReadWrite:
-                {
-                    imgArgDescriptor.access = MTLBindingAccessReadWrite;
-                    break;
-                }
-                default:
-                {
-                    AZ_Assert(false, "Invalid usage type.");
-                }
-            }
+            imgArgDescriptor.access = GetBindingAccess(shaderInputImage.m_access);
+
             switch(shaderInputImage.m_type)
             {
                 case RHI::ShaderInputImageType::Image1D:
@@ -1024,24 +1048,8 @@ namespace AZ
             AZ_Assert(bufferArgDescriptor, "bufferArgDescriptor is null");
             
             bufferArgDescriptor.index = shaderInputBuffer.m_registerId;
-            switch(shaderInputBuffer.m_access)
-            {
-                case RHI::ShaderInputBufferAccess::Constant:
-                case RHI::ShaderInputBufferAccess::Read:
-                {
-                    bufferArgDescriptor.access = MTLBindingAccessReadOnly;
-                    break;
-                }
-                case RHI::ShaderInputBufferAccess::ReadWrite:
-                {
-                    bufferArgDescriptor.access = MTLBindingAccessReadWrite;
-                    break;
-                }
-                default:
-                {
-                    AZ_Assert(false, "Invalid usage type.");
-                }
-            }
+            bufferArgDescriptor.access = GetBindingAccess(shaderInputBuffer.m_access);
+
             bufferArgDescriptor.arrayLength = shaderInputBuffer.m_count;
             
             if(shaderInputBuffer.m_type == RHI::ShaderInputBufferType::Typed)

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Conversions.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Conversions.h
@@ -79,6 +79,8 @@ namespace AZ
         MTLResourceOptions CovertCPUCahceMode(MTLCPUCacheMode cpuCahceMode);
         MTLResourceOptions CovertToResourceOptions(MTLStorageMode storageMode, MTLCPUCacheMode cpuCahceMode, MTLHazardTrackingMode hazardTrackingMode);
         MTLStorageMode GetCPUGPUMemoryMode();
+        MTLBindingAccess GetBindingAccess(RHI::ShaderInputImageAccess accessType);
+        MTLBindingAccess GetBindingAccess(RHI::ShaderInputBufferAccess accessType);
     
         void ConvertSamplerState(const RHI::SamplerState& state, MTLSamplerDescriptor* samplerDesc);
         void ConvertDepthStencilState(const RHI::DepthStencilState& depthStencil, MTLDepthStencilDescriptor* mtlDepthStencilDesc);

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Device.cpp
@@ -400,6 +400,7 @@ namespace AZ
             m_limits.m_maxConstantBufferSize = m_metalDevice.maxBufferLength;
             m_limits.m_maxBufferSize = m_metalDevice.maxBufferLength;
  
+            m_features.m_swapchainScalingFlags = RHI::ScalingFlags::Stretch;
             AZ_Assert(m_metalDevice.argumentBuffersSupport >= MTLArgumentBuffersTier1, "Atom needs Argument buffer support to run");
         }
 

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Scope.cpp
@@ -94,8 +94,11 @@ namespace AZ
             
             for (RHI::ImageScopeAttachment* scopeAttachment : GetImageAttachments())
             {
-                m_isWritingToSwapChainScope = scopeAttachment->IsSwapChainAttachment() && scopeAttachment->HasUsage(RHI::ScopeAttachmentUsage::RenderTarget);
-                if(m_isWritingToSwapChainScope)
+                bool isWritingToSwapChainScope = scopeAttachment->IsSwapChainAttachment() && scopeAttachment->HasUsage(RHI::ScopeAttachmentUsage::RenderTarget);
+                const RHI::SwapChainFrameAttachment* swapChainFrameAttachment = (azrtti_cast<const RHI::SwapChainFrameAttachment*>(&scopeAttachment->GetFrameAttachment()));
+                
+                //Check if this scope is writing to the swapchain texture and if the swapchain attachment is valid
+                if(isWritingToSwapChainScope && swapChainFrameAttachment)
                 {
                     //The way Metal works is that we ask the drivers for the swapchain texture right before we write to it.
                     //And if we have to read from the swapchain texture we need to tell the driver this information when requesting the
@@ -115,7 +118,8 @@ namespace AZ
                         }
                     }
                     
-                    //Cache this as we will use this to request the drawable from the driver in the Execute phase (i.e Scope::Begin)
+                    //Cache the result as we will use this to request the drawable from the driver in the Execute phase (i.e Scope::Begin)
+                    m_isWritingToSwapChainScope = true;
                     m_swapChainAttachment = scopeAttachment;
                 }
                 


### PR DESCRIPTION
## What does this PR do?

- For the mobile pipeline we want to write to the swap chain texture in the tone map pass and remove the copytoswapchain pass. This PR fixes an error related to that
- Deprecates MTLArgumentAccessReadOnly/MTLArgumentAccessReadWrite

## How was this PR tested?

Tested iOS and Editor on Mac
