### PR TITLE
Save CPU time in CAudioSystem::InternalUpdate

### DIFF
--- a/Gems/AudioSystem/Code/Source/Engine/AudioSystem.cpp
+++ b/Gems/AudioSystem/Code/Source/Engine/AudioSystem.cpp
@@ -244,7 +244,12 @@ namespace Audio
             if (elapsedUpdateTime < m_targetUpdatePeriod)
             {
                 AZ_PROFILE_SCOPE(Audio, "Wait Remaining Time in Update Period");
+#if defined(CARBONATED)
+                AZStd::this_thread::sleep_for(AZStd::chrono::duration_cast<AZStd::chrono::microseconds>(m_targetUpdatePeriod) -  AZStd::chrono::duration_cast<AZStd::chrono::microseconds>(endUpdateTime - startUpdateTime));
+                m_processingEvent.try_acquire_for(AZStd::chrono::microseconds(100));
+#else
                 m_processingEvent.try_acquire_for(m_targetUpdatePeriod - elapsedUpdateTime);
+#endif
             }
         }
     }


### PR DESCRIPTION
## What does this PR do?

Since `semaphore::try_acquire_for` uses a busy-wait logic, this results in the heavy loaded Audio thread.

Use a combination of `this_thread::sleep_for` and a short time `semaphore::try_acquire_for`
instead.

## How was this PR tested?

Tested on iPhone 15.
