### PR TITLE
EMotionFX: enable Motion reload

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionSet.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionSet.cpp
@@ -74,7 +74,11 @@ namespace EMotionFX
 
     MotionSet::MotionEntry::MotionEntry()
         : m_motion(nullptr)
+#if defined (CARBONATED)
+        , m_loadAttempts(MaxAttemptsToLoad)
+#else
         , m_loadFailed(false)
+#endif
     {
     }
 
@@ -83,7 +87,11 @@ namespace EMotionFX
         : m_id(motionId)
         , m_filename(fileName)
         , m_motion(motion)
+#if defined (CARBONATED)
+        , m_loadAttempts(MaxAttemptsToLoad)
+#else
         , m_loadFailed(false)
+#endif
     {
     }
 
@@ -533,9 +541,8 @@ namespace EMotionFX
 #if defined (CARBONATED)
                 // do not disable to reload missed motion
                 AZ_Printf("EMotionFX", "Failed to load motion '%s' for motion set '%s'.", entry->GetFilename(), GetName());
-#else
-                entry->SetLoadingFailed(true);
 #endif
+                entry->SetLoadingFailed(true);
             }
 #if defined (CARBONATED)
             else

--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionSet.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionSet.cpp
@@ -450,6 +450,13 @@ namespace EMotionFX
         }
 
         Motion* motion = entry->GetMotion();
+#if defined (CARBONATED)
+        if (!motion && !entry->GetLoadingFailed())
+        {
+            AZ_Printf("EMotionFX", "Try to reload motion '%s' for motion set '%s'. Attempts left %i.", entry->GetFilename(), GetName(), entry->GetLoadAttempts());
+            loadOnDemand = true;
+        }
+#endif
         if (loadOnDemand)
         {
             motion = LoadMotion(entry);
@@ -539,7 +546,6 @@ namespace EMotionFX
             if (!motion)
             {
 #if defined (CARBONATED)
-                // do not disable to reload missed motion
                 AZ_Printf("EMotionFX", "Failed to load motion '%s' for motion set '%s'.", entry->GetFilename(), GetName());
 #endif
                 entry->SetLoadingFailed(true);

--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionSet.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionSet.cpp
@@ -530,9 +530,19 @@ namespace EMotionFX
             // Mark that we already tried to load this motion, so that we don't retry this next time.
             if (!motion)
             {
+#if defined (CARBONATED)
+                // do not disable to reload missed motion
+                AZ_Printf("EMotionFX", "Failed to load motion '%s' for motion set '%s'.", entry->GetFilename(), GetName());
+#else
                 entry->SetLoadingFailed(true);
+#endif
             }
-
+#if defined (CARBONATED)
+            else
+            {
+                AZ_Printf("EMotionFX", "Loaded motion '%s' for motion set '%s'.", entry->GetFilename(), GetName());
+            }
+#endif
             entry->SetMotion(motion);
         }
 

--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionSet.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionSet.cpp
@@ -453,7 +453,6 @@ namespace EMotionFX
 #if defined (CARBONATED)
         if (!motion && !entry->GetLoadingFailed())
         {
-            AZ_Printf("EMotionFX", "Try to reload motion '%s' for motion set '%s'. Attempts left %i.", entry->GetFilename(), GetName(), entry->GetLoadAttempts());
             loadOnDemand = true;
         }
 #endif
@@ -556,6 +555,7 @@ namespace EMotionFX
                 AZ_Printf("EMotionFX", "Loaded motion '%s' for motion set '%s'.", entry->GetFilename(), GetName());
             }
 #endif
+
             entry->SetMotion(motion);
         }
 

--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionSet.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionSet.h
@@ -92,14 +92,22 @@ namespace EMotionFX
              * It is possible that the motion pointer is nullptr, but that this was because loading failed, rather than not having tried to load before.
              * @result Returns true when loading failed before, otherwise false is returned.
              */
+#if defined (CARBONATED)
+            bool GetLoadingFailed() const { return m_loadAttempts <= 0; }
+#else
             bool GetLoadingFailed() const                                                                       { return m_loadFailed; }
+#endif
 
             /**
              * Set the flag that specifies whether loading failed or not.
              * This flag is used to skip trying to reload the motion on demand when it is nullptr and failed to load before.
              * @param failed Set to true to skip trying to reload on demand again.
              */
+#if defined (CARBONATED)            
+            void SetLoadingFailed(bool failed) { m_loadAttempts = static_cast<int8_t>(failed ? std::max(m_loadAttempts - 1, 0) : MaxAttemptsToLoad); }
+#else
             void SetLoadingFailed(bool failed)                                                                  { m_loadFailed = failed; }
+#endif
 
             /**
              * Reset the entry motion so that it will reload it next time automatically.
@@ -124,7 +132,12 @@ namespace EMotionFX
             AZStd::string   m_filename;     /**< The local filename of the motion. */
             AZStd::string   m_id;           /**< The motion name. */
             Motion*         m_motion;       /**< A pointer to the motion. */
+#if defined (CARBONATED)
+            static constexpr int8_t MaxAttemptsToLoad = 5;
+            int8_t          m_loadAttempts;
+#else
             bool            m_loadFailed;   /**< Did the last load attempt fail? */
+#endif
 
             void SetId(const AZStd::string& id);
         };

--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionSet.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionSet.h
@@ -94,7 +94,6 @@ namespace EMotionFX
              */
 #if defined (CARBONATED)
             bool GetLoadingFailed() const { return m_loadAttempts <= 0; }
-            int GetLoadAttempts() const { return m_loadAttempts; }
 #else
             bool GetLoadingFailed() const                                                                       { return m_loadFailed; }
 #endif

--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionSet.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionSet.h
@@ -94,6 +94,7 @@ namespace EMotionFX
              */
 #if defined (CARBONATED)
             bool GetLoadingFailed() const { return m_loadAttempts <= 0; }
+            int GetLoadAttempts() const { return m_loadAttempts; }
 #else
             bool GetLoadingFailed() const                                                                       { return m_loadFailed; }
 #endif


### PR DESCRIPTION
Ticket: 16103

## What does this PR do?

Changes: enable Motion reload in EMotionFX with 5 attempts

## How was this PR tested?

Verified on PC, on  Jenkins iOS build 26708
