### PR TITLE
Address slowdown from removing CopyToSwapchain pass

### DIFF
--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Scope.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Scope.h
@@ -72,6 +72,11 @@ namespace AZ
             //! Wait on all the transient resource fences associated with this scope
             void WaitOnAllResourceFences(CommandList& commandList) const;
             void WaitOnAllResourceFences(id <MTLCommandBuffer> mtlCommandBuffer) const;
+            
+            //! Accesors for the information cached in Compile phase
+            bool IsWritingToSwapChain() const;
+            bool IsRequestingSwapChain() const;
+            
         private:
             
             struct QueryPoolAttachment
@@ -126,7 +131,10 @@ namespace AZ
 
             AZStd::vector<QueryPoolAttachment> m_queryPoolAttachments;
             
-            /// Used to check if the current scope is writing to a swapchain texture
+            /// Used to check if the current scope is requesting to a swapchain texture
+            bool m_isRequestingSwapChainDrawable = false;
+            
+            /// Used to check if the current scope is writing the swapchain texture
             bool m_isWritingToSwapChainScope = false;
             
             /// Used to check if the current scope is a swapchain scope and the next scope will be used to capture the current frame


### PR DESCRIPTION

## What does this PR do?

The issue was that we hade two scopes in different groups requesting for a drawable in parallel setting up nasty race conditions. We fix it by assuring that the scope that requests the drawable and the ones that write to it are together in one merged group. If in future this gets hard to support I have added an assert to catch it. As a fallback we could mov requesting the drawable in Compile phase although it is not desirable to move the request further up in the frame.

## How was this PR tested?

Tested iOS
