### PR TITLE
Fix precision issue with cascade shadowmaps

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/BicubicPcfFilters.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/BicubicPcfFilters.azsli
@@ -23,7 +23,7 @@
 //--------------------------------------------------------------------------------------------------
 
 // Margin to avoid counting samples past the shadows bounds as being in shadow.
-static const real DepthMargin = 1.0 - 1e-6;
+static const real DepthMargin = 1.0 - 1e-3;
 
 struct SampleShadowMapBicubicParameters
 {


### PR DESCRIPTION
## What does this PR do?

Fix precision issue with cascade shadowmaps when using fp16

Fixes #18001
Fixes #17991

## How was this PR tested?

Run Android