### PR TITLE
Fixing LyShine Texture Atlas Support

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Include/Atom/ImageProcessing/ImageProcessingBus.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Include/Atom/ImageProcessing/ImageProcessingBus.h
@@ -96,6 +96,11 @@ namespace ImageProcessingAtom
 
         //! Return true if the preset name is valid
         virtual bool IsValidPreset(PresetName presetName) = 0;
+
+#if defined(CARBONATED)
+        //! Returns true if the specified extension is supported by the image processing gem
+        virtual bool IsExtensionSupported(const char* extension) = 0;
+#endif
     };
 
     using ImageBuilderRequestBus = AZ::EBus<ImageBuilderRequests>;

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageBuilderComponent.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageBuilderComponent.cpp
@@ -289,6 +289,13 @@ namespace ImageProcessingAtom
         return ImageProcessingAtom::BuilderSettingManager::Instance()->IsValidPreset(presetName);
     }
 
+#if defined(CARBONATED)
+    bool BuilderPluginComponent::IsExtensionSupported(const char* extension)
+    {
+        return ImageProcessingAtom::IsExtensionSupported(extension);
+    }
+#endif
+
     void ImageBuilderWorker::ShutDown()
     {
         // it is important to note that this will be called on a different thread than your process job thread

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageBuilderComponent.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageBuilderComponent.h
@@ -97,6 +97,10 @@ namespace ImageProcessingAtom
         PresetName GetDefaultAlphaPreset() override;
         bool IsValidPreset(PresetName presetName) override;
 
+#if defined(CARBONATED)
+        bool IsExtensionSupported(const char* extension) override;
+#endif
+
         ////////////////////////////////////////////////////////////////////////
 
     private:

--- a/Gems/LyShine/Code/Source/RenderGraph.cpp
+++ b/Gems/LyShine/Code/Source/RenderGraph.cpp
@@ -189,14 +189,16 @@ namespace LyShine
         m_primitives.push_back(*primitive);
 
 #if defined(CARBONATED)
-        uint16 vertex_index_start = (uint16)m_combinedVertices.size();
+        uint16 vertex_start = aznumeric_caster(m_combinedVertices.size());
+        uint16 index_start = aznumeric_caster(m_combinedIndices.size());
 
-        // Add the vertices at the
+        // Add the vertices at the end of the combined buffer.  We need to update the vertex indices with their new offset separately.
         m_combinedVertices.insert(m_combinedVertices.end(), primitive->m_vertices, primitive->m_vertices + primitive->m_numVertices);
+        m_combinedIndices.resize_no_construct(m_combinedIndices.size() + primitive->m_numIndices);
 
         for (int i = 0; i < primitive->m_numIndices; i++)
         {
-            m_combinedIndices.push_back(vertex_index_start + primitive->m_indices[i]);
+            m_combinedIndices[index_start + i] = vertex_start + primitive->m_indices[i];
         }
 #endif
 

--- a/Gems/LyShine/Code/Source/RenderGraph.cpp
+++ b/Gems/LyShine/Code/Source/RenderGraph.cpp
@@ -51,6 +51,11 @@ namespace LyShine
     {
         m_textures[0].m_texture = texture;
         m_textures[0].m_isClampTextureMode = isClampTextureMode;
+
+#if defined(CARBONATED)
+        m_combinedVertices.reserve(1024);
+        m_combinedIndices.reserve(1024);
+#endif
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -70,12 +75,22 @@ namespace LyShine
         m_textures[0].m_isClampTextureMode = isClampTextureMode;
         m_textures[1].m_texture = maskTexture;
         m_textures[1].m_isClampTextureMode = isClampTextureMode;
+
+#if defined(CARBONATED)
+        m_combinedVertices.reserve(1024);
+        m_combinedIndices.reserve(1024);
+#endif
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////
     PrimitiveListRenderNode::~PrimitiveListRenderNode()
     {
         m_primitives.clear();
+
+#if defined(CARBONATED)
+        m_combinedVertices.clear();
+        m_combinedIndices.clear();
+#endif
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -149,6 +164,9 @@ namespace LyShine
 
         drawSrg->Compile();
 
+#if defined(CARBONATED)
+        dynamicDraw->DrawIndexed(&m_combinedVertices[0], (uint32_t)m_combinedVertices.size(), &m_combinedIndices[0],  (uint32_t)m_combinedIndices.size(), AZ::RHI::IndexFormat::Uint16, drawSrg);
+#else
         // Add the indexed primitives to the dynamic draw context for drawing
         //
         // [LYSHINE_ATOM_TODO][ATOM-15073] Combine into a single DrawIndexed call to take advantage of the draw call
@@ -158,6 +176,7 @@ namespace LyShine
         {
             dynamicDraw->DrawIndexed(primitive.m_vertices, primitive.m_numVertices, primitive.m_indices, primitive.m_numIndices, AZ::RHI::IndexFormat::Uint16, drawSrg);
         }
+#endif
 
         uiRenderer->SetBaseState(prevBaseState);
     }
@@ -168,6 +187,18 @@ namespace LyShine
         // always clear the next pointer before adding to list
         primitive->m_next = nullptr;
         m_primitives.push_back(*primitive);
+
+#if defined(CARBONATED)
+        uint16 vertex_index_start = (uint16)m_combinedVertices.size();
+
+        // Add the vertices at the
+        m_combinedVertices.insert(m_combinedVertices.end(), primitive->m_vertices, primitive->m_vertices + primitive->m_numVertices);
+
+        for (int i = 0; i < primitive->m_numIndices; i++)
+        {
+            m_combinedIndices.push_back(vertex_index_start + primitive->m_indices[i]);
+        }
+#endif
 
         m_totalNumVertices += primitive->m_numVertices;
         m_totalNumIndices += primitive->m_numIndices;

--- a/Gems/LyShine/Code/Source/RenderGraph.h
+++ b/Gems/LyShine/Code/Source/RenderGraph.h
@@ -132,6 +132,12 @@ namespace LyShine
         int             m_totalNumIndices;
 
         LyShine::UiPrimitiveList   m_primitives;
+
+#if defined(CARBONATED)
+        // Per-frame combined vertex and index buffers
+        AZStd::vector<UiPrimitiveVertex> m_combinedVertices;
+        AZStd::vector<uint16> m_combinedIndices;
+#endif
     };
 
     // A mask render node handles using one set of render nodes to mask another set of render nodes

--- a/Gems/TextureAtlas/Code/Source/Editor/AtlasBuilderWorker.cpp
+++ b/Gems/TextureAtlas/Code/Source/Editor/AtlasBuilderWorker.cpp
@@ -482,7 +482,13 @@ namespace TextureAtlasBuilder
             {
                 AZStd::string ext;
                 AzFramework::StringFunc::Path::GetExtension(candidates[i].c_str(), ext, false);
+#if defined(CARBONATED)
+                bool extensionSupported = false;
+                ImageProcessingAtom::ImageBuilderRequestBus::BroadcastResult(extensionSupported, &ImageProcessingAtom::ImageBuilderRequestBus::Events::IsExtensionSupported, ext.c_str());
+                if (extensionSupported)
+#else
                 if (ext != "dds")
+#endif
                 {
                     bool duplicate = false;
                     for (size_t j = 0; j < paths.size() && !duplicate; ++j)
@@ -592,12 +598,24 @@ namespace TextureAtlasBuilder
             {
                 AZStd::string child = (entry.filePath().toStdString()).c_str();
                 AZStd::string ext;
+
                 bool isDir = !AzFramework::StringFunc::Path::GetExtension(child.c_str(), ext, false);
                 if (isDir)
                 {
                     AddFolderContents(paths, child, valid);
+#if defined(CARBONATED)
+                    continue;
+#endif
                 }
+
+#if defined(CARBONATED)
+                bool extensionSupported = false;
+                ImageProcessingAtom::ImageBuilderRequestBus::BroadcastResult(extensionSupported, &ImageProcessingAtom::ImageBuilderRequestBus::Events::IsExtensionSupported, ext.c_str());
+
+                if (extensionSupported)    
+#else
                 else if (ext != "dds")
+#endif
                 {
                     AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::NormalizePathKeepCase, child);
                     bool duplicate = false;
@@ -1052,7 +1070,11 @@ namespace TextureAtlasBuilder
                 return;
             }
 
+#if defined(CARBONATED)
+            response.m_outputProducts.insert(response.m_outputProducts.end(), outProducts.begin(), outProducts.end());
+#else
             response.m_outputProducts.push_back(outProducts[0]);
+#endif
 
             // The texatlasidx file is a data file that indicates where the original parts are inside the atlas, 
             // and this would usually imply that it refers to its dds file in some way or needs it to function.


### PR DESCRIPTION
## What does this PR do?

Fixes the LyShine Texture Atlas support.

1)  Fixes the texture atlas generation - the final streamingimage is now created and saved in the Cache
2) Combining vertex and index buffers for lyshine rendernodes.

## How was this PR tested?

Locally on PC to confirm drawcalls are combined.