### PR TITLE
Added mesh vis editor component toggle

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshComponent.cpp
@@ -82,6 +82,11 @@ namespace AZ
                             ->DataElement(AZ::Edit::UIHandlers::CheckBox, &MeshComponentConfig::m_isRayTracingEnabled, "Use ray tracing",
                                 "Includes this mesh in ray tracing calculations.")
                                 ->Attribute(AZ::Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
+#if defined(CARBONATED)
+                            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &MeshComponentConfig::m_visibility, "Starting Visibility",
+                                "Starting visibility for play mode.")
+                                ->Attribute(AZ::Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
+#endif
                             ->DataElement(AZ::Edit::UIHandlers::CheckBox, &MeshComponentConfig::m_enableRayIntersection, "Support ray intersection",
                                 "Set to true when the entity has UiCanvasOnMeshComponent")
                                 ->Attribute(AZ::Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
@@ -75,13 +75,16 @@ namespace AZ
             if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))
             {
                 serializeContext->Class<MeshComponentConfig>()
-                    ->Version(3, &MeshComponentControllerVersionUtility::VersionConverter)
+                    ->Version(4, &MeshComponentControllerVersionUtility::VersionConverter)
                     ->Field("ModelAsset", &MeshComponentConfig::m_modelAsset)
                     ->Field("SortKey", &MeshComponentConfig::m_sortKey)
                     ->Field("ExcludeFromReflectionCubeMaps", &MeshComponentConfig::m_excludeFromReflectionCubeMaps)
                     ->Field("UseForwardPassIBLSpecular", &MeshComponentConfig::m_useForwardPassIblSpecular)
                     ->Field("IsRayTracingEnabled", &MeshComponentConfig::m_isRayTracingEnabled)
                     ->Field("IsAlwaysDynamic", &MeshComponentConfig::m_isAlwaysDynamic)
+#if defined(CARBONATED)
+                    ->Field("Visibility", &MeshComponentConfig::m_visibility)
+#endif
                     ->Field("SupportRayIntersection", &MeshComponentConfig::m_enableRayIntersection)
                     ->Field("LodType", &MeshComponentConfig::m_lodType)
                     ->Field("LodOverride", &MeshComponentConfig::m_lodOverride)
@@ -445,7 +448,11 @@ namespace AZ
                 m_meshFeatureProcessor->SetTransform(m_meshHandle, transform, m_cachedNonUniformScale);
                 m_meshFeatureProcessor->SetSortKey(m_meshHandle, m_configuration.m_sortKey);
                 m_meshFeatureProcessor->SetMeshLodConfiguration(m_meshHandle, GetMeshLodConfiguration());
+#if defined(CARBONATED)
+                m_meshFeatureProcessor->SetVisible(m_meshHandle, m_configuration.m_visibility);
+#else
                 m_meshFeatureProcessor->SetVisible(m_meshHandle, m_isVisible);
+#endif
                 m_meshFeatureProcessor->SetRayTracingEnabled(m_meshHandle, meshDescriptor.m_isRayTracingEnabled);
                 // [GFX TODO] This should happen automatically. m_changeEventHandler should be passed to AcquireMesh
                 // If the model instance or asset already exists, announce a model change to let others know it's loaded.
@@ -633,6 +640,9 @@ namespace AZ
                 {
                     m_meshFeatureProcessor->SetVisible(m_meshHandle, visible);
                 }
+#if defined(CARBONATED)
+                m_configuration.m_visibility = visible;
+#endif
                 m_isVisible = visible;
             }
         }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
@@ -50,6 +50,9 @@ namespace AZ
             bool m_isAlwaysDynamic = false;
             bool m_useForwardPassIblSpecular = false;
             bool m_isRayTracingEnabled = true;
+#if defined(CARBONATED)
+            bool m_visibility = true;
+#endif
             // the ModelAsset should support ray intersection if any one of the two flags are enabled.
             bool m_editorRayIntersection = false;       // Set to true if the config is for EditorMeshComponent so the ModelAsset always support ray intersection 
             bool m_enableRayIntersection = false;       // Set to true if a mesh need ray intersection support at runtime. 


### PR DESCRIPTION
## What does this PR do?

Allows the ability to set a mesh invisible by default at edit time, just using the existing runtime vis toggle

## How was this PR tested?

Made a change to a level, tried it on device, and made sure it responded correctly at edit time as well
