### PR TITLE
Add support to apply r_renderScale when r_resolutionMode is 0

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Windowing/NativeWindow.h
+++ b/Code/Framework/AzFramework/AzFramework/Windowing/NativeWindow.h
@@ -128,8 +128,6 @@ namespace AzFramework
         WindowSize GetMaximumClientAreaSize() const override;
         void ResizeClientArea(WindowSize clientAreaSize, const WindowPosOptions& options) override;
         bool SupportsClientAreaResize() const override;
-        void SetEnableCustomizedResolution(bool enable) override;
-        bool IsCustomizedResolutionEnabled() const override;
         WindowSize GetRenderResolution() const override;
         void SetRenderResolution(WindowSize resolution) override;
         bool GetFullScreenState() const override;
@@ -168,7 +166,8 @@ namespace AzFramework
             static Implementation* Create();
             virtual ~Implementation() = default;
 
-            virtual void InitWindow(const AZStd::string& title,
+            void InitWindow(const AZStd::string& title, const WindowGeometry& geometry, const WindowStyleMasks& styleMasks);
+            virtual void InitWindowInternal(const AZStd::string& title,
                                     const WindowGeometry& geometry,
                                     const WindowStyleMasks& styleMasks) = 0;
 
@@ -183,8 +182,6 @@ namespace AzFramework
             virtual WindowSize GetMaximumClientAreaSize() const;
             virtual void ResizeClientArea(WindowSize clientAreaSize, const WindowPosOptions& options);
             virtual bool SupportsClientAreaResize() const;
-            virtual void SetEnableCustomizedResolution(bool enable);
-            virtual bool IsCustomizedResolutionEnabled() const;
             virtual WindowSize GetRenderResolution() const;
             virtual void SetRenderResolution(WindowSize resolution);
             virtual bool GetFullScreenState() const;
@@ -197,8 +194,7 @@ namespace AzFramework
             uint32_t m_width = 0;
             uint32_t m_height = 0;
             bool m_activated = false;
-            WindowSize m_customizedRenderResolution;
-            bool m_enableCustomizedResolution = false;
+            WindowSize m_renderResolution;
         };
 
         ////////////////////////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzFramework/AzFramework/Windowing/WindowBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Windowing/WindowBus.h
@@ -90,13 +90,6 @@ namespace AzFramework
         //! Generally desktop platforms support resizing, mobile platforms don't.
         virtual bool SupportsClientAreaResize() const = 0;
 
-        //! Enable custom render resolution which is different than client area size.
-        //! If custom render resolution is disabled, the render resolution is same as client area size
-        virtual void SetEnableCustomizedResolution(bool enable) = 0;
-        
-        //! If the custom render resolution is enabled.
-        virtual bool IsCustomizedResolutionEnabled() const = 0;
-
         //! Get the render resolution.
         //! If customized resolution is not enabled, it would return client area size
         virtual WindowSize GetRenderResolution() const = 0;

--- a/Code/Framework/AzFramework/Platform/Android/AzFramework/Windowing/NativeWindow_Android.cpp
+++ b/Code/Framework/AzFramework/Platform/Android/AzFramework/Windowing/NativeWindow_Android.cpp
@@ -22,7 +22,7 @@ namespace AzFramework
         ~NativeWindowImpl_Android() override = default;
 
         // NativeWindow::Implementation overrides...
-        void InitWindow(const AZStd::string& title,
+        void InitWindowInternal(const AZStd::string& title,
                         const WindowGeometry& geometry,
                         const WindowStyleMasks& styleMasks) override;
         NativeWindowHandle GetWindowHandle() const override;
@@ -34,9 +34,10 @@ namespace AzFramework
         ANativeWindow* m_nativeWindow = nullptr;
     };
 
