### PR TITLE
[MAD-15393] Do not call RetrieveTicket() if ticketId == 0 due to Entities have been already despawned.

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesManager.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesManager.cpp
@@ -336,7 +336,7 @@ namespace AzFramework
                 }
             }
 
-            if (ticketId != InvalidTicketId)
+            if (ticketId != InvalidTicketId && ticketId != 0) // Entities could already be despawned with ticketId assigned to 0
             {
                 SpawnableEntitiesInterface::Get()->RetrieveTicket(ticketId,
                     [optionalArgs](EntitySpawnTicket&& entitySpawnTicket)


### PR DESCRIPTION
### Ticket: 
[MAD-15393](https://jira.carbonated.com:8443/browse/MAD-15393)

### What does this PR do?
Fixes Gruber-patched code in `SpawnableEntitiesManager::DespawnAllEntitiesInTicketByEntityID()` to not call `RetrieveTicket()` if `ticketId == 0` due to Entities have been already despawned, and `entity->SetEntitySpawnTicketId(0);` has been previously called for every despawned Entity.
This may happen if a game component is storing EntityIds, and then attempts to depawn Entities by TicketId multiple times, for example, in `Deactivate()`, which is legal to be called multiple times.
[Entity::SetEntitySpawnTicketId(0) is called here
](https://github.com/carbonated-dev/o3de/blob/4d51ebee8611fd154641c7dc92c7793de1240706/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesManager.cpp#L1013) and [here](https://github.com/carbonated-dev/o3de/blob/4d51ebee8611fd154641c7dc92c7793de1240706/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesManager.cpp#L966).

### How was this PR tested?
Standalone Game run, no Assert raised.

### Note:
The related [PR to Gruber](https://github.com/carbonated-dev/o3de-gruber/pull/816) fixes game code to avoid somewhat invalid attempts to despawn a MeleeAttck spawnable muliple times.
PRs can be merged independently.