### PR TITLE
[MAD-15485] Support for explicit streaming images regiistration and usage

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetCatalog.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetCatalog.cpp
@@ -264,7 +264,7 @@ namespace AzFramework
             newInfo.m_assetType = typeToRegister;
             newInfo.m_sizeBytes = fileSize;
             AZ::Data::AssetId generatedID = GenerateAssetIdTEMP(newInfo.m_relativePath.c_str());
-
+#if defined(CARBONATED)
             // Request to register an asset may have path to a preprocessed streaming image without a raw texture,
             // which has ".streamingImage" extension, and then consumers (e.g. CSprite class) expect
             //    streamingImageAssetId.m_subId = AZ::RPI::StreamingImageAsset::GetImageAssetSubId()
@@ -274,7 +274,7 @@ namespace AzFramework
             {
                 generatedID.m_subId = 1000; // hardcoded, class StreamingImageAsset not available here
             }   
-
+#endif // defined(CARBONATED)
             newInfo.m_assetId = generatedID;
 
             {

--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetCatalog.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetCatalog.cpp
@@ -267,12 +267,12 @@ namespace AzFramework
 
             AZStd::string extension;
             AzFramework::StringFunc::Path::GetExtension(path, extension, false);
-            // We may have a preprocessed streaming image without a raw texture, and thus no need to append streamingImageExtension
-            // and then consumers expect
+            // We may have a preprocessed streaming image without a raw texture, it has "streamingImage" extension
+            // and then consumers (e.g. CSprite) expect
             //    streamingImageAssetId.m_subId = AZ::RPI::StreamingImageAsset::GetImageAssetSubId()
             if (extension.compare("streamingimage") == 0)
             {
-                generatedID.m_subId = 1000; // sort of a hack, see comment above, class StreamingImageAsset unknown here
+                generatedID.m_subId = 1000; // hack, see comment above, class StreamingImageAsset unknown here
             }   
             newInfo.m_assetId = generatedID;
 

--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetCatalog.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetCatalog.cpp
@@ -265,15 +265,16 @@ namespace AzFramework
             newInfo.m_sizeBytes = fileSize;
             AZ::Data::AssetId generatedID = GenerateAssetIdTEMP(newInfo.m_relativePath.c_str());
 
+            // Request to register an asset may have path to a preprocessed streaming image without a raw texture,
+            // which has ".streamingImage" extension, and then consumers (e.g. CSprite class) expect
+            //    streamingImageAssetId.m_subId = AZ::RPI::StreamingImageAsset::GetImageAssetSubId()
             AZStd::string extension;
             AzFramework::StringFunc::Path::GetExtension(path, extension, false);
-            // We may have a preprocessed streaming image without a raw texture, it has "streamingImage" extension
-            // and then consumers (e.g. CSprite) expect
-            //    streamingImageAssetId.m_subId = AZ::RPI::StreamingImageAsset::GetImageAssetSubId()
             if (extension.compare("streamingimage") == 0)
             {
-                generatedID.m_subId = 1000; // hack, see comment above, class StreamingImageAsset unknown here
+                generatedID.m_subId = 1000; // hardcoded, class StreamingImageAsset not available here
             }   
+
             newInfo.m_assetId = generatedID;
 
             {

--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetCatalog.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetCatalog.cpp
@@ -264,6 +264,16 @@ namespace AzFramework
             newInfo.m_assetType = typeToRegister;
             newInfo.m_sizeBytes = fileSize;
             AZ::Data::AssetId generatedID = GenerateAssetIdTEMP(newInfo.m_relativePath.c_str());
+
+            AZStd::string extension;
+            AzFramework::StringFunc::Path::GetExtension(path, extension, false);
+            // We may have a preprocessed streaming image without a raw texture, and thus no need to append streamingImageExtension
+            // and then consumers expect
+            //    streamingImageAssetId.m_subId = AZ::RPI::StreamingImageAsset::GetImageAssetSubId()
+            if (extension.compare("streamingimage") == 0)
+            {
+                generatedID.m_subId = 1000; // sort of a hack, see comment above, class StreamingImageAsset unknown here
+            }   
             newInfo.m_assetId = generatedID;
 
             {

--- a/Gems/LyShine/Code/Source/Sprite.cpp
+++ b/Gems/LyShine/Code/Source/Sprite.cpp
@@ -637,6 +637,11 @@ CSprite* CSprite::LoadSprite(const AZStd::string& pathname)
         return nullptr;
     }
 
+    if (IsImageProductPath(pathname)) // We may have a preprocessed streaming image without a raw texture
+    {
+         texturePath = AZStd::string::format("%s.%s", texturePath.c_str(), streamingImageExtension);
+    }
+
     // test if the sprite is already loaded, if so return loaded sprite
     auto result = s_loadedSprites->find(spritePath.c_str());
     CSprite* loadedSprite = (result == s_loadedSprites->end()) ? nullptr : result->second;
@@ -751,7 +756,7 @@ bool CSprite::DoesSpriteTextureAssetExist(const AZStd::string& pathname)
 
     // Check if the texture asset exists
     const AZStd::string cacheRelativePath = AZStd::string::format("%s.%s", pathname.c_str(), streamingImageExtension);
-    bool textureExists = CheckIfFileExists(/* sourceRelativePath = */ pathname, cacheRelativePath);
+    bool textureExists = CheckIfFileExists(spritePath, cacheRelativePath);
 
     return textureExists;
 }
@@ -819,7 +824,12 @@ AZStd::string CSprite::GetImageSourcePathFromProductPath(const AZStd::string& pr
 bool CSprite::LoadImage(const AZStd::string& nameTex, AZ::Data::Instance<AZ::RPI::Image>& image)
 {
     AZStd::string sourceRelativePath(nameTex);
-    AZStd::string cacheRelativePath = AZStd::string::format("%s.%s", sourceRelativePath.c_str(), streamingImageExtension);
+    AZStd::string cacheRelativePath(nameTex);
+    // We may have a preprocessed streaming image without a raw texture, and thus no need to append streamingImageExtension
+    if (!IsImageProductPath(cacheRelativePath))
+    {
+        cacheRelativePath = AZStd::string::format("%s.%s", sourceRelativePath.c_str(), streamingImageExtension);
+    }
     bool textureExists = CheckIfFileExists(sourceRelativePath, cacheRelativePath);
 
     if (!textureExists)

--- a/Gems/LyShine/Code/Source/Sprite.cpp
+++ b/Gems/LyShine/Code/Source/Sprite.cpp
@@ -637,10 +637,12 @@ CSprite* CSprite::LoadSprite(const AZStd::string& pathname)
         return nullptr;
     }
 
+#if defined(CARBONATED)
     if (IsImageProductPath(pathname)) // We may have a preprocessed streaming image without a raw texture
     {
          texturePath = AZStd::string::format("%s.%s", texturePath.c_str(), streamingImageExtension);
     }
+#endif // defined(CARBONATED)
 
     // test if the sprite is already loaded, if so return loaded sprite
     auto result = s_loadedSprites->find(spritePath.c_str());
@@ -825,11 +827,13 @@ bool CSprite::LoadImage(const AZStd::string& nameTex, AZ::Data::Instance<AZ::RPI
 {
     AZStd::string sourceRelativePath(nameTex);
     AZStd::string cacheRelativePath(nameTex);
+#if defined(CARBONATED)
     // We may have a preprocessed streaming image without a raw texture, and thus no need to append streamingImageExtension
     if (!IsImageProductPath(cacheRelativePath))
     {
         cacheRelativePath = AZStd::string::format("%s.%s", sourceRelativePath.c_str(), streamingImageExtension);
     }
+#endif // defined(CARBONATED)
     bool textureExists = CheckIfFileExists(sourceRelativePath, cacheRelativePath);
 
     if (!textureExists)

--- a/Gems/LyShine/Code/Source/Sprite.cpp
+++ b/Gems/LyShine/Code/Source/Sprite.cpp
@@ -826,13 +826,15 @@ AZStd::string CSprite::GetImageSourcePathFromProductPath(const AZStd::string& pr
 bool CSprite::LoadImage(const AZStd::string& nameTex, AZ::Data::Instance<AZ::RPI::Image>& image)
 {
     AZStd::string sourceRelativePath(nameTex);
-    AZStd::string cacheRelativePath(nameTex);
 #if defined(CARBONATED)
     // We may have a preprocessed streaming image without a raw texture, and thus no need to append streamingImageExtension
+    AZStd::string cacheRelativePath(nameTex);
     if (!IsImageProductPath(cacheRelativePath))
     {
         cacheRelativePath = AZStd::string::format("%s.%s", sourceRelativePath.c_str(), streamingImageExtension);
     }
+#else
+    AZStd::string cacheRelativePath = AZStd::string::format("%s.%s", sourceRelativePath.c_str(), streamingImageExtension);
 #endif // defined(CARBONATED)
     bool textureExists = CheckIfFileExists(sourceRelativePath, cacheRelativePath);
 


### PR DESCRIPTION
### Ticket:
[MAD-15485](https://jira.carbonated.com:8443/browse/MAD-15485)

### What does this PR do?
* Patches `AssetCatalog::GetAssetIdByPath()` to set correct `streamingImageAssetId.m_subId == 1000` for a preprocessed streaming image  being registered.
* Patches `CSprite::LoadSprite() `/ `CSprite::LoadImage()` to use fully qualified paths with the `.streamingimage` extension for preprocessed streaming images.
* Minor: restores correct (original) 1st argument in the call to `bool textureExists = CheckIfFileExists(spritePath, cacheRelativePath);` in `CSprite::DoesSpriteTextureAssetExist()`;

### How was this PR tested?
Game run. Hex sprites are shown, no extra errors noted.