### PR TITLE
Removed redundant level path fix in engine code

### DIFF
--- a/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
+++ b/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
@@ -229,33 +229,6 @@ namespace LegacyLevelSystem
                 {
                     validLevelName = possibleLevelAssetPath;
                 }
-#if defined(CARBONATED)
-                // TODO : fix the level path on the backend
-                else
-                {
-                    AZStd::string levelNameStr = levelName;
-                    AZStd::string assetPath;
-                    if (levelNameStr.starts_with("/dlc/"))
-                    {
-                        assetPath = AZStd::string::format("Levels%s/%s.spawnable", levelName, strrchr(levelName, '/') + 1);
-                    }
-                    else if (levelNameStr.starts_with("dlc/"))
-                    {
-                        assetPath = AZStd::string::format("Levels/%s/%s.spawnable", levelName, strrchr(levelName, '/') + 1);
-                    }
-
-                    AZ::Data::AssetCatalogRequestBus::BroadcastResult(
-                        rootSpawnableAssetId,
-                        &AZ::Data::AssetCatalogRequestBus::Events::GetAssetIdByPath,
-                        assetPath.c_str(),
-                        AZ::Data::AssetType{},
-                        false);
-                    if (rootSpawnableAssetId.IsValid())
-                    {
-                        validLevelName = assetPath;
-                    }
-                }
-#endif // #if defined(CARBONATED)
             }
         }
 


### PR DESCRIPTION
## What does this PR do?

This is for removing the code that converts the level folder path into spawnable path. This code already exists in LevelManager.cpp, so it's redundant.

### Test Method

The changes were tested on iPhone 13 Pro Max, using both Dev Menu and Battle Button to test loading the levels.

### Jira Ticket(s)

[MAD-15192](https://jira.carbonated.com:8443/browse/MAD-15192)

### Related PR(s)

https://github.com/carbonated-dev/o3de-gruber/pull/808