-    void NativeWindowImpl_Android::InitWindow([[maybe_unused]]const AZStd::string& title,
-                                              const WindowGeometry& geometry,
-                                              [[maybe_unused]]const WindowStyleMasks& styleMasks)
+    void NativeWindowImpl_Android::InitWindowInternal(
+        [[maybe_unused]] const AZStd::string& title,
+        const WindowGeometry& geometry,
+        [[maybe_unused]]const WindowStyleMasks& styleMasks)
     {
         m_nativeWindow = AZ::Android::Utils::GetWindow();
 
@@ -78,7 +79,7 @@ namespace AzFramework
     void NativeWindowImpl_Android::SetRenderResolution(WindowSize resolution)
     {
         WindowSize newResolution = resolution;
-        if (m_enableCustomizedResolution && m_nativeWindow)
+        if (m_nativeWindow)
         {
             // Fit the aspect ratio of the resolution so it matches the aspect ratio of the window
             // so when the window image is scaled by the OS compositor, it doesn't look stretched in any direction.

--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbNativeWindow.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbNativeWindow.cpp
@@ -48,7 +48,7 @@ namespace AzFramework
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
-    void XcbNativeWindow::InitWindow(const AZStd::string& title, const WindowGeometry& geometry, const WindowStyleMasks& styleMasks)
+    void XcbNativeWindow::InitWindowInternal(const AZStd::string& title, const WindowGeometry& geometry, const WindowStyleMasks& styleMasks)
     {
         // Get the parent window
         const xcb_setup_t* xcbSetup = xcb_get_setup(m_xcbConnection);
@@ -437,10 +437,6 @@ namespace AzFramework
             {
                 WindowNotificationBus::Event(
                     reinterpret_cast<NativeWindowHandle>(m_xcbWindow), &WindowNotificationBus::Events::OnWindowResized, width, height);
-                if (!m_enableCustomizedResolution)
-                {
-                    WindowNotificationBus::Event(GetWindowHandle(), &WindowNotificationBus::Events::OnResolutionChanged, width, height);
-                }
             }
         }
     }

--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbNativeWindow.h
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbNativeWindow.h
@@ -27,7 +27,7 @@ namespace AzFramework
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         // NativeWindow::Implementation
-        void InitWindow(const AZStd::string& title, const WindowGeometry& geometry, const WindowStyleMasks& styleMasks) override;
+        void InitWindowInternal(const AZStd::string& title, const WindowGeometry& geometry, const WindowStyleMasks& styleMasks) override;
         void Activate() override;
         void Deactivate() override;
         NativeWindowHandle GetWindowHandle() const override;

--- a/Code/Framework/AzFramework/Platform/Mac/AzFramework/Windowing/NativeWindow_Mac.mm
+++ b/Code/Framework/AzFramework/Platform/Mac/AzFramework/Windowing/NativeWindow_Mac.mm
@@ -25,7 +25,7 @@ namespace AzFramework
         ~NativeWindowImpl_Darwin() override;
         
         // NativeWindow::Implementation overrides...
-        void InitWindow(const AZStd::string& title,
+        void InitWindowInternal(const AZStd::string& title,
                         const WindowGeometry& geometry,
                         const WindowStyleMasks& styleMasks) override;
         NativeWindowHandle GetWindowHandle() const override;
@@ -52,7 +52,7 @@ namespace AzFramework
         m_nativeWindow = nil;
     }
 
-    void NativeWindowImpl_Darwin::InitWindow(const AZStd::string& title,
+    void NativeWindowImpl_Darwin::InitWindowInternal(const AZStd::string& title,
                                              const WindowGeometry& geometry,
                                              const WindowStyleMasks& styleMasks)
     {

--- a/Code/Framework/AzFramework/Platform/Windows/AzFramework/Windowing/NativeWindow_Windows.cpp
+++ b/Code/Framework/AzFramework/Platform/Windows/AzFramework/Windowing/NativeWindow_Windows.cpp
@@ -40,9 +40,10 @@ namespace AzFramework
         m_win32Handle = nullptr;
     }
 
-    void NativeWindowImpl_Win32::InitWindow(const AZStd::string& title,
-                                            const WindowGeometry& geometry,
-                                            const WindowStyleMasks& styleMasks)
+    void NativeWindowImpl_Win32::InitWindowInternal(
+        const AZStd::string& title,
+        const WindowGeometry& geometry,
+        const WindowStyleMasks& styleMasks)
     {
         const HINSTANCE hInstance = GetModuleHandle(0);
 
@@ -380,10 +381,6 @@ namespace AzFramework
             if (m_activated)
             {
                 WindowNotificationBus::Event(m_win32Handle, &WindowNotificationBus::Events::OnWindowResized, width, height);
-                if (!m_enableCustomizedResolution)
-                {
-                    WindowNotificationBus::Event(m_win32Handle, &WindowNotificationBus::Events::OnResolutionChanged, width, height);
-                }
             }
         }
     }

--- a/Code/Framework/AzFramework/Platform/Windows/AzFramework/Windowing/NativeWindow_Windows.h
+++ b/Code/Framework/AzFramework/Platform/Windows/AzFramework/Windowing/NativeWindow_Windows.h
@@ -26,7 +26,7 @@ namespace AzFramework
         ~NativeWindowImpl_Win32() override;
 
         // NativeWindow::Implementation overrides...
-        void InitWindow(const AZStd::string& title,
+        void InitWindowInternal(const AZStd::string& title,
                         const WindowGeometry& geometry,
                         const WindowStyleMasks& styleMasks) override;
         void Activate() override;

--- a/Code/Framework/AzFramework/Platform/iOS/AzFramework/Windowing/NativeWindow_ios.mm
+++ b/Code/Framework/AzFramework/Platform/iOS/AzFramework/Windowing/NativeWindow_ios.mm
@@ -31,9 +31,8 @@ namespace AzFramework
         uint32_t GetDisplayRefreshRate() const override;
         
     private:
-#if defined(CARBONATED)
-        static bool IsLandscape();
-#endif
+        bool IsLandscape() const;
+
         UIWindow* m_nativeWindow;
         uint32_t m_mainDisplayRefreshRate = 0;
     };
@@ -59,14 +58,12 @@ namespace AzFramework
         m_width = [[UIScreen mainScreen] nativeBounds].size.width;
         m_height = [[UIScreen mainScreen] nativeBounds].size.height;
 
-#if defined(CARBONATED)
         // The rectangle returned by nativeBounds is always in a portrait orientation.
         // If the app is landscape, width and height must be swapped.
         if (IsLandscape())
         {
             AZStd::swap(m_width, m_height);
         }
-#endif
         
         m_mainDisplayRefreshRate = [[UIScreen mainScreen] maximumFramesPerSecond];
     }
@@ -81,30 +78,11 @@ namespace AzFramework
         return m_mainDisplayRefreshRate;
     }
 
