### PR TITLE
Set default assert level value

### DIFF
--- a/Code/Legacy/CrySystem/SystemInit.cpp
+++ b/Code/Legacy/CrySystem/SystemInit.cpp
@@ -1472,7 +1472,7 @@ void CSystem::CreateSystemVars()
 #if !defined(CARBONATED)
     const int defaultAssertValue = 1;
 #else
-    const int defaultAssertValue = 2; // Workaround for MAD-15166: set default assert level to 2 to show assert message dialogs on any platforms
+    const int defaultAssertValue = Legacy::System::CVars::sys_asserts;
 #endif
 
 #if !defined(CARBONATED)

--- a/Code/Legacy/CrySystem/SystemInit.cpp
+++ b/Code/Legacy/CrySystem/SystemInit.cpp
@@ -1469,10 +1469,10 @@ void CSystem::CreateSystemVars()
     REGISTER_STRING_CB("g_language", "", VF_NULL, "Defines which language pak is loaded", CSystem::OnLanguageCVarChanged);
 
     // adding CVAR to toggle assert verbosity level
-#if !defined(CARBONATED)
-    const int defaultAssertValue = 1;
-#else
+#if defined(CARBONATED)
     const int defaultAssertValue = Legacy::System::CVars::sys_asserts;
+#else
+    const int defaultAssertValue = 1;
 #endif
 
 #if !defined(CARBONATED)

--- a/Code/Legacy/CrySystem/SystemInit.cpp
+++ b/Code/Legacy/CrySystem/SystemInit.cpp
@@ -1469,7 +1469,11 @@ void CSystem::CreateSystemVars()
     REGISTER_STRING_CB("g_language", "", VF_NULL, "Defines which language pak is loaded", CSystem::OnLanguageCVarChanged);
 
     // adding CVAR to toggle assert verbosity level
+#if !defined(CARBONATED)
     const int defaultAssertValue = 1;
+#else
+    const int defaultAssertValue = 2; // Workaround for MAD-15166: set default assert level to 2 to show assert message dialogs on any platforms
+#endif
 
 #if !defined(CARBONATED)
     REGISTER_CVAR2_CB(


### PR DESCRIPTION
## What does this PR do?
Ticket: [15166]

Brief reason of issue: 
(A) On PC we initialize CVars by default values in CSystem::CreateSystemVars() then overwrite them by values from the file "bootstrap.client.profile.setreg" in the GameApplication::MergeSettingsToRegistry().
(B) On iOS we load CVars from the file "bootstrap.client.profile.setreg" then overwrite them by default values.
Not all CVars but many, including the assert level value.

Changes:
Use the current value of Legacy::System::CVars::sys_asserts in the CSystem::CreateSystemVars().
If it is a default value (e.g. on PC), we will use this default value.
If it is a changed-from-file value (e.g. on iOS), we will use this changed value.

## How was this PR tested?

Verified locally, on PC and iPhone14

The Jenkins test job: http://10.0.1.100:8080/job/MadWorld/job/Client-O3DE/job/build%252Fvmedn%252Ftest-MAD-15166-enable-assert-dialog/