### PR TITLE
Milliseconds in the log timestamp

### DIFF
--- a/Code/Legacy/CrySystem/Log.cpp
+++ b/Code/Legacy/CrySystem/Log.cpp
@@ -138,7 +138,7 @@ namespace
 
 #if defined(CARBONATED)
         const auto now = AZStd::chrono::system_clock::now();
-        const auto milliseconds = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(now.time_since_epoch()) % 1000;
+        const int milliseconds = static_cast<int>((AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(now.time_since_epoch()) % 1000).count());
 
 #ifdef AZ_COMPILER_MSVC
         const auto timeStamp = AZStd::chrono::system_clock::to_time_t(now);
@@ -147,7 +147,7 @@ namespace
         std::ostringstream oss;
         oss << std::put_time(&localTime, "%H:%M:%S");
 
-        sprintf_s(sTime.data(), sTime.capacity(), "<%s.%03lld> ", oss.str().c_str(), milliseconds.count());
+        sprintf_s(sTime.data(), sTime.capacity(), "<%s.%03d> ", oss.str().c_str(), milliseconds);
 #else
         time_t ltime;
         time(&ltime);
@@ -155,7 +155,7 @@ namespace
         char hms[64];
         strftime(std::data(hms), std::size(hms), "%H:%M:%S", today);
                 
-        sprintf_s(sTime.data(), sTime.capacity(), "<%s.%03lld> ", hms, milliseconds.count());
+        sprintf_s(sTime.data(), sTime.capacity(), "<%s.%03d> ", hms, milliseconds);
 #endif
 
         // Fix up the internal size member of the fixed string

--- a/Code/Legacy/CrySystem/Log.cpp
+++ b/Code/Legacy/CrySystem/Log.cpp
@@ -135,23 +135,28 @@ namespace
     auto GetHourMinuteSeconds() -> TimeStringType
     {
         TimeStringType sTime;
-#ifdef AZ_COMPILER_MSVC
 
-// carbonated begin (akostin/LogWithMS): Log date with milliseconds
 #if defined(CARBONATED)
         const auto now = AZStd::chrono::system_clock::now();
         const auto milliseconds = AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(now.time_since_epoch()) % 1000;
 
+#ifdef AZ_COMPILER_MSVC
         const auto timeStamp = AZStd::chrono::system_clock::to_time_t(now);
         std::tm localTime;
-
         localtime_s(&localTime, &timeStamp);
-
         std::ostringstream oss;
-
         oss << std::put_time(&localTime, "%H:%M:%S");
 
         sprintf_s(sTime.data(), sTime.capacity(), "<%s.%03lld> ", oss.str().c_str(), milliseconds.count());
+#else
+        time_t ltime;
+        time(&ltime);
+        const auto today = localtime(&ltime);
+        char hms[64];
+        strftime(std::data(hms), std::size(hms), "%H:%M:%S", today);
+                
+        sprintf_s(sTime.data(), sTime.capacity(), "<%s.%03lld> ", hms, milliseconds.count());
+#endif
 
         // Fix up the internal size member of the fixed string
         // Using the traits_type::length function to calculate the strlen of the c-string returned by sprintf_s
@@ -159,20 +164,18 @@ namespace
 #else
         time_t ltime;
         time(&ltime);
+#ifdef AZ_COMPILER_MSVC
         struct tm today;
         localtime_s(&today, &ltime);
         strftime(sTime.data(), sTime.capacity(), "<%H:%M:%S> ", &today);
         // Fix up the internal size member of the fixed string
         // Using the traits_type::length function to calculate the strlen of the c-string returned by strftime
         sTime.resize_no_construct(TimeStringType::traits_type::length(sTime.data()));
-#endif
-// carbonated end
 #else
-        time_t ltime;
-        time(&ltime);
         auto today = localtime(&ltime);
         strftime(sTime.data(), sTime.capacity(), "<%H:%M:%S> ", today);
         sTime.resize_no_construct(TimeStringType::traits_type::length(sTime.data()));
+#endif
 #endif
         return sTime;
     };


### PR DESCRIPTION
## What does this PR do?

Added milliseconds in the log timestamp. The existed resolution is not convenient to track small delays in the app execution.

## How was this PR tested?

Build and run locally
