### PR TITLE
Add fps info on device

### DIFF
--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Include/AtomLyIntegration/AtomViewportDisplayInfo/AtomViewportInfoDisplayBus.h
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Include/AtomLyIntegration/AtomViewportDisplayInfo/AtomViewportInfoDisplayBus.h
@@ -20,6 +20,9 @@ namespace AZ
             NormalInfo = 1,
             FullInfo = 2,
             CompactInfo = 3,
+#if defined (CARBONATED)
+            FpsInfo = 4,
+#endif
             Invalid
         };
 

--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
@@ -41,7 +41,7 @@ namespace AZ::Render
             );
         }, AZ::ConsoleFunctorFlags::DontReplicate,
         "Toggles debugging information display.\n"
-        "Usage: r_displayInfo [0=off/1=show/2=enhanced/3=compact]"
+        "Usage: r_displayInfo [0=off/1=show/2=enhanced/3=compact/4=fps]" // CARBONATED: changed string parameter in macro
     );
     AZ_CVAR(float, r_fpsCalcInterval, 1.0f, nullptr, AZ::ConsoleFunctorFlags::DontReplicate,
         "The time period over which to calculate the framerate for r_displayInfo."

--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
@@ -31,6 +31,12 @@
 
 namespace AZ::Render
 {
+#if defined (CARBONATED)
+    #define DISPLAY_INFO_USAGE "Usage: r_displayInfo [0=off/1=show/2=enhanced/3=compact/4=fps]"
+#else
+    #define DISPLAY_INFO_USAGE "Usage: r_displayInfo [0=off/1=show/2=enhanced/3=compact]"
+#endif
+
     AZ_CVAR(int, r_displayInfo, 1, [](const int& newDisplayInfoVal)->void
         {
             // Forward this event to the system component so it can update accordingly.
@@ -41,7 +47,7 @@ namespace AZ::Render
             );
         }, AZ::ConsoleFunctorFlags::DontReplicate,
         "Toggles debugging information display.\n"
-        "Usage: r_displayInfo [0=off/1=show/2=enhanced/3=compact/4=fps]" // CARBONATED: changed string parameter in macro
+        DISPLAY_INFO_USAGE
     );
     AZ_CVAR(float, r_fpsCalcInterval, 1.0f, nullptr, AZ::ConsoleFunctorFlags::DontReplicate,
         "The time period over which to calculate the framerate for r_displayInfo."
@@ -393,7 +399,7 @@ namespace AZ::Render
     }
 
 #if defined (CARBONATED)
-    void AtomViewportDisplayInfoSystemComponent::DrawFramerate(bool drawFpsOnly)
+    void AtomViewportDisplayInfoSystemComponent::DrawFramerate(bool drawAverageOnly)
 #else
     void AtomViewportDisplayInfoSystemComponent::DrawFramerate()
 #endif
@@ -432,7 +438,7 @@ namespace AZ::Render
         };
 
 #if defined (CARBONATED)
-        if (drawFpsOnly)
+        if (drawAverageOnly)
         {
             DrawLine(
                 AZStd::string::format(

--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
@@ -33,11 +33,17 @@ namespace AZ::Render
 {
 #if defined (CARBONATED)
     #define DISPLAY_INFO_USAGE "Usage: r_displayInfo [0=off/1=show/2=enhanced/3=compact/4=fps]"
+    #if defined(_RELEASE)
+        #define DISPLAY_INFO_DEFAULT 4
+    #else
+        #define DISPLAY_INFO_DEFAULT 1
+    #endif
 #else
     #define DISPLAY_INFO_USAGE "Usage: r_displayInfo [0=off/1=show/2=enhanced/3=compact]"
+    #define DISPLAY_INFO_DEFAULT 1
 #endif
 
-    AZ_CVAR(int, r_displayInfo, 1, [](const int& newDisplayInfoVal)->void
+    AZ_CVAR(int, r_displayInfo, DISPLAY_INFO_DEFAULT, [](const int& newDisplayInfoVal)->void
         {
             // Forward this event to the system component so it can update accordingly.
             // This callback only gets triggered by console commands, so this will not recurse.
@@ -203,13 +209,6 @@ namespace AZ::Render
         m_lineSpacing = lineHeight * m_drawParams.m_lineSpacing;
 
 #if defined (CARBONATED)
-        // rescale font according to base screen resolution
-        const float fontScale = static_cast<float>(viewportContext->GetViewportSize().m_width) / 1920;
-        if (fontScale > 1.0f)
-        {
-            m_drawParams.m_scale = AZ::Vector2(BaseFontSize) * fontScale;
-        }
-
         if (displayLevel == AtomBridge::ViewportInfoDisplayState::FpsInfo)
         {
             DrawFramerate(true);

--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.h
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.h
@@ -62,7 +62,7 @@ namespace AZ
             void DrawMemoryInfo();
 #if defined (CARBONATED)
             void DrawFramerate(bool drawAverageOnly = false);
-            static constexpr float BaseFontSize = 1.2f;
+            static constexpr float BaseFontSize = 0.85f; // 120%
 #else
             void DrawFramerate();
 

--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.h
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.h
@@ -60,9 +60,14 @@ namespace AZ
             void DrawCameraInfo();
             void DrawPassInfo();
             void DrawMemoryInfo();
+#if defined (CARBONATED)
+            void DrawFramerate(bool drawFpsOnly = false);
+            static constexpr float BaseFontSize = 1.2f;
+#else
             void DrawFramerate();
 
             static constexpr float BaseFontSize = 0.7f;
+#endif
 
             AZStd::string m_rendererDescription;
             AzFramework::TextDrawParameters m_drawParams;

--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.h
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.h
@@ -61,7 +61,7 @@ namespace AZ
             void DrawPassInfo();
             void DrawMemoryInfo();
 #if defined (CARBONATED)
-            void DrawFramerate(bool drawFpsOnly = false);
+            void DrawFramerate(bool drawAverageOnly = false);
             static constexpr float BaseFontSize = 1.2f;
 #else
             void DrawFramerate();


### PR DESCRIPTION
Ticket [15792]

## What does this PR do?
1) Added a new mode №4 for variable "r_dispalyMode" to display only FPS value on the screen corner (as string "FPS NNN")
2) Scaled up FPS font size
3) In additional, also automatically scaled up the fps font when screen weight in pixels more than base width (1920). Did not scale down to prevent text visibility corruption.

## How was this PR tested?

Verified on PC locally and on iPhone14 using Jenkins build 25701
See example video in the ticket attachment


