### PR TITLE
Fixed issues in the PropertyAssetCtrl.cpp

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -350,7 +350,11 @@ namespace AzToolsFramework
         const auto selectableAssetTypes = GetSelectableAssetTypes();
         const auto isSelectableAssetType =
             AZStd::find(selectableAssetTypes.begin(), selectableAssetTypes.end(), assetType) != selectableAssetTypes.end();
+#if defined(CARBONATED)
+        return (assetId.IsValid() && isSelectableAssetType); // do not reject an asset with the zero asset type {00000000-0000-0000-0000-000000000000} due to it could be added to GetSelectableAssetTypes() by intention, for copied asset files (e.g. for .cfg, .txt, .json, .ttf, .xml, .dat, ...)
+#else
         return (assetId.IsValid() && !assetType.IsNull() && isSelectableAssetType);
+#endif
     }
 
     bool PropertyAssetCtrl::IsCorrectMimeData(const QMimeData* pData, AZ::Data::AssetId* pAssetId, AZ::Data::AssetType* pAssetType) const

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -1188,7 +1188,12 @@ namespace AzToolsFramework
             AzFramework::StringFunc::Path::GetFileName(m_currentAssetHint.c_str(), assetName);
         }
 
+#if defined(CARBONATED)
+        // tooltip should be assigned to a current list element which contains an asset file name
+        m_browseEdit->setToolTip(m_currentAssetHint.c_str());
+#else
         setToolTip(m_currentAssetHint.c_str());
+#endif
         
         // If no asset is selected but a default asset id is, show the default name.
         if (m_selectedAssetID.IsValid())


### PR DESCRIPTION
Required for ticket [15664]

## What does this PR do?

This PR fixes issues in the PropertyAssetCtrl.cpp:
1) Do not reject an asset with the zero asset type {00000000-0000-0000-0000-000000000000} due to it could be added to GetSelectableAssetTypes() by intention, for copied asset files (e.g. for .cfg, .txt, .json, .ttf, .xml, .dat, ...)
2) Tooltip should be assigned to a current list element which contains an asset file name. Current o3de implementation does nothing due to it contains misprint

## How was this PR tested?

Verified locally in the PC Editor
