### PR TITLE
Fix pixelated shadows on mobile

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/DirectionalLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/DirectionalLight.azsli
@@ -49,7 +49,7 @@ void ApplyDirectionalLights(Surface surface, inout LightingData lightingData, fl
             litRatio = DirectionalLightShadow::GetVisibility(shadowIndex, real3(surface.position), surface.vertexNormal, screenUv);
         }
 #else 
-        litRatio = DirectionalLightShadow::GetVisibility(shadowIndex, real3(surface.position), surface.vertexNormal, screenUv);
+        litRatio = DirectionalLightShadow::GetVisibility(shadowIndex, surface.position, surface.vertexNormal, screenUv);
 #endif // ENABLE_TRANSMISSION
 
     }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadow.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadow.azsli
@@ -40,13 +40,13 @@ class DirectionalLightShadow
 
     //! Calculates visibility ratio of the surface from the light origin. Should be called from fragment shaders.
     //! Returns lit ratio from the light (1.0 is fully visible, 0.0 is fully shadowed).
-    static real GetVisibility(uint lightIndex, real3 worldPos, real3 normalVector, float4 screenUv);
+    static real GetVisibility(uint lightIndex, float3 worldPos, real3 normalVector, float4 screenUv);
 
     static float2 GetVisibilityThickTransmission(uint lightIndex, real3 worldPos, real3 normalVector, float4 screenUv);
 
     static float2 GetVisibilityThinTransmission(uint lightIndex, real3 worldPos, real3 normalVector, float4 screenUv, real shrinkFactor);
 
-    static DirectionalShadowCalculator MakeShadowCalculator(uint lightIndex, real3 worldPos, real3 normalVector);
+    static DirectionalShadowCalculator MakeShadowCalculator(uint lightIndex, float3 worldPos, real3 normalVector);
 
     //! This alters the input color to visualize which cascade is being used
     //! and whether PCF is used as a fallback in ESM+PCF mode or not.
@@ -67,7 +67,7 @@ bool DirectionalLightShadow::UseFullscreenShadows()
 #endif
 }
 
-DirectionalShadowCalculator DirectionalLightShadow::MakeShadowCalculator(uint lightIndex, real3 worldPos, real3 normalVector)
+DirectionalShadowCalculator DirectionalLightShadow::MakeShadowCalculator(uint lightIndex, float3 worldPos, real3 normalVector)
 {
     DirectionalShadowCalculator calc;
     calc.SetBlendBetweenCascadesEnable(o_blend_between_cascades_enable);
@@ -127,7 +127,7 @@ float2 DirectionalLightShadow::GetVisibilityThinTransmission(uint lightIndex, re
     return float2(visibility, thickness);
 }
 
-real DirectionalLightShadow::GetVisibility(uint lightIndex, real3 worldPos, real3 normalVector, float4 screenUv)
+real DirectionalLightShadow::GetVisibility(uint lightIndex, float3 worldPos, real3 normalVector, float4 screenUv)
 {
     if (UseFullscreenShadows())
     {

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadowCalculator.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadowCalculator.azsli
@@ -46,7 +46,7 @@ class DirectionalShadowCalculator
         m_worldNormal = worldNormal;
     }
 
-    void SetWorldPos(const real3 worldPos)
+    void SetWorldPos(const float3 worldPos)
     {
         m_worldPos = worldPos;
     }
@@ -84,7 +84,7 @@ class DirectionalShadowCalculator
     float3 m_shadowPosDX[ViewSrg::MaxCascadeCount];
     float3 m_shadowPosDY[ViewSrg::MaxCascadeCount];
     real3 m_worldNormal;
-    real3 m_worldPos;
+    float3 m_worldPos;
 
     bool m_receiverShadowPlaneBiasEnable;
     bool m_blendBetweenCascadesEnable;
@@ -324,6 +324,7 @@ real DirectionalShadowCalculator::SamplePcfBicubic(const real3 shadowCoord, cons
 real DirectionalShadowCalculator::GetVisibilityFromLightPcf()
 {
     real lit = 1.0;
+    
     for (int indexOfCascade = m_minCascade; indexOfCascade <= m_maxCascade && lit > 0.01; ++indexOfCascade)
     {
         lit = min(lit, SamplePcfBicubic(real3(m_shadowCoords[indexOfCascade]), indexOfCascade));
@@ -410,3 +411,4 @@ real DirectionalShadowCalculator::CalculateCascadeBlendAmount(const real3 texCoo
     const real currentPixelsBlendBandLocation = min(min(texCoord.x, texCoord.y), distanceToOneMin);
     return currentPixelsBlendBandLocation / CascadeBlendArea;
 }
+

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/ReceiverPlaneDepthBias.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/ReceiverPlaneDepthBias.azsli
@@ -15,7 +15,12 @@
 // Another implementation example: https://github.com/TheRealMJP/Shadows
 float2 ComputeReceiverPlaneDepthBias(float3 projCoordsDDX, float3 projCoordsDDY)
 {
-    const float invDet = 1.0 / ((projCoordsDDX.x * projCoordsDDY.y) - (projCoordsDDX.y * projCoordsDDY.x));
+    float denom = ((projCoordsDDX.x * projCoordsDDY.y) - (projCoordsDDX.y * projCoordsDDY.x));
+    if(denom < EPSILON)
+    {
+        return float2(0.0,0.0);
+    }
+    const float invDet = 1.0 / denom ;
 
     float2 receiverPlaneDepthBias;
     


### PR DESCRIPTION
## What does this PR do?

- Ensure that world position retains full float as it is used for shadow uv coord calculations.
- Protect against Div by o when calculating receiverPlaneDepthBias
 
![image](https://github.com/carbonated-dev/o3de/assets/47460854/aeaafa5f-c6b6-4ce5-953c-cfdd01687afb)

## How was this PR tested?

Tested on iOS