-#if defined(CARBONATED)
-    bool NativeWindowImpl_Ios::IsLandscape()
+    bool NativeWindowImpl_Ios::IsLandscape() const
     {
-        UIInterfaceOrientation uiOrientation = UIInterfaceOrientationUnknown;
-
-        UIWindow* foundWindow = nil;
-        NSArray* windows = [[UIApplication sharedApplication] windows];
-        for (UIWindow* window in windows)
-        {
-            if (window.isKeyWindow)
-            {
-                foundWindow = window;
-                break;
-            }
-        }
-        UIWindowScene* windowScene = foundWindow ? foundWindow.windowScene : nullptr;
-        AZ_Assert(windowScene, "WindowScene is invalid");
-        if (windowScene)
-        {
-            uiOrientation = windowScene.interfaceOrientation;
-        }
+        UIInterfaceOrientation uiOrientation = m_nativeWindow.windowScene.interfaceOrientation;
         return uiOrientation == UIInterfaceOrientationLandscapeLeft || uiOrientation == UIInterfaceOrientationLandscapeRight;
     }
-#endif
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
     class IosNativeWindowFactory 

--- a/Code/Framework/AzFramework/Platform/iOS/AzFramework/Windowing/NativeWindow_ios.mm
+++ b/Code/Framework/AzFramework/Platform/iOS/AzFramework/Windowing/NativeWindow_ios.mm
@@ -10,10 +10,6 @@
 #include <AzFramework/Windowing/NativeWindow.h>
 #include <AzFramework/Components/NativeUISystemComponent.h>
 
