### PR TITLE
Asset Processor:  Ignoring Cyclic Dependencies in the analysis phase

### DIFF
--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -3271,6 +3271,7 @@ namespace AssetProcessor
         // If this file is already in the remaining jobs queue, no need to assess it all over again.
         if (m_remainingJobsForEachSourceFile.find(absolutePath.c_str()) != m_remainingJobsForEachSourceFile.end())
         {
+            AZ_TracePrintf(AssetProcessor::DebugChannel, "AssessFileInternal: Skipping %s, already queued for job\n", absolutePath.c_str());
             return;
         }
 

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -3243,6 +3243,7 @@ namespace AssetProcessor
         }
 
         QString normalizedFullFile = AssetUtilities::NormalizeFilePath(fullFile);
+        AZ::IO::FixedMaxPath absolutePath(normalizedFullFile.toUtf8().constData());
 
         if (!fromScanner) // the scanner already does exclusion and doesn't need to deal with metafiles.
         {
@@ -3267,13 +3268,18 @@ namespace AssetProcessor
             }
         }
 
+        // If this file is already in the remaining jobs queue, no need to assess it all over again.
+        if (m_remainingJobsForEachSourceFile.find(absolutePath.c_str()) != m_remainingJobsForEachSourceFile.end())
+        {
+            return;
+        }
+
         if (!isDelete && IsInIntermediateAssetsFolder(normalizedFullFile) && !m_knownFolders.contains(normalizedFullFile))
         {
             // Make a special case check for MetadataManager files
             // An update to one of these types of files needs to cause a re-process of the intermediate file.
             // Converting a metadata file to the real file normally happens later in the processing but needs to be done
-            // up front for intermediates to avoid bypassing this whole block - which stops processing intermediates before they're recorded in the database.
-            AZ::IO::FixedMaxPath absolutePath(normalizedFullFile.toUtf8().constData());
+            // up front for intermediates to avoid bypassing this whole block - which stops processing intermediates before they're recorded in the database.            
 
             if (absolutePath.Extension() == AzToolsFramework::MetadataManager::MetadataFileExtension)
             {
@@ -3674,38 +3680,44 @@ namespace AssetProcessor
         {
             // File is a source file that has been processed before
             AZStd::string fingerprintFromDatabase = sourceFileItr->m_analysisFingerprint.toUtf8().data();
+            if (fingerprintFromDatabase.empty())
+            {
+                // No recorded fingerprint
+                return false;
+            }
+
             AZStd::string_view builderEntries(fingerprintFromDatabase.begin() + s_lengthOfUuid + 1, fingerprintFromDatabase.end());
             AZStd::string_view dependencyFingerprint(fingerprintFromDatabase.begin(), fingerprintFromDatabase.begin() + s_lengthOfUuid);
             int numBuildersEmittingSourceDependencies = 0;
 
-            if (!fingerprintFromDatabase.empty() && AreBuildersUnchanged(builderEntries, numBuildersEmittingSourceDependencies))
+            // Check for updated builders
+            if (!AreBuildersUnchanged(builderEntries, numBuildersEmittingSourceDependencies))
             {
-                // Builder(s) have not changed since last time
-                AZStd::string currentFingerprint = ComputeRecursiveDependenciesFingerprint(sourceFileItr->m_sourceAssetReference);
-
-                if(dependencyFingerprint != currentFingerprint)
-                {
-                    // Dependencies have changed
-                    ++m_assetsNeedingProcessing_DependenciesChanged;
-                    return false;
-                }
-                // Success - we can skip this file, nothing has changed!
-
-                // Remove it from the list of to-be-processed files, otherwise the AP will assume the file was deleted
-                // Note that this means any files that *were* deleted are already handled by CheckMissingFiles
-                m_sourceFilesInDatabase.erase(sourceFileItr);
-                return true;
+                ++m_assetsNeedingProcessing_BuildersChanged;
+                return false;
             }
-        }
-        else
-        {
-            // File is a non-tracked file, aka a file that no builder cares about.
-            // The fact that it has a matching modtime means we've already seen this file and attempted to process it
-            // If it were a new, unprocessed source file, there would be no modtime stored
+
+            // Check for updated fingerprint
+            AZStd::string currentFingerprint = ComputeRecursiveDependenciesFingerprint(sourceFileItr->m_sourceAssetReference);
+            if (dependencyFingerprint != currentFingerprint)
+            {
+                // Dependencies have changed
+                ++m_assetsNeedingProcessing_DependenciesChanged;
+                return false;
+            }
+
+            // Success - we can skip this file, nothing has changed!
+
+            // Remove it from the list of to-be-processed files, otherwise the AP will assume the file was deleted
+            // Note that this means any files that *were* deleted are already handled by CheckMissingFiles
+            m_sourceFilesInDatabase.erase(sourceFileItr);
             return true;
         }
 
-        return false;
+        // File is a non-tracked file, aka a file that no builder cares about.
+        // The fact that it has a matching modtime means we've already seen this file and attempted to process it
+        // If it were a new, unprocessed source file, there would be no modtime stored
+        return true;
     }
 
     void AssetProcessorManager::AssessDeletedFile(QString filePath)

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -1879,13 +1879,13 @@ namespace AssetProcessor
                     continue;
                 }
 
