### PR TITLE
Fix NANs showing up in DOF effect.

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/ForwardPass_StandardLighting_CustomZ.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/ForwardPass_StandardLighting_CustomZ.azsli
@@ -36,6 +36,7 @@
 #define ENABLE_REFLECTIONPROBE_BLENDING 0
 #define ENABLE_SPECULARAA 0
 #define ENABLE_PARALLAX 0
+#define ENABLE_MOBILEBRDF 1
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/Transparent_StandardLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/Transparent_StandardLighting.azsli
@@ -34,6 +34,7 @@
 #define ENABLE_REFLECTIONPROBE_BLENDING 0
 #define ENABLE_SPECULARAA 0
 #define ENABLE_PARALLAX 0
+#define ENABLE_MOBILEBRDF 1
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_LightingBrdf.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/EnhancedPBR/EnhancedPBR_LightingBrdf.azsli
@@ -67,7 +67,11 @@ real3 GetSpecularLighting_EnhancedPBR(Surface surface, LightingData lightingData
     }
     else
     {
+#if ENABLE_MOBILEBRDF
+        specular = SpecularGGXMobile(lightingData.dirToCamera, dirToLight, surface.normal, surface.specularF0, surface.roughnessA2, surface.roughnessA, surface.roughnessLinear);
+#else
         specular = SpecularGGX(lightingData.dirToCamera, dirToLight, surface.normal, surface.specularF0, lightingData.NdotV, surface.roughnessA2, lightingData.multiScatterCompensation);
+#endif
     }
 
 #if ENABLE_CLEAR_COAT

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/NormalInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/NormalInput.azsli
@@ -45,7 +45,7 @@ real2 SampleNormalXY(Texture2D map, sampler mapSampler, float2 uv)
     sampledValue =  (sampledValue * 2) - 1;
 #endif
 
-    return sampledValue;
+    return sampledValue.xy;
 }
 
 //! Samples the normal map and returns the XY values of the normal. 

--- a/Gems/Atom/RPI/Assets/ShaderLib/Atom/RPI/TangentSpace.azsli
+++ b/Gems/Atom/RPI/Assets/ShaderLib/Atom/RPI/TangentSpace.azsli
@@ -11,9 +11,15 @@
 // ---------- Tangent & World Space ----------
 
 //! Utility function to convert vector from tangent space to world space
-real3 TangentSpaceToWorld(real3 vectorTS, real3 normalWS, real3 tangentWS, real3 bitangentWS)
+half3 TangentSpaceToWorld(half3 vectorTS, half3 normalWS, half3 tangentWS, half3 bitangentWS)
 {
-    return real3(vectorTS.x * tangentWS + vectorTS.y * bitangentWS + vectorTS.z * normalWS);
+    return half3(vectorTS.x * tangentWS + vectorTS.y * bitangentWS + vectorTS.z * normalWS);
+}
+
+//! Utility function to convert vector from tangent space to world space
+float3 TangentSpaceToWorld(float3 vectorTS, float3 normalWS, float3 tangentWS, float3 bitangentWS)
+{
+    return float3(vectorTS.x * tangentWS + vectorTS.y * bitangentWS + vectorTS.z * normalWS);
 }
 
 float3 TangentSpaceToWorldFp32(float3 vectorTS, float3 normalWS, float3 tangentWS, float3 bitangentWS)
@@ -22,13 +28,22 @@ float3 TangentSpaceToWorldFp32(float3 vectorTS, float3 normalWS, float3 tangentW
 }
 
 //! Utility function to convert vector from world space to tangent space
-real3 WorldSpaceToTangent(real3 vectorWS, real3 normalWS, real3 tangentWS, real3 bitangentWS)
+half3 WorldSpaceToTangent(half3 vectorWS, half3 normalWS, half3 tangentWS, half3 bitangentWS)
 {
-    real a = dot(tangentWS, vectorWS);
-    real b = dot(bitangentWS, vectorWS);
-    real c = dot(normalWS, vectorWS);
+    half a = dot(tangentWS, vectorWS);
+    half b = dot(bitangentWS, vectorWS);
+    half c = dot(normalWS, vectorWS);
 
-    return real3(a, b, c);
+    return half3(a, b, c);
+}
+
+float3 WorldSpaceToTangent(float3 vectorWS, float3 normalWS, float3 tangentWS, float3 bitangentWS)
+{
+    float a = dot(tangentWS, vectorWS);
+    float b = dot(bitangentWS, vectorWS);
+    float c = dot(normalWS, vectorWS);
+
+    return float3(a, b, c);
 }
 
 float3 WorldSpaceToTangentFp32(float3 vectorWS, float3 normalWS, float3 tangentWS, float3 bitangentWS)


### PR DESCRIPTION
## What does this PR do?

- Fixes the black splotches by enabling mobile optimized BRDF for transparent meshes within mobile pipeline
- Few other warning related fixes.

Before
![image](https://github.com/carbonated-dev/o3de/assets/47460854/9e87cee1-bd7f-4148-8b12-3f1858def1ad)

After
![image](https://github.com/carbonated-dev/o3de/assets/47460854/4a8299e7-9019-462b-9a85-00beb48c2f57)

## How was this PR tested?

Tested iOS
