### PR TITLE
Additional EMotionFX logs

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraph.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraph.cpp
@@ -1120,6 +1120,12 @@ namespace EMotionFX
 
             AZ_Printf("EMotionFX", "Loaded anim graph from buffer in %.1f ms (Deserialization %.1f ms, Initialization %.1f ms).", deserializeTimeInMs + initTimeInMs, deserializeTimeInMs, initTimeInMs);
         }
+#if defined (CARBONATED)
+        else
+        {
+            AZ_Error("EMotionFX", false, "Anim graph was not loaded from buffer!");
+        }
+#endif
 
         return animGraph;
     }

--- a/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphInstance.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphInstance.cpp
@@ -33,6 +33,18 @@ namespace EMotionFX
     AnimGraphInstance::AnimGraphInstance(AnimGraph* animGraph, ActorInstance* actorInstance, MotionSet* motionSet, const InitSettings* initSettings)
         : BaseObject()
     {
+#if defined (CARBONATED)
+        AZStd::string animGraphName = "[missed]";
+        if (animGraph)
+        {
+            AzFramework::StringFunc::Path::GetFileName(animGraph->GetFileName(), animGraphName);
+        }
+        AZ_Printf("EMotionFX", "Create AnimGraphInstance: motionSet=%s actorInstance=%s animGraph=%s"
+            , motionSet ? motionSet->GetName() : "[missed]"
+            , actorInstance && actorInstance->GetActor() ? actorInstance->GetActor()->GetName() : "[missed]"
+            , animGraphName.c_str());
+#endif
+
         // register at the animgraph
         animGraph->AddAnimGraphInstance(this);
         animGraph->Lock();

--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionSet.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionSet.cpp
@@ -858,8 +858,18 @@ namespace EMotionFX
             result->InitAfterLoading();
 
             const float loadTimeInMs = loadTimer.GetDeltaTimeInSeconds() * 1000.0f;
+#if defined (CARBONATED)
+            AZ_Printf("EMotionFX", "Loaded motion set '%s' from buffer in %.1f ms.", result->GetName(), loadTimeInMs);
+#else
             AZ_Printf("EMotionFX", "Loaded motion set from buffer in %.1f ms.", loadTimeInMs);
+#endif
         }
+#if defined (CARBONATED)
+        else
+        {
+            AZ_Error("EMotionFX", false, "Motion set was not loaded from buffer!");
+        }
+#endif
 
         return result;
     }

--- a/Gems/EMotionFX/Code/Source/Integration/Assets/AnimGraphAsset.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Assets/AnimGraphAsset.cpp
@@ -69,6 +69,9 @@ namespace EMotionFX
                 AZStd::string assetFilename;
                 AZ::Data::AssetCatalogRequestBus::BroadcastResult(assetFilename, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetPathById, asset.GetId());
                 AZ::IO::FixedMaxPath projectPath = AZ::Utils::GetProjectPath();
+#if defined (CARBONATED)
+                AZ_Printf("EMotionFX", "Loaded anim graph '%s'.", assetFilename.c_str());
+#endif
                 if (!projectPath.empty())
                 {
                     AZ::IO::FixedMaxPathString filename{ (projectPath / assetFilename).LexicallyNormal().FixedMaxPathStringAsPosix() };


### PR DESCRIPTION
Ticket [16103]

## What does this PR do?

This PR contains aitional EMotionFX logs for MotionSet and AnimGraph on asset loading phase and on AnimGraphInstance creation (including an actor asset name)

## How was this PR tested?

PC/iPhone14