-                if (source.m_causedBy.find("file:" + absolutePath) != source.m_causedBy.end())
+                if (source.m_fromDependencyChain.contains(absolutePath))
                 {
                     // cyclic dependency, ignore
                     continue;
                 }
 
-                AssessFileInternal(absolutePath, false, false, "file:" + normalizedFilePath);
+                AssessFileInternal(absolutePath, false, false, source.m_fromDependencyChain + QString(";") + absolutePath);
             }
         }
 
@@ -3243,7 +3243,7 @@ namespace AssetProcessor
     // during startup, and should avoid logging, sleeping, or doing
     // any more work than is necessary (Log only in error or uncommon
     // circumstances).
-    void AssetProcessorManager::AssessFileInternal(QString fullFile, bool isDelete, bool fromScanner, QString causedBy)
+    void AssetProcessorManager::AssessFileInternal(QString fullFile, bool isDelete, bool fromScanner, QString fromDependencyChain)
     {
         if (m_quitRequested)
         {
@@ -3344,6 +3344,7 @@ namespace AssetProcessor
         }
 
         FileEntry newEntry(normalizedFullFile, isDelete, fromScanner);
+        newEntry.m_fromDependencyChain = fromDependencyChain;
 
         if (m_alreadyActiveFiles.find(normalizedFullFile) != m_alreadyActiveFiles.end())
         {
@@ -3358,9 +3359,6 @@ namespace AssetProcessor
                 m_activeFiles.erase(entryIt);
             }
         }
-
-        if (causedBy != "")
-            newEntry.m_causedBy.insert(causedBy);
 
         m_AssetProcessorIsBusy = true;
         m_activeFiles.push_back(newEntry);

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
@@ -130,6 +130,8 @@ namespace AssetProcessor
             bool m_isFromScanner = false;
             AZStd::chrono::steady_clock::time_point m_initialProcessTime{};
 
+            QSet<QString> m_causedBy;
+
             FileEntry() = default;
 
             FileEntry(const QString& fileName, bool isDelete, bool isFromScanner = false, AZStd::chrono::steady_clock::time_point initialProcessTime = {})
@@ -371,7 +373,7 @@ namespace AssetProcessor
     private:
         template <class R>
         bool Recv(unsigned int connId, QByteArray payload, R& request);
-        void AssessFileInternal(QString fullFile, bool isDelete, bool fromScanner = false);
+        void AssessFileInternal(QString fullFile, bool isDelete, bool fromScanner = false, QString causedBy = "");
         void CheckSource(const FileEntry& source);
         void CheckMissingJobs(const SourceAssetReference& sourceAsset, const ScanFolderInfo* scanFolder, const AZStd::vector<JobDetails>& jobsThisTime);
         void CheckDeletedProductFile(QString normalizedPath);

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
@@ -130,7 +130,9 @@ namespace AssetProcessor
             bool m_isFromScanner = false;
             AZStd::chrono::steady_clock::time_point m_initialProcessTime{};
 
+#if defined(CARBONATED)
             QString m_fromDependencyChain;
+#endif
 
             FileEntry() = default;
 
@@ -373,7 +375,11 @@ namespace AssetProcessor
     private:
         template <class R>
         bool Recv(unsigned int connId, QByteArray payload, R& request);
-        void AssessFileInternal(QString fullFile, bool isDelete, bool fromScanner = false, QString causedBy = "");
+#if defined(CARBONATED)
+        void AssessFileInternal(QString fullFile, bool isDelete, bool fromScanner = false, QString fromDependencyChain = "");
+#else
+        void AssessFileInternal(QString fullFile, bool isDelete, bool fromScanner = false);
+#endif
         void CheckSource(const FileEntry& source);
         void CheckMissingJobs(const SourceAssetReference& sourceAsset, const ScanFolderInfo* scanFolder, const AZStd::vector<JobDetails>& jobsThisTime);
         void CheckDeletedProductFile(QString normalizedPath);

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
@@ -130,7 +130,7 @@ namespace AssetProcessor
             bool m_isFromScanner = false;
             AZStd::chrono::steady_clock::time_point m_initialProcessTime{};
 
-            QSet<QString> m_causedBy;
+            QString m_fromDependencyChain;
 
             FileEntry() = default;
 


### PR DESCRIPTION
## What does this PR do?

Skips files that were previously analyzed in a cyclic dependency chain.  

## How was this PR tested?

Locally, running the AP and ensuring it correctly breaks out of a cyclic asset chain.