-#if defined(CARBONATED)
-#include <AzCore/Console/IConsole.h>
-#endif
-
 #include <UIKit/UIKit.h>
 @class NSWindow;
 
@@ -28,7 +24,7 @@ namespace AzFramework
         ~NativeWindowImpl_Ios() override;
         
         // NativeWindow::Implementation overrides...
-        void InitWindow(const AZStd::string& title,
+        void InitWindowInternal(const AZStd::string& title,
                         const WindowGeometry& geometry,
                         const WindowStyleMasks& styleMasks) override;
         NativeWindowHandle GetWindowHandle() const override;
@@ -51,49 +47,27 @@ namespace AzFramework
         }
     }
     
-    void NativeWindowImpl_Ios::InitWindow([[maybe_unused]]const AZStd::string& title,
+    void NativeWindowImpl_Ios::InitWindowInternal([[maybe_unused]]const AZStd::string& title,
                                           const WindowGeometry& geometry,
                                           [[maybe_unused]]const WindowStyleMasks& styleMasks)
     {
         CGRect screenBounds = [[UIScreen mainScreen] bounds];
         m_nativeWindow = [[UIWindow alloc] initWithFrame: screenBounds];
         [m_nativeWindow makeKeyAndVisible];
-
-#if defined(CARBONATED)
+        
+        // On iOS we don't set the window size, we use the OS window's' size
         m_width = [[UIScreen mainScreen] nativeBounds].size.width;
         m_height = [[UIScreen mainScreen] nativeBounds].size.height;
+
+#if defined(CARBONATED)
         // The rectangle returned by nativeBounds is always in a portrait orientation.
         // If the app is landscape, width and height must be swapped.
         if (IsLandscape())
         {
             AZStd::swap(m_width, m_height);
         }
-        
-        uint32_t resolutionMode = 0;
-        AZ::IConsole* console = AZ::Interface<AZ::IConsole>::Get();
-        if (console)
-        {
-            console->GetCvarValue("r_resolutionMode", resolutionMode);
-        }
-        if (resolutionMode == 1)
-        {
-            // Make sure that the window width does not exceed the given geometry width.
-            if (geometry.m_width < m_width)
-            {
-                m_height = static_cast<uint32_t>((static_cast<float>(m_height) / m_width) * geometry.m_width);
-                m_width = geometry.m_width;
-            }
-        }
-        if (console)
-        {
-            // screen to world uses default viewport's size, which is based on these cvars, so we should keep them in sync
-            console->PerformCommand(AZStd::string::format("r_width %d", m_width).c_str());
-            console->PerformCommand(AZStd::string::format("r_height %d", m_height).c_str());
-        }
-#else
-        m_width = geometry.m_width;
-        m_height = geometry.m_height;
 #endif
+        
         m_mainDisplayRefreshRate = [[UIScreen mainScreen] maximumFramesPerSecond];
     }
     

--- a/Gems/Atom/Bootstrap/Code/Include/Atom/Bootstrap/BootstrapRequestBus.h
+++ b/Gems/Atom/Bootstrap/Code/Include/Atom/Bootstrap/BootstrapRequestBus.h
@@ -25,6 +25,7 @@ namespace AZ::Render::Bootstrap
         virtual AZ::RPI::ScenePtr GetOrCreateAtomSceneFromAzScene(AzFramework::Scene* scene) = 0;
         virtual bool EnsureDefaultRenderPipelineInstalledForScene(AZ::RPI::ScenePtr scene, AZ::RPI::ViewportContextPtr viewportContext) = 0;
         virtual void SwitchRenderPipeline(const AZ::RPI::RenderPipelineDescriptor& newRenderPipelineDesc, AZ::RPI::ViewportContextPtr viewportContext) = 0;
+        virtual void RefreshWindowResolution() = 0;
 
     protected:
         ~Request() = default;

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -74,26 +74,28 @@ void cvar_r_renderPipelinePath_Changed(const AZ::CVarFixedString& newPipelinePat
     }
 }
 
