### PR TITLE
Fixing Job Manager Stats

### DIFF
--- a/Code/Framework/AzCore/AzCore/Jobs/Internal/JobManagerWorkStealing.h
+++ b/Code/Framework/AzCore/AzCore/Jobs/Internal/JobManagerWorkStealing.h
@@ -21,6 +21,10 @@
 #include <AzCore/std/parallel/binary_semaphore.h>
 #include <AzCore/std/parallel/thread.h>
 
+#if defined(CARBONATED)
+// #define JOBMANAGER_ENABLE_STATS
+#endif
+
 namespace AZ
 {
     class Job;
@@ -105,8 +109,13 @@ namespace AZ
                 unsigned int m_jobsForked = 0;
                 unsigned int m_jobsDone = 0;
                 unsigned int m_jobsStolen = 0;
+#if defined(CARBONATED)
+                AZStd::chrono::milliseconds m_jobTime;
+                AZStd::chrono::milliseconds m_stealTime;
+#else
                 u64 m_jobTime = 0;
                 u64 m_stealTime = 0;
+#endif
 #endif
             };
             using ThreadList = AZStd::vector<ThreadInfo*>;

--- a/Code/Framework/AzCore/AzCore/Jobs/JobManager.h
+++ b/Code/Framework/AzCore/AzCore/Jobs/JobManager.h
@@ -13,7 +13,11 @@
 #include <AzCore/Memory/Memory.h>
 #include <AzCore/Jobs/Internal/JobManagerWorkStealing.h>
 
+#if defined(CARBONATED)
+// ...
+#else
 //#define JOBMANAGER_ENABLE_STATS
+#endif
 
 namespace AZ
 {

--- a/Gems/AWSCore/Code/Include/Framework/HttpRequestJob.h
+++ b/Gems/AWSCore/Code/Include/Framework/HttpRequestJob.h
@@ -184,7 +184,11 @@ namespace AWSCore
             AZ_UNUSED(response);
         };
 
+#if defined(CARBONATED)
+        // ... 
+#else
     private:
+#endif
         /// Runs the HTTP request on the Job's thread.
         void Process() override;
 


### PR DESCRIPTION
## What does this PR do?

Fixes the Job Manager stats if the #define is enabled.

## How was this PR tested?

Locally, on PC.  It remains undefined by default, and so should not impact building etc.
