### PR TITLE
Reset the character physics on material update

### DIFF
--- a/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterControllerComponent.cpp
+++ b/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterControllerComponent.cpp
@@ -387,6 +387,10 @@ namespace PhysX
         AZ_Warning("CharacterControllerComponent", index < m_characterConfig->m_materialSlots.GetSlotsCount(),
             "SetMaterial(): Invalid index %li passed for Entity %s.", index, GetEntityId().ToString().c_str());
         m_characterConfig->m_materialSlots.SetMaterialAsset(index, materialAsset);
+
+        // Re-enable physics to apply the new material - this is a bit of a hack, but it's the easiest way to ensure the material is applied
+        DisablePhysics();
+        EnablePhysics();
     }
 
     void CharacterControllerComponent::SetTag(const AZ::Crc32& tag)


### PR DESCRIPTION
Tested on device - the previous update to set material only updated the config of the character physx component, not the actual physx shape data. This is a quick hack to force a refresh of the physx shape, ill make a follow up ticket for the engine team to properly implement it