-AZ_CVAR(AZ::CVarFixedString, r_renderPipelinePath, AZ_TRAIT_BOOTSTRAPSYSTEMCOMPONENT_PIPELINE_NAME, cvar_r_renderPipelinePath_Changed, AZ::ConsoleFunctorFlags::DontReplicate, "The asset (.azasset) path for default render pipeline");
-AZ_CVAR(AZ::CVarFixedString, r_default_openxr_pipeline_name, "passes/MultiViewRenderPipeline.azasset", nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Default openXr render pipeline name");
-AZ_CVAR(AZ::CVarFixedString, r_default_openxr_left_pipeline_name, "passes/XRLeftRenderPipeline.azasset", nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Default openXr Left eye render pipeline name");
-AZ_CVAR(AZ::CVarFixedString, r_default_openxr_right_pipeline_name, "passes/XRRightRenderPipeline.azasset", nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Default openXr Right eye render pipeline name");
-AZ_CVAR(uint32_t, r_width, 1920, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Starting window width in pixels.");
-AZ_CVAR(uint32_t, r_height, 1080, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Starting window height in pixels.");
-AZ_CVAR(uint32_t, r_fullscreen, false, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Starting fullscreen state.");
-AZ_CVAR(uint32_t, r_resolutionMode, 0, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "0: render resolution same as window client area size, 1: render resolution use the values specified by r_width and r_height");
+void cvar_r_resolution_Changed([[maybe_unused]] const uint32_t& newValue)
+{
+    AZ::Render::Bootstrap::RequestBus::Broadcast(&AZ::Render::Bootstrap::RequestBus::Events::RefreshWindowResolution);
+}
 
 void cvar_r_renderScale_Changed(const float& newRenderScale)
 {
     AZ_Error("AtomBootstrap", newRenderScale > 0, "RenderScale should be greater than 0");
     if (newRenderScale > 0)
     {
-        AzFramework::WindowSize newSize =
-            AzFramework::WindowSize(static_cast<uint32_t>(r_width * newRenderScale), static_cast<uint32_t>(r_height * newRenderScale));
-        AzFramework::WindowRequestBus::Broadcast(&AzFramework::WindowRequestBus::Events::SetEnableCustomizedResolution, true);
-        AzFramework::WindowRequestBus::Broadcast(&AzFramework::WindowRequestBus::Events::SetRenderResolution, newSize);
+        AZ::Render::Bootstrap::RequestBus::Broadcast(&AZ::Render::Bootstrap::RequestBus::Events::RefreshWindowResolution);
     }
 }
+
+AZ_CVAR(AZ::CVarFixedString, r_renderPipelinePath, AZ_TRAIT_BOOTSTRAPSYSTEMCOMPONENT_PIPELINE_NAME, cvar_r_renderPipelinePath_Changed, AZ::ConsoleFunctorFlags::DontReplicate, "The asset (.azasset) path for default render pipeline");
+AZ_CVAR(AZ::CVarFixedString, r_default_openxr_pipeline_name, "passes/MultiViewRenderPipeline.azasset", nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Default openXr render pipeline name");
+AZ_CVAR(AZ::CVarFixedString, r_default_openxr_left_pipeline_name, "passes/XRLeftRenderPipeline.azasset", nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Default openXr Left eye render pipeline name");
+AZ_CVAR(AZ::CVarFixedString, r_default_openxr_right_pipeline_name, "passes/XRRightRenderPipeline.azasset", nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Default openXr Right eye render pipeline name");
+AZ_CVAR(uint32_t, r_width, 1920, cvar_r_resolution_Changed, AZ::ConsoleFunctorFlags::DontReplicate, "Starting window width in pixels.");
+AZ_CVAR(uint32_t, r_height, 1080, cvar_r_resolution_Changed, AZ::ConsoleFunctorFlags::DontReplicate, "Starting window height in pixels.");
+AZ_CVAR(uint32_t, r_fullscreen, false, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Starting fullscreen state.");
+AZ_CVAR(uint32_t, r_resolutionMode, 0, cvar_r_resolution_Changed, AZ::ConsoleFunctorFlags::DontReplicate, "0: render resolution same as window client area size, 1: render resolution use the values specified by r_width and r_height");
 AZ_CVAR(float, r_renderScale, 1.0f, cvar_r_renderScale_Changed, AZ::ConsoleFunctorFlags::DontReplicate, "Scale to apply to the window resolution.");
 
 namespace AZ
@@ -278,8 +280,8 @@ namespace AZ
                     // command line arguments into cvars.
                     UpdateCVarsFromCommandLine();
 
-                    auto windowSize = GetWindowResolution();
-                    m_nativeWindow = AZStd::make_unique<AzFramework::NativeWindow>(projectTitle.c_str(), AzFramework::WindowGeometry(0, 0, windowSize.m_width, windowSize.m_height));
+                    m_nativeWindow = AZStd::make_unique<AzFramework::NativeWindow>(
+                        projectTitle.c_str(), AzFramework::WindowGeometry(0, 0, r_width, r_height));
                     AZ_Assert(m_nativeWindow, "Failed to create the game window\n");
 
                     m_nativeWindow->Activate();
@@ -399,8 +401,7 @@ namespace AZ
                 if (!m_nativeWindow)
                 {
                     auto projectTitle = AZ::Utils::GetProjectDisplayName();
-                    auto windowSize = GetWindowResolution();
-                    m_nativeWindow = AZStd::make_unique<AzFramework::NativeWindow>(projectTitle.c_str(), AzFramework::WindowGeometry(0, 0, windowSize.m_width, windowSize.m_height));
+                    m_nativeWindow = AZStd::make_unique<AzFramework::NativeWindow>(projectTitle.c_str(), AzFramework::WindowGeometry(0, 0, r_width, r_height));
                     AZ_Assert(m_nativeWindow, "Failed to create the game window\n");
 
                     m_nativeWindow->Activate();
@@ -439,15 +440,20 @@ namespace AZ
                 if (m_nativeWindow)
                 {
                     // wait until swapchain has been created before setting fullscreen state
+                    AzFramework::WindowSize resolution;
+                    float scale = AZStd::max(static_cast<float>(r_renderScale), 0.f);
                     if (r_resolutionMode > 0u)
                     {
-                        m_nativeWindow->SetEnableCustomizedResolution(true);
-                        m_nativeWindow->SetRenderResolution(GetWindowResolution());
+                        resolution.m_width = static_cast<uint32_t>(r_width * scale);
+                        resolution.m_height = static_cast<uint32_t>(r_height * scale);
                     }
                     else
                     {
-                        m_nativeWindow->SetEnableCustomizedResolution(false);
+                        const auto& windowSize = m_nativeWindow->GetClientAreaSize();
+                        resolution.m_width = static_cast<uint32_t>(windowSize.m_width * scale);
+                        resolution.m_height = static_cast<uint32_t>(windowSize.m_height * scale);
                     }
+                    m_nativeWindow->SetRenderResolution(resolution);
                     m_nativeWindow->SetFullScreenState(r_fullscreen);
                 }
             }
@@ -626,6 +632,11 @@ namespace AZ
                 AZ::RPI::RPISystemInterface::Get()->SetApplicationMultisampleState(newRenderPipeline->GetRenderSettings().m_multisampleState);
             }
 
+            void BootstrapSystemComponent::RefreshWindowResolution()
+            {
+                SetWindowResolution();
+            }
+
             RPI::RenderPipelinePtr BootstrapSystemComponent::LoadPipeline( AZ::RPI::ScenePtr scene, AZ::RPI::ViewportContextPtr viewportContext,
                                                     AZStd::string_view pipelineName, AZ::RPI::ViewType viewType, AZ::RHI::MultisampleState& multisampleState)
             {
@@ -671,12 +682,6 @@ namespace AZ
                     AZ_Error("AtomBootstrap", false, "Pipeline file failed to load from path: %s.", pipelineName.data());
                     return nullptr;
                 }
-            }
-
-            AzFramework::WindowSize BootstrapSystemComponent::GetWindowResolution() const
-            {
-                float scale = AZStd::max(static_cast<float>(r_renderScale), 0.f);
-                return AzFramework::WindowSize(static_cast<uint32_t>(r_width * scale), static_cast<uint32_t>(r_height * scale));
             }
 
             void BootstrapSystemComponent::CreateDefaultRenderPipeline()
@@ -747,6 +752,11 @@ namespace AZ
                 AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::ExitMainLoop);
 #endif
                 AzFramework::WindowNotificationBus::Handler::BusDisconnect();
+            }
+
+            void BootstrapSystemComponent::OnWindowResized([[maybe_unused]] uint32_t width, [[maybe_unused]] uint32_t height)
+            {
+                SetWindowResolution();
             }
 
             AzFramework::NativeWindowHandle BootstrapSystemComponent::GetDefaultWindowHandle()

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.h
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.h
@@ -70,6 +70,7 @@ namespace AZ
                 AZ::RPI::ScenePtr GetOrCreateAtomSceneFromAzScene(AzFramework::Scene* scene) override;
                 bool EnsureDefaultRenderPipelineInstalledForScene(AZ::RPI::ScenePtr scene, AZ::RPI::ViewportContextPtr viewportContext) override;
                 void SwitchRenderPipeline(const AZ::RPI::RenderPipelineDescriptor& newRenderPipelineDesc, AZ::RPI::ViewportContextPtr viewportContext) override;
+                void RefreshWindowResolution() override;
 
             protected:
                 // Component overrides ...
@@ -78,6 +79,7 @@ namespace AZ
 
                 // WindowNotificationBus::Handler overrides ...
                 void OnWindowClosed() override;
+                void OnWindowResized(uint32_t width, uint32_t height) override;
 
                 // TickBus::Handler overrides ...
                 void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
@@ -108,8 +110,6 @@ namespace AZ
                     AZStd::string_view xrPipelineName,
                     AZ::RPI::ViewType viewType,
                     AZ::RHI::MultisampleState& multisampleState);
-
-                AzFramework::WindowSize GetWindowResolution() const;
 
                 AzFramework::Scene::RemovalEvent::Handler m_sceneRemovalHandler;
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
@@ -16,6 +16,7 @@
 #include <Atom/RHI.Reflect/Vulkan/XRVkDescriptors.h>
 #include <AzCore/std/algorithm.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
+#include <AzCore/Console/ILogger.h>
 #include <Atom/RHI.Reflect/Vulkan/Conversion.h>
 #include <RHI/Device.h>
 #include <RHI/Image.h>
@@ -597,14 +598,13 @@ namespace AZ
                     m_dimensions.m_imageWidth,
                     m_surfaceCapabilities.minImageExtent.width,
                     m_surfaceCapabilities.maxImageExtent.width);
-                AZ_Printf(
-                    "Vulkan", "Resizing swapchain from (%u, %u) to (%u, %u).",
+                AZLOG_DEBUG("Resizing swapchain from (%u, %u) to (%u, %u).",
                     oldWidth, oldHeight, m_dimensions.m_imageWidth, m_dimensions.m_imageHeight);
             }
 
             RHI::ResultCode result = BuildNativeSwapChain(m_dimensions);
             RETURN_RESULT_IF_UNSUCCESSFUL(result);
-            AZ_TracePrintf("Vulkan", "Swapchain created. Width: %u, Height: %u.\n", m_dimensions.m_imageWidth, m_dimensions.m_imageHeight);
+            AZLOG_DEBUG("Swapchain created. Width: %u, Height: %u.\n", m_dimensions.m_imageWidth, m_dimensions.m_imageHeight);
 
             // Do not recycle the semaphore because they may not ever get signaled and since
             // we can't recycle Vulkan semaphores we just delete them.
@@ -631,13 +631,13 @@ namespace AZ
                 device.GetNativeDevice(), m_nativeSwapChain, &m_dimensions.m_imageCount, m_swapchainNativeImages.data());
             AssertSuccess(vkResult);
             RETURN_RESULT_IF_UNSUCCESSFUL(ConvertResult(vkResult));
-            AZ_TracePrintf("Swapchain", "Obtained presentable images.\n");
+            AZLOG_DEBUG("Obtained presentable images.\n");
 
             // Acquire the first image
             uint32_t imageIndex = 0;
             result = AcquireNewImage(&imageIndex);
             RETURN_RESULT_IF_UNSUCCESSFUL(result);
-            AZ_TracePrintf("Swapchain", "Acquired the first image.\n");
+            AZLOG_DEBUG("Acquired the first image.\n");
 
             return RHI::ResultCode::Success;
         }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/RenderViewportWidget.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/RenderViewportWidget.h
@@ -117,8 +117,6 @@ namespace AtomToolsFramework
         void SetFullScreenState(bool fullScreenState) override;
         bool CanToggleFullScreenState() const override;
         void ToggleFullScreenState() override;
-        void SetEnableCustomizedResolution(bool enable) override;
-        bool IsCustomizedResolutionEnabled() const override;
         AzFramework::WindowSize GetRenderResolution() const override;
         void SetRenderResolution(AzFramework::WindowSize resolution) override;
         float GetDpiScaleFactor() const override;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
@@ -454,16 +454,6 @@ namespace AtomToolsFramework
         // The RenderViewportWidget does not currently support full screen.
     }
 
-    void RenderViewportWidget::SetEnableCustomizedResolution([[maybe_unused]]bool enable)
-    {
-        // The RenderViewportWidget does not currently support customized render resolution.
-    }
-
-    bool RenderViewportWidget::IsCustomizedResolutionEnabled() const
-    {
-        return false;
-    }
-
     AzFramework::WindowSize RenderViewportWidget::GetRenderResolution() const
     {
         // We want render resolution matches the screen's resolution


### PR DESCRIPTION
## What does this PR do?

Add support to use the r_renderScale when the resolution mode is 0 (use the native window resolution). Before, in order to use the r_renderScale you need to set the r_resolutionMode to 1, which means setting the r_width and r_height to fix values. In some cases users may want to scale not from fixed values, but from the native window resolution. This may be the case for Android and iOS where applications may scale from the window resolution using the quality cvar system.

Removed the enable/disable of custom resolution. Now you can set a resolution always. If you want to match the window resolution you can just do SetRenderResolution(GetClientAreaSize())

Added callback for certain CVARs related to resolution.

Removed hack of setting the r_width and r_height in the NativeWindow_iOS.mm

## How was this PR tested?

Run PC Vulkan/DX12 in Editor and Game mode. Run Android and iOS.
