### PR TITLE
Reduce number of SetPosition requests to avoid wwise optimization issue

### DIFF
--- a/Gems/AudioSystem/Code/Source/Engine/AudioProxy.cpp
+++ b/Gems/AudioSystem/Code/Source/Engine/AudioProxy.cpp
@@ -203,6 +203,11 @@ namespace Audio
         }
         else
         {
+#if defined (CARBONATED)
+            if (Audio::CVars::s_PositionUpdateThreshold <= 0.f      // <-- no gating
+                || !refPosition.GetPositionVec().IsClose(m_oPosition.GetPositionVec(), Audio::CVars::s_PositionUpdateThreshold))
+            {
+#endif
             // If a SetPosition is queued during init, don't need to check threshold.
             m_oPosition = refPosition;
 
@@ -212,6 +217,9 @@ namespace Audio
 
             setPosition.m_position = refPosition;
             TryEnqueueRequest(AZStd::move(setPosition));
+#if defined (CARBONATED)
+            }
+#endif
         }
     }
 

--- a/Gems/AudioSystem/Code/Source/Engine/SoundCVars.cpp
+++ b/Gems/AudioSystem/Code/Source/Engine/SoundCVars.cpp
@@ -132,7 +132,7 @@ namespace Audio::CVars
         "Usage: s_AudioObjectPoolSize=" AZ_TRAIT_AUDIOSYSTEM_AUDIO_OBJECT_POOL_SIZE_DEFAULT_TEXT "\n");
 
 #if defined (CARBONATED)
-    AZ_CVAR(float, s_PositionUpdateThreshold, 1.0f,
+    AZ_CVAR(float, s_PositionUpdateThreshold, 0.6f,
         nullptr, AZ::ConsoleFunctorFlags::Null,
         "An audio object needs to move by this distance in order to issue a position update to the audio system.\n"
         "Usage: s_PositionUpdateThreshold=5.0\n");

--- a/Gems/AudioSystem/Code/Source/Engine/SoundCVars.cpp
+++ b/Gems/AudioSystem/Code/Source/Engine/SoundCVars.cpp
@@ -131,10 +131,17 @@ namespace Audio::CVars
         "The number of audio objects to preallocate in a pool.\n"
         "Usage: s_AudioObjectPoolSize=" AZ_TRAIT_AUDIOSYSTEM_AUDIO_OBJECT_POOL_SIZE_DEFAULT_TEXT "\n");
 
+#if defined (CARBONATED)
+    AZ_CVAR(float, s_PositionUpdateThreshold, 1.0f,
+        nullptr, AZ::ConsoleFunctorFlags::Null,
+        "An audio object needs to move by this distance in order to issue a position update to the audio system.\n"
+        "Usage: s_PositionUpdateThreshold=5.0\n");
+#else
     AZ_CVAR(float, s_PositionUpdateThreshold, 0.1f,
         nullptr, AZ::ConsoleFunctorFlags::Null,
         "An audio object needs to move by this distance in order to issue a position update to the audio system.\n"
         "Usage: s_PositionUpdateThreshold=5.0\n");
+#endif
 
     AZ_CVAR(float, s_VelocityTrackingThreshold, 0.1f,
         nullptr, AZ::ConsoleFunctorFlags::Null,


### PR DESCRIPTION
Ticket: 15711

## What does this PR do?

**Issue:** Looks like WWise binary libraries contains an internal optimization. 
It prevents to play the same sound when we set the sound position close to the previous sound position. It causes this issue MAD-15711. If we don't set a new position, this internal WWise optimization does not work.
This is ^^^ my suggestions after a lot of experiments (in real, I can't know or change how WWise methods AK::SoundEngine::PostEvent and AK::SoundEngine::SetPosition work, they are inside binary libs).

Why this issue don't occurs when we stay on the same position and fire??
Because O3DE team added CVar s_PositionUpdateThreshold which prevents to send SetPosition event when position change is less the threshold. It fixed this issue, when we stay and fire.
If we increase this CVar value, it will mostly fix this issue when we move and fire.

**Changes:** do not send Audio::ObjectRequest::SetPosition request when sound position change are less then necessary threshold to prevent a missed fire SFX when player moves and fires .
**In additional:** added missed s_PositionUpdateThreshold in the secondary ELSE-branch.

**Note:** probably we even can move this fix from O3DE code to the game code and just set up CVar s_PositionUpdateThreshold in the game.cfg file.
**Note2:** interesting, iOS wwise player works better then PC wwise player, maybe it has more sound channels than PC.
**Note3:** It could be the WWise 2021.1.1.7601 issue only. It could be fixed in the latest WWise versions.

## How was this PR tested?

Locally on PC, on iPhone14 via Jenkins Build: 26783 QA/iOS
