### PR TITLE
Cleaning up the TransformComponent

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/TransformBus.h
+++ b/Code/Framework/AzCore/AzCore/Component/TransformBus.h
@@ -232,14 +232,6 @@ namespace AZ
         //! @return The scale value in local space.
         virtual AZ::Vector3 GetLocalScale() { return AZ::Vector3(FLT_MAX); }
 
-#if !defined(CARBONATED)
-        /**
-         * Set local scale of the transform.
-         * @param scale The new scale to set along three local axes.
-         */
-         virtual void SetLocalScale(const AZ::Vector3& /*scale*/) {}
-#endif
-
         //! Set the uniform scale value in local space.
         virtual void SetLocalUniformScale([[maybe_unused]] float scale) {}
 

--- a/Code/Framework/AzCore/AzCore/Component/TransformBus.h
+++ b/Code/Framework/AzCore/AzCore/Component/TransformBus.h
@@ -225,7 +225,6 @@ namespace AZ
         virtual AZ::Quaternion GetLocalRotationQuaternion() { return AZ::Quaternion::CreateZero(); }
         //! @}
 
-#if !defined(CARBONATED)
         //! Scale modifiers
         //! @{
         //! @deprecated GetLocalScale is deprecated, and is left only to allow migration of legacy vector scale.
@@ -233,12 +232,13 @@ namespace AZ
         //! @return The scale value in local space.
         virtual AZ::Vector3 GetLocalScale() { return AZ::Vector3(FLT_MAX); }
 
+#if !defined(CARBONATED)
         /**
          * Set local scale of the transform.
          * @param scale The new scale to set along three local axes.
          */
          virtual void SetLocalScale(const AZ::Vector3& /*scale*/) {}
-#endif // carbonated end
+#endif
 
         //! Set the uniform scale value in local space.
         virtual void SetLocalUniformScale([[maybe_unused]] float scale) {}
@@ -311,12 +311,10 @@ namespace AZ
         //! Set the behavior at runtime when this entity's parent's transform changes.
         virtual void SetOnParentChangedBehavior([[maybe_unused]] OnParentChangedBehavior onParentChangedBehavior) {}
 
-        // carbonated begin enable_carbonated_1: Methods called from o3de-gruber
 #if defined(CARBONATED)
         // Ignore network updates... currently
         virtual void SetClientSimulated(bool /* clientSim */){};
 #endif
-       // carbonated end enable_carbonated_1
     };
 
     //! The EBus for requests to position and parent an entity.

--- a/Code/Framework/AzCore/AzCore/Math/Vector2.h
+++ b/Code/Framework/AzCore/AzCore/Math/Vector2.h
@@ -163,7 +163,6 @@ namespace AZ
         //! The positive rotation direction is defined such that the x-axis is rotated into the y-axis.
         Vector2 GetPerpendicular() const;
 
-       // carbonated begin enable_carbonated_1: Methods called from o3de-gruber
 #if defined(CARBONATED)
 #define AZ_MATH_FORCE_INLINE AZ_FORCE_INLINE
         /**
@@ -174,7 +173,6 @@ namespace AZ
             return Vector2(cos(r) * m_x - sin(r) * m_y, sin(r) * m_x + cos(r) * m_y);
         }
 #endif
-        // carbonated end enable_carbonated_1
 
         //! Checks the vector is equal to another within a floating point tolerance.
         bool IsClose(const Vector2& v, float tolerance = 0.001f) const;

--- a/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
@@ -789,29 +789,23 @@ namespace AzFramework
 
     void TransformComponent::OnEntityDeactivated([[maybe_unused]] const AZ::EntityId& parentEntityId)
     {
+        AZ_Assert(parentEntityId == m_parentId, "We expect to receive notifications only from the current parent!");
+        m_parentTM = nullptr;
+        m_parentActive = false;
+
 #if defined(CARBONATED)
         if (!IsNetworkControlled())
         {
-            AZ_Assert(parentEntityId == m_parentId, "We expect to receive notifications only from the current parent!");
-            m_parentTM = nullptr;
-            m_parentActive = false;
-            ComputeLocalTM();
-            
+            ComputeLocalTM();            
             UpdateReplicaChunk();
         }
         else
         {
             // If this transform is network controlled, then the localTM is updated by the network,
             // so update m_parentTM and compute worldTM instead.
-            AZ_Assert(parentEntityId == m_parentId, "We expect to receive notifications only from the current parent!");
-            m_parentTM = nullptr;
-            m_parentActive = false;
             ComputeWorldTM();
         }
 #else
-        AZ_Assert(parentEntityId == m_parentId, "We expect to receive notifications only from the current parent!");
-        m_parentTM = nullptr;
-        m_parentActive = false;
         ComputeLocalTM();
 #endif
     }

--- a/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
@@ -6,15 +6,17 @@
  *
  */
 
-#if defined(CARBONATED)
 #include <AzFramework/Components/TransformComponent.h>
 #include <AzFramework/Visibility/EntityBoundsUnionBus.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
+#include <AzCore/Interface/Interface.h>
 #include <AzCore/Math/Transform.h>
 #include <AzCore/Math/Quaternion.h>
+
+#if defined(CARBONATED)
 #include <AzFramework/Network/NetBindingHandlerBus.h>
 #include <AzFramework/Network/NetBindingSystemBus.h>
 #include <AzFramework/Network/NetworkContext.h>
@@ -23,18 +25,24 @@
 #include <GridMate/Replica/ReplicaFunctions.h>
 #include <GridMate/Replica/DataSet.h>
 #include <GridMate/Serialize/CompressionMarshal.h>
-
+#endif
 
 namespace AZ
 {
-    class BehaviorTransformNotificationBusHandler : public TransformNotificationBus::Handler, public AZ::BehaviorEBusHandler
+    class BehaviorTransformNotificationBusHandler
+        : public TransformNotificationBus::Handler
+        , public AZ::BehaviorEBusHandler
     {
     public:
-        AZ_EBUS_BEHAVIOR_BINDER(BehaviorTransformNotificationBusHandler, "{9CEF4DAB-F359-4A3E-9856-7780281E0DAA}", AZ::SystemAllocator
-            , OnTransformChanged
-            , OnParentChanged
-            , OnChildAdded
-            , OnChildRemoved
+        AZ_EBUS_BEHAVIOR_BINDER
+        (
+            BehaviorTransformNotificationBusHandler,
+            "{9CEF4DAB-F359-4A3E-9856-7780281E0DAA}",
+            AZ::SystemAllocator, 
+            OnTransformChanged, 
+            OnParentChanged, 
+            OnChildAdded, 
+            OnChildRemoved
         );
 
         void OnTransformChanged(const Transform& localTM, const Transform& worldTM) override
@@ -84,6 +92,7 @@ namespace AZ
 
 namespace AzFramework
 {
+#if defined(CARBONATED)
     //=========================================================================
     // TransformReplicaChunk
     // [3/9/2016]
@@ -102,13 +111,8 @@ namespace AzFramework
             , m_localRotation("LocalRotationData")
             , m_localScale("LocalScaleData")
         {
-#if defined(CARBONATED)
             m_localTranslation.GetThrottler().SetThreshold(AZ::Vector3(0.01f, 0.01f, 0.01f));
             m_localScale.GetThrottler().SetThreshold(AZ::Vector3(0.01f, 0.01f, 0.01f));
-#else
-            m_localTranslation.GetThrottler().SetThreshold(AZ::Vector3(0.005f, 0.005f, 0.005f));
-            m_localScale.GetThrottler().SetThreshold(AZ::Vector3(0.001f, 0.001f, 0.001f));
-#endif
         }
 
         bool IsReplicaMigratable() override
@@ -126,9 +130,7 @@ namespace AzFramework
             // Gruber patch begin // VMED -- missed ExtractScaleExact, CreateFromTransform are replaced
             const float uniformScale = t.GetUniformScale();
             m_localScale.Set(AZ::Vector3(uniformScale, uniformScale, uniformScale));
-#if defined(CARBONATED)
             AZ_Assert(t.GetTranslation().IsFinite(), "SetLocalTM: Transform is invalid");
-#endif
             m_localTranslation.Set(t.GetTranslation());
             m_localRotation.Set(t.GetRotation());
             // Gruber patch end // VMED
@@ -194,8 +196,8 @@ namespace AzFramework
             }
         };
     };
+#endif
 
-    //=========================================================================
     bool TransformComponentVersionConverter(AZ::SerializeContext& context, AZ::SerializeContext::DataElementNode& classElement)
     {
         if (classElement.GetVersion() < 3)
@@ -217,29 +219,8 @@ namespace AzFramework
             // future re-additions of it won't remove it (as long as they bump the version number.)
             classElement.RemoveElementByName(AZ_CRC("InterpolateScale", 0x9d00b831));
         }
-        
 
         return true;
-    }
-
-    //=========================================================================
-    // TransformComponent
-    // [8/9/2013]
-    //=========================================================================
-    TransformComponent::TransformComponent()
-        : m_parentTM(nullptr)
-        , m_parentActive(false)
-        , m_onNewParentKeepWorldTM(true)
-        , m_parentActivationTransformMode(ParentActivationTransformMode::MaintainOriginalRelativeTransform)
-        , m_isStatic(false)
-        , m_interpolatePosition(AZ::InterpolationMode::NoInterpolation)
-        , m_interpolateRotation(AZ::InterpolationMode::NoInterpolation)
-#if defined(CARBONATED)
-        , m_isClientSimulated(false)
-#endif
-    {
-        m_localTM = AZ::Transform::CreateIdentity();
-        m_worldTM = AZ::Transform::CreateIdentity();
     }
 
     TransformComponent::TransformComponent(const TransformComponent& copy)
@@ -251,14 +232,17 @@ namespace AzFramework
         , m_notificationBus(nullptr)
         , m_onNewParentKeepWorldTM(copy.m_onNewParentKeepWorldTM)
         , m_parentActivationTransformMode(copy.m_parentActivationTransformMode)
-        , m_replicaChunk(nullptr)
         , m_isStatic(copy.m_isStatic)
+#if defined(CARBONATED)
+        , m_replicaChunk(nullptr)
         , m_interpolatePosition(copy.m_interpolatePosition)
         , m_interpolateRotation(copy.m_interpolateRotation)
         , m_netTargetTranslation()
         , m_netTargetRotation()
-        , m_netTargetScale(copy.m_netTargetScale)        
+        , m_netTargetScale(copy.m_netTargetScale)
+#endif
     {
+#if defined(CARBONATED)
         CreateSamples();
         if (copy.m_netTargetTranslation)
         {
@@ -270,9 +254,12 @@ namespace AzFramework
         }
 
         SetSyncEnabled(copy.m_isSyncEnabled);
+#else
+        ;
+#endif
     }
 
-
+#if defined(CARBONATED)
     void TransformComponent::CreateTranslationSample()
     {
         switch(m_interpolatePosition)
@@ -331,10 +318,7 @@ namespace AzFramework
             CreateRotationSample();
         }
     }
-
-    TransformComponent::~TransformComponent()
-    {
-    }
+#endif
 
     bool TransformComponent::ReadInConfig(const AZ::ComponentConfig* baseConfig)
     {
@@ -344,10 +328,12 @@ namespace AzFramework
             m_worldTM = config->m_worldTransform;
             m_parentId = config->m_parentId;
             m_parentActivationTransformMode = config->m_parentActivationTransformMode;
+            m_isStatic = config->m_isStatic;
+#if defined(CARBONATED)
             SetSyncEnabled(config->m_netSyncEnabled);
             m_interpolatePosition = config->m_interpolatePosition;
             m_interpolateRotation = config->m_interpolateRotation;
-            m_isStatic = config->m_isStatic;
+#endif
             return true;
         }
         return false;
@@ -361,10 +347,12 @@ namespace AzFramework
             config->m_worldTransform = m_worldTM;
             config->m_parentId = m_parentId;
             config->m_parentActivationTransformMode = m_parentActivationTransformMode;
+            config->m_isStatic = m_isStatic;
+#if defined(CARBONATED)
             config->m_netSyncEnabled = IsSyncEnabled();
             config->m_interpolatePosition = m_interpolatePosition;
             config->m_interpolateRotation = m_interpolateRotation;
-            config->m_isStatic = m_isStatic;
+#endif
             return true;
         }
         return false;
@@ -375,1326 +363,6 @@ namespace AzFramework
         AZ::TransformBus::Handler::BusConnect(m_entity->GetId());
         AZ::TransformNotificationBus::Bind(m_notificationBus, m_entity->GetId());
 
-
-        const bool keepWorldTm = (m_parentActivationTransformMode == ParentActivationTransformMode::MaintainCurrentWorldTransform || !m_parentId.IsValid());
-        SetParentImpl(m_parentId, keepWorldTm);
-    }
-
-    void TransformComponent::Deactivate()
-    {
-        EBUS_EVENT_ID(m_parentId, AZ::TransformNotificationBus, OnChildRemoved, GetEntityId());
-
-        UnbindFromNetwork();
-
-        m_notificationBus = nullptr;
-        if (m_parentId.IsValid())
-        {
-            AZ::TransformNotificationBus::Handler::BusDisconnect();
-            AZ::TransformHierarchyInformationBus::Handler::BusDisconnect();
-            AZ::EntityBus::Handler::BusDisconnect();
-        }
-        AZ::TransformBus::Handler::BusDisconnect();
-    }
-
-    void TransformComponent::BindTransformChangedEventHandler(AZ::TransformChangedEvent::Handler& handler)
-    {
-        handler.Connect(m_transformChangedEvent);
-    }
-
-    void TransformComponent::BindParentChangedEventHandler(AZ::ParentChangedEvent::Handler& handler)
-    {
-        handler.Connect(m_parentChangedEvent);
-    }
-
-    void TransformComponent::BindChildChangedEventHandler(AZ::ChildChangedEvent::Handler& handler)
-    {
-        handler.Connect(m_childChangedEvent);
-    }
-
-    void TransformComponent::NotifyChildChangedEvent(AZ::ChildChangeType changeType, AZ::EntityId entityId)
-    {
-        m_childChangedEvent.Signal(changeType, entityId);
-    }
-
-
-    void TransformComponent::SetLocalTM(const AZ::Transform& tm)
-    {
-        if (AreMoveRequestsAllowed())
-        {
-            SetLocalTMImpl(tm);
-            UpdateReplicaChunk();
-        }
-    }
-
-    void TransformComponent::SetWorldTM(const AZ::Transform& tm)
-    {
-        if (AreMoveRequestsAllowed())
-        {
-            SetWorldTMImpl(tm);
-            UpdateReplicaChunk();
-        }
-    }
-
-    void TransformComponent::SetParent(AZ::EntityId id)
-    {
-        if (!IsNetworkControlled())
-        {
-            SetParentImpl(id, true);
-
-            UpdateReplicaChunk();
-        }
-    }
-
-    void TransformComponent::SetParentRelative(AZ::EntityId id)
-    {
-        if (!IsNetworkControlled())
-        {
-            SetParentImpl(id, m_isStatic);
-
-            UpdateReplicaChunk();
-        }
-    }
-
-    void TransformComponent::SetWorldTranslation(const AZ::Vector3& newPosition)
-    {
-        AZ::Transform newWorldTransform = m_worldTM;
-        newWorldTransform.SetTranslation(newPosition);
-        SetWorldTM(newWorldTransform);
-    }
-
-    void TransformComponent::SetLocalTranslation(const AZ::Vector3& newPosition)
-    {
-        AZ::Transform newLocalTransform = m_localTM;
-        newLocalTransform.SetTranslation(newPosition);
-        SetLocalTM(newLocalTransform);
-    }
-
-    AZ::Vector3 TransformComponent::GetWorldTranslation()
-    {
-        return m_worldTM.GetTranslation();
-    }
-
-    AZ::Vector3 TransformComponent::GetLocalTranslation()
-    {
-        return m_localTM.GetTranslation();
-    }
-
-    void TransformComponent::MoveEntity(const AZ::Vector3& offset)
-    {
-        const AZ::Vector3& worldPosition = m_worldTM.GetTranslation();
-        SetWorldTranslation(worldPosition + offset);
-    }
-
-    void TransformComponent::SetWorldX(float x)
-    {
-        const AZ::Vector3& worldPosition = m_worldTM.GetTranslation();
-        SetWorldTranslation(AZ::Vector3(x, worldPosition.GetY(), worldPosition.GetZ()));
-    }
-
-    void TransformComponent::SetWorldY(float y)
-    {
-        const AZ::Vector3& worldPosition = m_worldTM.GetTranslation();
-        SetWorldTranslation(AZ::Vector3(worldPosition.GetX(), y, worldPosition.GetZ()));
-    }
-
-    void TransformComponent::SetWorldZ(float z)
-    {
-        const AZ::Vector3& worldPosition = m_worldTM.GetTranslation();
-        SetWorldTranslation(AZ::Vector3(worldPosition.GetX(), worldPosition.GetY(), z));
-    }
-
-    float TransformComponent::GetWorldX()
-    {
-        return GetWorldTranslation().GetX();
-    }
-
-    float TransformComponent::GetWorldY()
-    {
-        return GetWorldTranslation().GetY();
-    }
-
-    float TransformComponent::GetWorldZ()
-    {
-        return GetWorldTranslation().GetZ();
-    }
-
-    void TransformComponent::SetLocalX(float x)
-    {
-        AZ::Vector3 newLocalTranslation = m_localTM.GetTranslation();
-        newLocalTranslation.SetX(x);
-        SetLocalTranslation(newLocalTranslation);
-    }
-
-    void TransformComponent::SetLocalY(float y)
-    {
-        AZ::Vector3 newLocalTranslation = m_localTM.GetTranslation();
-        newLocalTranslation.SetY(y);
-        SetLocalTranslation(newLocalTranslation);
-    }
-
-    void TransformComponent::SetLocalZ(float z)
-    {
-        AZ::Vector3 newLocalTranslation = m_localTM.GetTranslation();
-        newLocalTranslation.SetZ(z);
-        SetLocalTranslation(newLocalTranslation);
-    }
-
-    float TransformComponent::GetLocalX()
-    {
-        float localX = m_localTM.GetTranslation().GetX();
-        return localX;
-    }
-
-    float TransformComponent::GetLocalY()
-    {
-        float localY = m_localTM.GetTranslation().GetY();
-        return localY;
-    }
-
-    float TransformComponent::GetLocalZ()
-    {
-        float localZ = m_localTM.GetTranslation().GetZ();
-        return localZ;
-    }
-
-#if 0
-    void TransformComponent::SetRotation(const AZ::Vector3& eulerAnglesRadian)
-    {
-        AZ_Warning("TransformComponent", false, "SetRotation is deprecated, please use SetLocalRotation");
-
-        AZ::Transform newWorldTransform = m_worldTM;
-        newWorldTransform.SetRotationPartFromQuaternion(AZ::ConvertEulerRadiansToQuaternion(eulerAnglesRadian));
-        SetWorldTM(newWorldTransform);
-    }
-
-    void TransformComponent::SetRotationQuaternion(const AZ::Quaternion& quaternion)
-    {
-        AZ_Warning("TransformComponent", false, "SetRotationQuaternion is deprecated, please use SetLocalRotationQuaternion");
-
-        AZ::Transform newWorldTransform = m_worldTM;
-        newWorldTransform.SetRotationPartFromQuaternion(quaternion);
-        SetWorldTM(newWorldTransform);
-    }
-
-    void TransformComponent::SetRotationX(float eulerAngleRadian)
-    {
-        AZ_Warning("TransformComponent", false, "SetRotationX is deprecated, please use SetLocalRotation");
-
-        AZ::Transform newWorldTransform = m_worldTM;
-        newWorldTransform.SetRotationPartFromQuaternion(AZ::Quaternion::CreateRotationX(eulerAngleRadian));
-        SetWorldTM(newWorldTransform);
-    }
-
-    void TransformComponent::SetRotationY(float eulerAngleRadian)
-    {
-        AZ_Warning("TransformComponent", false, "SetRotationY is deprecated, please use SetLocalRotation");
-
-        AZ::Transform newWorldTransform = m_worldTM;
-        newWorldTransform.SetRotationPartFromQuaternion(AZ::Quaternion::CreateRotationY(eulerAngleRadian));
-        SetWorldTM(newWorldTransform);
-    }
-
-    void TransformComponent::SetRotationZ(float eulerAngleRadian)
-    {
-        AZ_Warning("TransformComponent", false, "SetRotationZ is deprecated, please use SetLocalRotation");
-
-        AZ::Transform newWorldTransform = m_worldTM;
-        newWorldTransform.SetRotationPartFromQuaternion(AZ::Quaternion::CreateRotationZ(eulerAngleRadian));
-        SetWorldTM(newWorldTransform);
-    }
-
-    void TransformComponent::RotateByX(float eulerAngleRadian)
-    {
-        AZ_Warning("TransformComponent", false, "RotateByX is deprecated, please use RotateAroundLocalX");
-
-        RotateAroundLocalX(eulerAngleRadian);
-    }
-
-    void TransformComponent::RotateByY(float eulerAngleRadian)
-    {
-        AZ_Warning("TransformComponent", false, "RotateByY is deprecated, please use RotateAroundLocalY");
-
-        RotateAroundLocalY(eulerAngleRadian);
-    }
-
-    void TransformComponent::RotateByZ(float eulerAngleRadian)
-    {
-        AZ_Warning("TransformComponent", false, "RotateByZ is deprecated, please use RotateAroundLocalZ");
-
-        RotateAroundLocalZ(eulerAngleRadian);
-    }
-
-    AZ::Vector3 TransformComponent::GetRotationEulerRadians()
-    {
-        AZ_Warning("TransformComponent", false, "GetRotationEulerRadians is deprecated, please use GetWorldRotation");
-
-        return m_worldTM.GetEulerRadians();
-    }
-
-    AZ::Quaternion TransformComponent::GetRotationQuaternion()
-    {
-        AZ_Warning("TransformComponent", false, "GetRotationQuaternion is deprecated, please use GetWorldRotationQuaternion");
-
-        return AZ::Quaternion::CreateFromTransform(m_worldTM);
-    }
-
-    float TransformComponent::GetRotationX()
-    {
-        AZ_Warning("TransformComponent", false, "GetRotationX is deprecated, please use GetWorldRotation");
-
-        return GetRotationEulerRadians().GetX();
-    }
-
-    float TransformComponent::GetRotationY()
-    {
-        AZ_Warning("TransformComponent", false, "GetRotationY is deprecated, please use GetWorldRotation");
-
-        return GetRotationEulerRadians().GetY();
-    }
-
-    float TransformComponent::GetRotationZ()
-    {
-        AZ_Warning("TransformComponent", false, "GetRotationZ is deprecated, please use GetWorldRotation");
-
-        return GetRotationEulerRadians().GetZ();
-    }
-#endif
-    AZ::Vector3 TransformComponent::GetWorldRotation()
-    {
-        return m_worldTM.GetRotation().GetEulerRadians();
-    }
-
-    AZ::Quaternion TransformComponent::GetWorldRotationQuaternion()
-    {
-        return m_worldTM.GetRotation();
-    }
-
-    void TransformComponent::SetLocalRotation(const AZ::Vector3& eulerRadianAngles)
-    {
-        AZ::Transform newLocalTM = m_localTM;
-        newLocalTM.SetRotation(AZ::Quaternion::CreateFromEulerAnglesRadians(eulerRadianAngles));
-        SetLocalTM(newLocalTM);
-    }
-
-    void TransformComponent::SetLocalRotationQuaternion(const AZ::Quaternion& quaternion)
-    {
-        AZ::Transform newLocalTM = m_localTM;
-        newLocalTM.SetRotation(quaternion);
-        SetLocalTM(newLocalTM);
-    }
-
-    static AZ::Transform RotateAroundLocalHelper(float eulerAngleRadian, const AZ::Transform& localTM, AZ::Vector3 axis)
-    {
-        // normalize the axis before creating rotation
-        axis.Normalize();
-        AZ::Quaternion rotate = AZ::Quaternion::CreateFromAxisAngle(axis, eulerAngleRadian);
-
-        AZ::Transform newLocalTM = localTM;
-        newLocalTM.SetRotation((rotate * localTM.GetRotation()).GetNormalized());
-        return newLocalTM;
-    }
-
-    void TransformComponent::RotateAroundLocalX(float eulerAngleRadian)
-    {
-        AZ::Vector3 xAxis = m_localTM.GetBasisX();
-
-        AZ::Transform newLocalTM = RotateAroundLocalHelper(eulerAngleRadian, m_localTM, xAxis);
-
-        SetLocalTM(newLocalTM);
-    }
-
-    void TransformComponent::RotateAroundLocalY(float eulerAngleRadian)
-    {
-        AZ::Vector3 yAxis = m_localTM.GetBasisY();
-        
-        AZ::Transform newLocalTM = RotateAroundLocalHelper(eulerAngleRadian, m_localTM, yAxis);
-
-        SetLocalTM(newLocalTM);
-    }
-
-    void TransformComponent::RotateAroundLocalZ(float eulerAngleRadian)
-    {
-        AZ::Vector3 zAxis = m_localTM.GetBasisZ();
-        
-        AZ::Transform newLocalTM = RotateAroundLocalHelper(eulerAngleRadian, m_localTM, zAxis);
-
-        SetLocalTM(newLocalTM);
-    }
-
-    AZ::Vector3 TransformComponent::GetLocalRotation()
-    {
-        return m_localTM.GetRotation().GetEulerRadians();
-    }
-
-    AZ::Quaternion TransformComponent::GetLocalRotationQuaternion()
-    {
-        return m_localTM.GetRotation();
-    }
-
-#if 0
-    void TransformComponent::SetScale(const AZ::Vector3& scale)
-    {
-        AZ_Warning("TransformComponent", false, "SetScale is deprecated, please use SetLocalScale");
-
-        AZ::Transform newWorldTransform = m_worldTM;
-        AZ::Vector3 prevScale = newWorldTransform.ExtractScale();
-        if (!prevScale.IsClose(scale))
-        {
-            newWorldTransform.MultiplyByScale(scale);
-            SetWorldTM(newWorldTransform);
-        }
-    }
-
-    void TransformComponent::SetScaleX(float scaleX)
-    {
-        AZ_Warning("TransformComponent", false, "SetScaleX is deprecated, please use SetLocalScaleX");
-
-        AZ::Transform newWorldTransform = m_worldTM;
-        AZ::Vector3 scale = newWorldTransform.ExtractScale();
-        scale.SetX(scaleX);
-        newWorldTransform.MultiplyByScale(scale);
-        SetWorldTM(newWorldTransform);
-    }
-
-    void TransformComponent::SetScaleY(float scaleY)
-    {
-        AZ_Warning("TransformComponent", false, "SetScaleY is deprecated, please use SetLocalScaleY");
-
-        AZ::Transform newWorldTransform = m_worldTM;
-        AZ::Vector3 scale = newWorldTransform.ExtractScale();
-        scale.SetY(scaleY);
-        newWorldTransform.MultiplyByScale(scale);
-        SetWorldTM(newWorldTransform);
-    }
-
-    void TransformComponent::SetScaleZ(float scaleZ)
-    {
-        AZ_Warning("TransformComponent", false, "SetScaleZ is deprecated, please use SetLocalScaleZ");
-
-        AZ::Transform newWorldTransform = m_worldTM;
-        AZ::Vector3 scale = newWorldTransform.ExtractScale();
-        scale.SetZ(scaleZ);
-        newWorldTransform.MultiplyByScale(scale);
-        SetWorldTM(newWorldTransform);
-    }
-
-    AZ::Vector3 TransformComponent::GetScale()
-    {
-        AZ_Warning("TransformComponent", false, "GetScale is deprecated, please use GetLocalScale");
-
-        return m_worldTM.RetrieveScale();
-    }
-
-    float TransformComponent::GetScaleX()
-    {
-        AZ_Warning("TransformComponent", false, "GetScaleX is deprecated, please use GetLocalScale");
-
-        AZ::Vector3 scale = m_worldTM.RetrieveScale();
-        return scale.GetX();
-    }
-
-    float TransformComponent::GetScaleY()
-    {
-        AZ_Warning("TransformComponent", false, "GetScaleY is deprecated, please use GetLocalScale");
-
-        AZ::Vector3 scale = m_worldTM.RetrieveScale();
-        return scale.GetY();
-    }
-
-    float TransformComponent::GetScaleZ()
-    {
-        AZ_Warning("TransformComponent", false, "GetScaleZ is deprecated, please use GetLocalScale");
-
-        AZ::Vector3 scale = m_worldTM.RetrieveScale();
-        return scale.GetZ();
-    }
-
-
-    }
-
-    void TransformComponent::SetLocalScaleX(float scaleX)
-    {
-        AZ::Transform newLocalTM = m_localTM;
-        AZ::Vector3 newScale = newLocalTM.ExtractScaleExact();
-        newScale.SetX(scaleX);
-        newLocalTM.MultiplyByScale(newScale);
-        SetLocalTM(newLocalTM);
-    }
-
-    void TransformComponent::SetLocalScaleY(float scaleY)
-    {
-        AZ::Transform newLocalTM = m_localTM;
-        AZ::Vector3 newScale = newLocalTM.ExtractScaleExact();
-        newScale.SetY(scaleY);
-        newLocalTM.MultiplyByScale(newScale);
-        SetLocalTM(newLocalTM);
-    }
-
-    void TransformComponent::SetLocalScaleZ(float scaleZ)
-    {
-        AZ::Transform newLocalTM = m_localTM;
-        AZ::Vector3 newScale = newLocalTM.ExtractScaleExact();
-        newScale.SetZ(scaleZ);
-        newLocalTM.MultiplyByScale(newScale);
-        SetLocalTM(newLocalTM);
-    }
-
-    AZ::Vector3 TransformComponent::GetWorldScale()
-    {
-        AZ::Vector3 scale = m_worldTM.RetrieveScaleExact();
-        return scale;
-    }
-    void TransformComponent::SetLocalScale(const AZ::Vector3& /* scale */)
-    {
-        AZ::Transform newLocalTM = m_localTM;
-
-        // Gruber patch begin // commented out as unsupported
-        AZ_Assert(false, "To be fixed");
-#if 0
-        newLocalTM.ExtractScaleExact();
-        newLocalTM.MultiplyByScale(scale);
-#endif
-        // Gruber patch end
-
-        SetLocalTM(newLocalTM);
-    }
-    AZ::Vector3 TransformComponent::GetLocalScale()
-    {
-        AZ_WarningOnce("TransformComponent", false, "GetLocalScale is deprecated, please use GetLocalUniformScale instead");
-        return AZ::Vector3(m_localTM.GetUniformScale());
-    }
-#endif
-
-    void TransformComponent::SetLocalUniformScale(float scale)
-    {
-        AZ::Transform newLocalTM = m_localTM;
-        newLocalTM.SetUniformScale(scale);
-        SetLocalTM(newLocalTM);
-    }
-
-    float TransformComponent::GetLocalUniformScale()
-    {
-        return m_localTM.GetUniformScale();
-    }
-
-    float TransformComponent::GetWorldUniformScale()
-    {
-        return m_worldTM.GetUniformScale();
-    }
-
-    AZStd::vector<AZ::EntityId> TransformComponent::GetChildren()
-    {
-        AZStd::vector<AZ::EntityId> children;
-        EBUS_EVENT_ID(GetEntityId(), AZ::TransformHierarchyInformationBus, GatherChildren, children);
-        return children;
-    }
-
-    AZStd::vector<AZ::EntityId> TransformComponent::GetAllDescendants()
-    {
-        AZStd::vector<AZ::EntityId> descendants = GetChildren();
-        for (size_t i = 0; i < descendants.size(); ++i)
-        {
-            EBUS_EVENT_ID(descendants[i], AZ::TransformHierarchyInformationBus, GatherChildren, descendants);
-        }
-        return descendants;
-    }
-
-    AZStd::vector<AZ::EntityId> TransformComponent::GetEntityAndAllDescendants()
-    {
-        AZStd::vector<AZ::EntityId> descendants = { GetEntityId() };
-        for (size_t i = 0; i < descendants.size(); ++i)
-        {
-            EBUS_EVENT_ID(descendants[i], AZ::TransformHierarchyInformationBus, GatherChildren, descendants);
-        }
-        return descendants;
-    }
-
-    bool TransformComponent::IsStaticTransform()
-    {
-        return m_isStatic;
-    }
-
-    void TransformComponent::OnTransformChanged(const AZ::Transform& parentLocalTM, const AZ::Transform& parentWorldTM)
-    {
-        OnTransformChangedImpl(parentLocalTM, parentWorldTM);
-    }
-
-    void TransformComponent::GatherChildren(AZStd::vector<AZ::EntityId>& children)
-    {
-        children.push_back(GetEntityId());
-    }
-
-    void TransformComponent::OnEntityActivated(const AZ::EntityId& parentEntityId)
-    {
-        OnEntityActivatedImpl(parentEntityId);
-        UpdateReplicaChunk();
-    }
-
-    void TransformComponent::OnEntityDeactivated(const AZ::EntityId& parentEntityId)
-    {
-        if (!IsNetworkControlled())
-        {
-            OnEntityDeactivateImpl(parentEntityId);
-            UpdateReplicaChunk();
-        }
-        else
-        {
-            // If this transform is network controlled, then the localTM is updated by the network,
-            // so update m_parentTM and compute worldTM instead.
-            AZ_Assert(parentEntityId == m_parentId, "We expect to receive notifications only from the current parent!");
-            m_parentTM = nullptr;
-            m_parentActive = false;
-            ComputeWorldTM();
-        }
-    }
-
-    GridMate::ReplicaChunkPtr TransformComponent::GetNetworkBinding()
-    {
-        TransformReplicaChunk* replicaChunk = GridMate::CreateReplicaChunk<TransformReplicaChunk>();
-        replicaChunk->SetHandler(this);
-        m_replicaChunk = replicaChunk;
-
-        UpdateReplicaChunk();
-
-        return m_replicaChunk;
-    }
-
-    void TransformComponent::SetNetworkBinding(GridMate::ReplicaChunkPtr replicaChunk)
-    {
-        AZ_Assert(m_replicaChunk == nullptr, "Being bound to two ReplicaChunks");
-
-        bool isTransformChunk = replicaChunk != nullptr;
-
-        AZ_Assert(isTransformChunk, "Being bound to invalid chunk type");
-        if (isTransformChunk)
-        {
-            replicaChunk->SetHandler(this);
-            m_replicaChunk = replicaChunk;
-
-            TransformReplicaChunk* transformReplicaChunk = static_cast<TransformReplicaChunk*>(m_replicaChunk.get());
-
-            m_parentId = AZ::EntityId(transformReplicaChunk->m_parentId.Get());
-
-            m_worldTM = transformReplicaChunk->m_initialWorldTM;
-            m_localTM = transformReplicaChunk->GetLocalTransform();
-
-            CreateSamples();
-
-            m_netTargetTranslation->SetPreviousValue(
-                transformReplicaChunk->m_localTranslation.Get(),
-                transformReplicaChunk->m_localTranslation.GetLastUpdateTime());
-            m_netTargetTranslation->SetNewTarget(
-                transformReplicaChunk->m_localTranslation.Get(),
-                transformReplicaChunk->m_localTranslation.GetLastUpdateTime());
-            m_netTargetRotation->SetPreviousValue(
-                transformReplicaChunk->m_localRotation.Get(),
-                transformReplicaChunk->m_localRotation.GetLastUpdateTime());
-            m_netTargetRotation->SetNewTarget(
-                transformReplicaChunk->m_localRotation.Get(),
-                transformReplicaChunk->m_localRotation.GetLastUpdateTime());
-            m_netTargetScale = transformReplicaChunk->m_localScale.Get();
-
-            if (HasAnyInterpolation())
-            {
-                // only connect if interpolation was selected for either position or rotation
-                AZ::TickBus::Handler::BusConnect();
-            }
-        }
-
-        m_onNewParentKeepWorldTM = false;
-    }
-
-    void TransformComponent::UnbindFromNetwork()
-    {
-        if (HasAnyInterpolation())
-        {
-            AZ::TickBus::Handler::BusDisconnect();
-        }
-
-        if (m_replicaChunk)
-        {
-            m_replicaChunk->SetHandler(nullptr);
-            m_replicaChunk = nullptr;
-        }
-    }
-
-    void TransformComponent::OnNewNetTransformData(const AZ::Transform& transform, const GridMate::TimeContext& /*tc*/)
-    {
-        SetLocalTMImpl(transform);
-    }
-
-    void TransformComponent::OnNewNetParentData(const AZ::u64& parentId, const GridMate::TimeContext& /*tc*/)
-    {
-        SetParentImpl(AZ::EntityId(parentId), false);
-    }
-
-    bool TransformComponent::IsNetworkControlled() const
-    {
-#if defined(CARBONATED)
-        if (m_isClientSimulated)
-            return false;
-#endif
-        return m_replicaChunk && m_replicaChunk->GetReplica() && !m_replicaChunk->IsMaster();
-    }
-
-#if defined(CARBONATED)
-    //Ignore network updates... currently
-    void TransformComponent::SetClientSimulated(bool clientSim)
-    {
-        m_isClientSimulated = clientSim;
-    }
-#endif
-
-    bool TransformComponent::IsPositionInterpolated()
-    {
-        return m_interpolatePosition != AZ::InterpolationMode::NoInterpolation;
-    }
-
-    bool TransformComponent::IsRotationInterpolated()
-    {
-        return m_interpolateRotation != AZ::InterpolationMode::NoInterpolation;
-    }
-
-    bool TransformComponent::HasAnyInterpolation()
-    {
-        return IsPositionInterpolated() || IsRotationInterpolated();
-    }
-
-    void TransformComponent::OnTick(float /*deltaTime*/, AZ::ScriptTimePoint /*currentTime*/)
-    {
-        if (GetEntity() && GetEntity()->GetState() == AZ::Entity::State::Active)
-        {
-#if defined(CARBONATED)
-            if (IsNetworkControlled())
-#else
-            if (m_replicaChunk && m_replicaChunk->IsProxy())
-#endif
-            {
-                const unsigned int localTime = m_replicaChunk->GetReplicaManager()->GetTime().m_localTime;
-                const AZ::Transform newXform = GetInterpolatedTransform(localTime);
-                SetLocalTMImpl(newXform);
-            }
-        }
-    }
-
-    AZ::Transform TransformComponent::GetInterpolatedTransform(unsigned localTime)
-    {
-        const AZ::Vector3 newTranslation = m_netTargetTranslation->GetInterpolatedValue(localTime);
-        const AZ::Quaternion newRotation = m_netTargetRotation->GetInterpolatedValue(localTime);
-        AZ::Transform newXform = AZ::Transform::CreateFromQuaternionAndTranslation(newRotation, newTranslation);
-        // Gruber patch begin // VMED -- missed MultiplyByScale is replaced
-        newXform.MultiplyByUniformScale(m_netTargetScale.GetX()); // local scale is setup as uniform scale
-        // Gruber patch end // VMED
-#if defined(CARBONATED)
-        AZ_Assert(newXform.IsFinite(), "Interpolated Transform is invalid");
-#endif
-        return newXform;
-    }
-
-    void TransformComponent::OnNewPositionData(const AZ::Vector3& translation, const GridMate::TimeContext& tc)
-    {
-#if defined(CARBONATED)
-        AZ_Assert(translation.IsFinite(), "TransformComponent:OnNewPositionData translation is invalid");
-#endif
-        m_netTargetTranslation->SetNewTarget(translation, tc.m_realTime);
-        if (!HasAnyInterpolation())
-        {
-            unsigned int localTime = m_replicaChunk->GetReplicaManager()->GetTime().m_localTime;
-            AZ::Transform newXform = GetInterpolatedTransform(localTime);
-            SetLocalTMImpl(newXform);
-        }
-    };
-
-    void TransformComponent::OnNewRotationData(const AZ::Quaternion& rotation, const GridMate::TimeContext& tc)
-    {
-        m_netTargetRotation->SetNewTarget(rotation, tc.m_realTime);
-        if (!HasAnyInterpolation())
-        {
-            unsigned int localTime = m_replicaChunk->GetReplicaManager()->GetTime().m_localTime;
-            AZ::Transform newXform = GetInterpolatedTransform(localTime);
-            SetLocalTMImpl(newXform);
-        }
-    }
-
-    void TransformComponent::OnNewScaleData(const AZ::Vector3& scale, const GridMate::TimeContext& /*tc*/)
-    {
-        // no interpolation of scale by design, very unlikely somebody needs it
-        m_netTargetScale = scale;
-    }
-
-    void TransformComponent::UpdateReplicaChunk()
-    {
-        if (!IsNetworkControlled() && m_replicaChunk)
-        {
-            TransformReplicaChunk* transformReplicaChunk = static_cast<TransformReplicaChunk*>(m_replicaChunk.get());
-            transformReplicaChunk->SetInitialTM(GetWorldTM());
-            transformReplicaChunk->SetLocalTM(GetLocalTM());
-            transformReplicaChunk->m_parentId.Set(static_cast<AZ::u64>(GetParentId()));
-        }
-    }
-
-    void TransformComponent::SetParentImpl(AZ::EntityId parentId, bool isKeepWorldTM)
-    {
-        if (parentId == GetEntityId())
-        {
-            AZ_Warning("TransformComponent", false, "An entity can not be set as its own parent.");
-            return;
-        }
-
-        AZ::EntityId oldParent = m_parentId;
-        if (m_parentId.IsValid())
-        {
-            AZ::TransformNotificationBus::Handler::BusDisconnect();
-            AZ::TransformHierarchyInformationBus::Handler::BusDisconnect();
-            AZ::EntityBus::Handler::BusDisconnect();
-            m_parentActive = false;
-        }
-
-        m_parentId = parentId;
-        if (m_parentId.IsValid())
-        {
-            AZ::Entity* parentEntity = nullptr;
-            AZ::ComponentApplicationBus::BroadcastResult(parentEntity, &AZ::ComponentApplicationBus::Events::FindEntity, m_parentId);
-            m_parentActive = parentEntity && (parentEntity->GetState() == AZ::Entity::State::Active);
-
-            m_onNewParentKeepWorldTM = isKeepWorldTM;
-
-            AZ::TransformNotificationBus::Handler::BusConnect(m_parentId);
-            AZ::TransformHierarchyInformationBus::Handler::BusConnect(m_parentId);
-            AZ::EntityBus::Handler::BusConnect(m_parentId);
-        }
-        else
-        {
-            m_parentTM = nullptr;
-
-            if (isKeepWorldTM)
-            {
-            SetWorldTM(m_worldTM);
-            }
-            else
-            {
-                SetLocalTM(m_localTM);
-            }
-
-            if (oldParent.IsValid())
-            {
-                AZ::TransformNotificationBus::Event(
-                    m_notificationBus, &AZ::TransformNotificationBus::Events::OnTransformChanged, m_localTM, m_worldTM);
-                m_transformChangedEvent.Signal(m_localTM, m_worldTM);
-            }
-        }
-
-        AZ::TransformNotificationBus::Event(m_notificationBus, &AZ::TransformNotificationBus::Events::OnParentChanged, oldParent, parentId);
-        m_parentChangedEvent.Signal(oldParent, parentId);
-
-        if (oldParent.IsValid() && oldParent != parentId) // Don't send removal notification while activating.
-        {
-            AZ::TransformNotificationBus::Event(oldParent, &AZ::TransformNotificationBus::Events::OnChildRemoved, GetEntityId());
-            auto oldParentTransform = AZ::TransformBus::FindFirstHandler(oldParent);
-            if (oldParentTransform)
-            {
-                oldParentTransform->NotifyChildChangedEvent(AZ::ChildChangeType::Removed, GetEntityId());
-            }
-        }
-
-        AZ::TransformNotificationBus::Event(parentId, &AZ::TransformNotificationBus::Events::OnChildAdded, GetEntityId());
-        auto newParentTransform = AZ::TransformBus::FindFirstHandler(parentId);
-        if (newParentTransform)
-        {
-            newParentTransform->NotifyChildChangedEvent(AZ::ChildChangeType::Added, GetEntityId());
-        }
-    }
-
-    void TransformComponent::SetLocalTMImpl(const AZ::Transform& tm)
-    {
-        m_localTM = tm;
-        ComputeWorldTM();  // We can user dirty flags and compute it later on demand
-    }
-
-    void TransformComponent::SetWorldTMImpl(const AZ::Transform& tm)
-    {
-        m_worldTM = tm;
-        ComputeLocalTM(); // We can user dirty flags and compute it later on demand
-    }
-
-    void TransformComponent::OnTransformChangedImpl(const AZ::Transform& /*parentLocalTM*/, const AZ::Transform& parentWorldTM)
-    {
-        // Called when our parent transform changes
-        // Ignore the event until we've already derived our local transform.
-        if (m_parentTM)
-        {
-            m_worldTM = parentWorldTM * m_localTM;
-            EBUS_EVENT_PTR(m_notificationBus, AZ::TransformNotificationBus, OnTransformChanged, m_localTM, m_worldTM);
-        }
-    }
-
-    void TransformComponent::OnEntityActivatedImpl(const AZ::EntityId& parentEntityId)
-    {
-        AZ_Assert(parentEntityId == m_parentId, "We expect to receive notifications only from the current parent!");
-
-        m_parentActive = true;
-
-#ifndef _RELEASE
-        AZ::EntityId parentId = m_parentId;
-
-        while (parentId.IsValid())
-        {
-            if (parentId == GetEntityId())
-            {
-                AZ_Error("TransformComponent", false, "Trying to create a circular dependency of parenting. Aborting set parent call.");
-                SetParent(AZ::EntityId());
-                return;
-            }
-
-            auto handler = AZ::TransformBus::FindFirstHandler(parentId);
-
-            if (handler == nullptr)
-            {
-                break;
-            }
-
-            parentId = handler->GetParentId();
-        }
-#endif
-
-        AZ::ComponentApplicationRequests* componentApplication = AZ::Interface<AZ::ComponentApplicationRequests>::Get();
-        AZ::Entity* parentEntity = (componentApplication != nullptr) ? componentApplication->FindEntity(parentEntityId) : nullptr;
-        AZ_Assert(parentEntity, "We expect to have a parent entity associated with the provided parent's entity Id.");
-        if (parentEntity)
-        {
-            m_parentTM = parentEntity->GetTransform();
-
-#if defined(CARBONATED)
-           //Warning keeps going off for statics in layers... so its just noise.
-#else
-           AZ_Warning("TransformComponent", !m_isStatic || m_parentTM->IsStaticTransform(),
-                "Entity '%s' %s has static transform, but parent has non-static transform. This may lead to unexpected movement.",
-                GetEntity()->GetName().c_str(), GetEntityId().ToString().c_str());
-#endif
-
-            if (m_onNewParentKeepWorldTM)
-            {
-                ComputeLocalTM();
-            }
-            else
-            {
-                ComputeWorldTM();
-            }
-        }
-    }
-
-    void TransformComponent::OnEntityDeactivateImpl(const AZ::EntityId& parentEntityId)
-    {
-        (void)parentEntityId;
-        AZ_Assert(parentEntityId == m_parentId, "We expect to receive notifications only from the current parent!");
-        m_parentTM = nullptr;
-        m_parentActive = false;
-        ComputeLocalTM();
-    }
-
-    void TransformComponent::ComputeLocalTM()
-    {
-        if (m_parentTM)
-        {
-            m_localTM = m_parentTM->GetWorldTM().GetInverse() * m_worldTM;
-        }
-        else if (!m_parentActive)
-        {
-            m_localTM = m_worldTM;
-        }
-        AZ::TransformNotificationBus::Event(
-            m_notificationBus, &AZ::TransformNotificationBus::Events::OnTransformChanged, m_localTM, m_worldTM);
-        m_transformChangedEvent.Signal(m_localTM, m_worldTM);
-
-        AzFramework::IEntityBoundsUnion* boundsUnion = AZ::Interface<AzFramework::IEntityBoundsUnion>::Get();
-        if (boundsUnion != nullptr)
-        {
-            boundsUnion->OnTransformUpdated(GetEntity());
-        }
-    }
-
-    void TransformComponent::ComputeWorldTM()
-    {
-        if (m_parentTM)
-        {
-            m_worldTM = m_parentTM->GetWorldTM() * m_localTM;
-        }
-        else if (!m_parentActive)
-        {
-            m_worldTM = m_localTM;
-        }
-
-        EBUS_EVENT_PTR(m_notificationBus, AZ::TransformNotificationBus, OnTransformChanged, m_localTM, m_worldTM);
-    }
-
-    bool TransformComponent::AreMoveRequestsAllowed() const
-    {
-        if (IsNetworkControlled())
-        {
-            return false;
-        }
-
-        // Don't allow static transform to be moved while entity is activated.
-        // But do allow a static transform to be moved when the entity is deactivated.
-        if (m_isStatic && m_entity && (m_entity->GetState() > AZ::Entity::State::Init))
-        {
-            return false;
-        }
-
-        return true;
-    }
-
-    void TransformComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
-    {
-        provided.push_back(AZ_CRC("TransformService", 0x8ee22c50));
-    }
-
-    void TransformComponent::Reflect(AZ::ReflectContext* reflection)
-    {
-        AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(reflection);
-        if (serializeContext)
-        {
-            serializeContext->Class<TransformComponent, AZ::Component, NetBindable>()
-                ->Version(4, &TransformComponentVersionConverter)
-                ->Field("Parent", &TransformComponent::m_parentId)
-                ->Field("Transform", &TransformComponent::m_worldTM)
-                ->Field("LocalTransform", &TransformComponent::m_localTM)
-                ->Field("ParentActivationTransformMode", &TransformComponent::m_parentActivationTransformMode)
-                ->Field("IsStatic", &TransformComponent::m_isStatic)
-                ->Field("InterpolatePosition", &TransformComponent::m_interpolatePosition)
-                ->Field("InterpolateRotation", &TransformComponent::m_interpolateRotation)
-                ;
-        }
-
-        AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(reflection);
-        if(behaviorContext)
-        {
-            behaviorContext->EBus<AZ::TransformNotificationBus>("TransformNotificationBus")->
-                Handler<AZ::BehaviorTransformNotificationBusHandler>();
-
-            behaviorContext->Class<TransformComponent>()->RequestBus("TransformBus");
-
-            behaviorContext->EBus<AZ::TransformBus>("TransformBus")
-                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
-                ->Attribute(AZ::Script::Attributes::Module, "components")
-                ->Event("GetLocalTM", &AZ::TransformBus::Events::GetLocalTM)
-                ->Event("GetWorldTM", &AZ::TransformBus::Events::GetWorldTM)
-                ->Event("GetParentId", &AZ::TransformBus::Events::GetParentId)
-                ->Event("GetLocalAndWorld", &AZ::TransformBus::Events::GetLocalAndWorld)
-                    ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
-                ->Event("SetLocalTM", &AZ::TransformBus::Events::SetLocalTM)
-                ->Event("SetWorldTM", &AZ::TransformBus::Events::SetWorldTM)
-                ->Event("SetParent", &AZ::TransformBus::Events::SetParent)
-                ->Event("SetParentRelative", &AZ::TransformBus::Events::SetParentRelative)
-                ->Event("SetWorldTranslation", &AZ::TransformBus::Events::SetWorldTranslation)
-                ->Event("SetLocalTranslation", &AZ::TransformBus::Events::SetLocalTranslation)
-                ->Event("GetWorldTranslation", &AZ::TransformBus::Events::GetWorldTranslation)
-                ->Event("GetLocalTranslation", &AZ::TransformBus::Events::GetLocalTranslation)
-                    ->Attribute("Position", AZ::Edit::Attributes::PropertyPosition)
-                ->VirtualProperty("Position", "GetLocalTranslation", "SetLocalTranslation")
-                ->Event("MoveEntity", &AZ::TransformBus::Events::MoveEntity)
-                ->Event("SetWorldX", &AZ::TransformBus::Events::SetWorldX)
-                ->Event("SetWorldY", &AZ::TransformBus::Events::SetWorldY)
-                ->Event("SetWorldZ", &AZ::TransformBus::Events::SetWorldZ)
-                ->Event("GetWorldX", &AZ::TransformBus::Events::GetWorldX)
-                ->Event("GetWorldY", &AZ::TransformBus::Events::GetWorldY)
-                ->Event("GetWorldZ", &AZ::TransformBus::Events::GetWorldZ)
-                ->Event("SetLocalX", &AZ::TransformBus::Events::SetLocalX)
-                ->Event("SetLocalY", &AZ::TransformBus::Events::SetLocalY)
-                ->Event("SetLocalZ", &AZ::TransformBus::Events::SetLocalZ)
-                ->Event("GetLocalX", &AZ::TransformBus::Events::GetLocalX)
-                ->Event("GetLocalY", &AZ::TransformBus::Events::GetLocalY)
-                ->Event("GetLocalZ", &AZ::TransformBus::Events::GetLocalZ)
-#if 0
-                ->Event("RotateByX", &AZ::TransformBus::Events::RotateByX)
-                    ->Attribute(AZ::Script::Attributes::Deprecated, true)
-                    ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
-                ->Event("RotateByY", &AZ::TransformBus::Events::RotateByY)
-                    ->Attribute(AZ::Script::Attributes::Deprecated, true)
-                    ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
-                ->Event("RotateByZ", &AZ::TransformBus::Events::RotateByZ)
-                    ->Attribute(AZ::Script::Attributes::Deprecated, true)
-                    ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
-                ->Event("SetEulerRotation", &AZ::TransformBus::Events::SetRotation)
-                    ->Attribute(AZ::Script::Attributes::Deprecated, true)
-                    ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
-                ->Event("SetRotationQuaternion", &AZ::TransformBus::Events::SetRotationQuaternion)
-                    ->Attribute(AZ::Script::Attributes::Deprecated, true)
-                    ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
-                ->Event("SetRotationX", &AZ::TransformBus::Events::SetRotationX)
-                    ->Attribute(AZ::Script::Attributes::Deprecated, true)
-                    ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
-                ->Event("SetRotationY", &AZ::TransformBus::Events::SetRotationY)
-                    ->Attribute(AZ::Script::Attributes::Deprecated, true)
-                    ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
-                ->Event("SetRotationZ", &AZ::TransformBus::Events::SetRotationZ)
-                    ->Attribute(AZ::Script::Attributes::Deprecated, true)
-                    ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
-                ->Event("GetEulerRotation", &AZ::TransformBus::Events::GetRotationEulerRadians)
-                    ->Attribute(AZ::Script::Attributes::Deprecated, true)
-                    ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
-                ->Event("GetRotationQuaternion", &AZ::TransformBus::Events::GetRotationQuaternion)
-                    ->Attribute(AZ::Script::Attributes::Deprecated, true)
-                    ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
-                ->Event("GetRotationX", &AZ::TransformBus::Events::GetRotationX)
-                    ->Attribute(AZ::Script::Attributes::Deprecated, true)
-                   ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
-                ->Event("GetRotationY", &AZ::TransformBus::Events::GetRotationY)
-                    ->Attribute(AZ::Script::Attributes::Deprecated, true)
-                    ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
-                ->Event("GetRotationZ", &AZ::TransformBus::Events::GetRotationZ)
-                    ->Attribute(AZ::Script::Attributes::Deprecated, true)
-                    ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
-#endif
-                ->Event("GetWorldRotation", &AZ::TransformBus::Events::GetWorldRotation)
-                ->Event("GetWorldRotationQuaternion", &AZ::TransformBus::Events::GetWorldRotationQuaternion)
-                ->Event("SetLocalRotation", &AZ::TransformBus::Events::SetLocalRotation)
-                ->Event("SetLocalRotationQuaternion", &AZ::TransformBus::Events::SetLocalRotationQuaternion)
-                ->Event("RotateAroundLocalX", &AZ::TransformBus::Events::RotateAroundLocalX)
-                ->Event("RotateAroundLocalY", &AZ::TransformBus::Events::RotateAroundLocalY)
-                ->Event("RotateAroundLocalZ", &AZ::TransformBus::Events::RotateAroundLocalZ)
-                ->Event("GetLocalRotation", &AZ::TransformBus::Events::GetLocalRotation)
-                ->Event("GetLocalRotationQuaternion", &AZ::TransformBus::Events::GetLocalRotationQuaternion)
-                    ->Attribute("Rotation", AZ::Edit::Attributes::PropertyRotation)
-                ->VirtualProperty("Rotation", "GetLocalRotationQuaternion", "SetLocalRotationQuaternion")
-#if 0
-                ->Event("SetScale", &AZ::TransformBus::Events::SetScale)
-                    ->Attribute(AZ::Script::Attributes::Deprecated, true)
-                    ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
-                ->Event("SetScaleX", &AZ::TransformBus::Events::SetScaleX)
-                    ->Attribute(AZ::Script::Attributes::Deprecated, true)
-                    ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
-                ->Event("SetScaleY", &AZ::TransformBus::Events::SetScaleY)
-                    ->Attribute(AZ::Script::Attributes::Deprecated, true)
-                    ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
-                ->Event("SetScaleZ", &AZ::TransformBus::Events::SetScaleZ)
-                    ->Attribute(AZ::Script::Attributes::Deprecated, true)
-                    ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
-                ->Event("GetScale", &AZ::TransformBus::Events::GetScale)
-                    ->Attribute(AZ::Script::Attributes::Deprecated, true)
-                    ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
-                ->Event("GetScaleX", &AZ::TransformBus::Events::GetScaleX)
-                    ->Attribute(AZ::Script::Attributes::Deprecated, true)
-                    ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
-                ->Event("GetScaleY", &AZ::TransformBus::Events::GetScaleY)
-                    ->Attribute(AZ::Script::Attributes::Deprecated, true)
-                    ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
-                ->Event("GetScaleZ", &AZ::TransformBus::Events::GetScaleZ)
-                    ->Attribute(AZ::Script::Attributes::Deprecated, true)
-                    ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
-                ->Event("SetLocalScale", &AZ::TransformBus::Events::SetLocalScale)
-                ->Event("SetLocalScaleX", &AZ::TransformBus::Events::SetLocalScaleX)
-                ->Event("SetLocalScaleY", &AZ::TransformBus::Events::SetLocalScaleY)
-                ->Event("SetLocalScaleZ", &AZ::TransformBus::Events::SetLocalScaleZ)
-                ->VirtualProperty("Scale", "GetLocalScale", "SetLocalScale")
-                ->Event("GetLocalScale", &AZ::TransformBus::Events::GetLocalScale)
-                    ->Attribute("Scale", AZ::Edit::Attributes::PropertyScale)
-#endif
-                ->Event("SetLocalUniformScale", &AZ::TransformBus::Events::SetLocalUniformScale)
-                ->Event("GetLocalUniformScale", &AZ::TransformBus::Events::GetLocalUniformScale)
-                ->VirtualProperty("Uniform Scale", "GetLocalUniformScale", "SetLocalUniformScale")
-#if 0
-                ->Event("GetWorldScale", &AZ::TransformBus::Events::GetWorldScale)
-#endif
-                ->Event("GetWorldUniformScale", &AZ::TransformBus::Events::GetWorldUniformScale)
-                ->Event("GetChildren", &AZ::TransformBus::Events::GetChildren)
-                ->Event("GetAllDescendants", &AZ::TransformBus::Events::GetAllDescendants)
-                ->Event("GetEntityAndAllDescendants", &AZ::TransformBus::Events::GetEntityAndAllDescendants)
-                ->Event("IsStaticTransform", &AZ::TransformBus::Events::IsStaticTransform)
-                ;
-
-            behaviorContext->Constant("TransformComponentTypeId", BehaviorConstant(AZ::TransformComponentTypeId));
-            behaviorContext->Constant("EditorTransformComponentTypeId", BehaviorConstant(AZ::EditorTransformComponentTypeId));
-
-            behaviorContext->Class<AZ::TransformConfig>()
-                ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::Unused)
-                ->Attribute(AZ::Script::Attributes::ConstructorOverride, &AZ::TransformConfigConstructor)
-                ->Enum<(int)AZ::TransformConfig::ParentActivationTransformMode::MaintainOriginalRelativeTransform>("MaintainOriginalRelativeTransform")
-                ->Enum<(int)AZ::TransformConfig::ParentActivationTransformMode::MaintainCurrentWorldTransform>("MaintainCurrentWorldTransform")
-                ->Constructor()
-                ->Constructor<const AZ::Transform&>()
-                ->Method("SetTransform", &AZ::TransformConfig::SetTransform)
-                    ->Attribute(AZ::Script::Attributes::Deprecated, true)
-                    ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
-                ->Method("SetLocalAndWorldTransform", &AZ::TransformConfig::SetLocalAndWorldTransform)
-                    ->Attribute(AZ::Script::Attributes::Deprecated, true)
-                    ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
-                ->Property("worldTransform", BehaviorValueProperty(&AZ::TransformConfig::m_worldTransform))
-                ->Property("localTransform", BehaviorValueProperty(&AZ::TransformConfig::m_localTransform))
-                ->Property("parentId", BehaviorValueProperty(&AZ::TransformConfig::m_parentId))
-                ->Property("parentActivationTransformMode",
-                    [](AZ::TransformConfig* config) { return (int&)(config->m_parentActivationTransformMode); },
-                    [](AZ::TransformConfig* config, const int& i) { config->m_parentActivationTransformMode = (AZ::TransformConfig::ParentActivationTransformMode)i; })
-                ->Property("netSyncEnabled", BehaviorValueProperty(&AZ::TransformConfig::m_netSyncEnabled))
-                ->Property("interpolatePosition",
-                    [](AZ::TransformConfig* config) { return (int&)(config->m_interpolatePosition); },
-                    [](AZ::TransformConfig* config, const int& i) { config->m_interpolatePosition = (AZ::InterpolationMode)i; })
-                ->Property("interpolateRotation",
-                    [](AZ::TransformConfig* config) { return (int&)(config->m_interpolateRotation); },
-                    [](AZ::TransformConfig* config, const int& i) { config->m_interpolateRotation = (AZ::InterpolationMode)i; })
-                ->Property("isStatic", BehaviorValueProperty(&AZ::TransformConfig::m_isStatic))
-                ;
-        }
-
-        NetworkContext* netContext = azrtti_cast<NetworkContext*>(reflection);
-        if (netContext)
-        {
-            netContext->Class<TransformComponent>()
-                ->Chunk<TransformReplicaChunk, TransformReplicaChunk::Descriptor>()
-                    ->Field("ParentId", &TransformReplicaChunk::m_parentId)
-                    ->Field("LocalTranslationData", &TransformReplicaChunk::m_localTranslation)
-                    ->Field("LocalRotationData", &TransformReplicaChunk::m_localRotation)
-                    ->Field("LocalScaleData", &TransformReplicaChunk::m_localScale);
-        }
-    }
-} // namespace AZ
-
-#else
-#include <AzFramework/Components/TransformComponent.h>
-#include <AzFramework/Visibility/EntityBoundsUnionBus.h>
-#include <AzCore/Serialization/EditContext.h>
-#include <AzCore/RTTI/BehaviorContext.h>
-#include <AzCore/Component/Entity.h>
-#include <AzCore/Component/ComponentApplicationBus.h>
-#include <AzCore/Interface/Interface.h>
-#include <AzCore/Math/Transform.h>
-#include <AzCore/Math/Quaternion.h>
-
-namespace AZ
-{
-    class BehaviorTransformNotificationBusHandler
-        : public TransformNotificationBus::Handler
-        , public AZ::BehaviorEBusHandler
-    {
-    public:
-        AZ_EBUS_BEHAVIOR_BINDER
-        (
-            BehaviorTransformNotificationBusHandler,
-            "{9CEF4DAB-F359-4A3E-9856-7780281E0DAA}",
-            AZ::SystemAllocator, 
-            OnTransformChanged, 
-            OnParentChanged, 
-            OnChildAdded, 
-            OnChildRemoved
-        );
-
-        void OnTransformChanged(const Transform& localTM, const Transform& worldTM) override
-        {
-            Call(FN_OnTransformChanged, localTM, worldTM);
-        }
-
-        void OnParentChanged(EntityId oldParent, EntityId newParent) override
-        {
-            Call(FN_OnParentChanged, oldParent, newParent);
-        }
-
-        void OnChildAdded(EntityId child) override
-        {
-            Call(FN_OnChildAdded, child);
-        }
-
-        void OnChildRemoved(EntityId child) override
-        {
-            Call(FN_OnChildRemoved, child);
-        }
-    };
-
-    void TransformConfigConstructor(TransformConfig* self, ScriptDataContext& dc)
-    {
-        const int numArgs = dc.GetNumArguments();
-        if (numArgs == 0)
-        {
-            new(self) TransformConfig();
-        }
-        else if (numArgs == 1 && dc.IsClass<Transform>(0))
-        {
-            Transform transform;
-            dc.ReadArg(0, transform);
-
-            new(self) TransformConfig(transform);
-        }
-        else
-        {
-            dc.GetScriptContext()->Error(AZ::ScriptContext::ErrorType::Error, true, "Invalid constructor call. Valid overrides are: TransformConfig(), TransfomConfig(Transform)");
-
-            new(self) TransformConfig();
-        }
-    }
-} // namespace AZ
-
-namespace AzFramework
-{
-    bool TransformComponentVersionConverter(AZ::SerializeContext& context, AZ::SerializeContext::DataElementNode& classElement)
-    {
-        if (classElement.GetVersion() < 3)
-        {
-            // IsStatic field added at v3.
-            // It should be false for old versions of TransformComponent.
-            classElement.AddElementWithData(context, "IsStatic", false);
-        }
-
-        // note the == on the following line.  Do not add to this block.  If you add an "InterpolateScale" back in, then
-        // consider erasing this block.
-        // The version was bumped from 3 to 4 to ensure this code runs.
-        // if you add the field back in, then increment the version number again.
-        if (classElement.GetVersion() == 3)
-        {
-            // a field was temporarily added to this specific version, then was removed.
-            // However, some data may have been exported with this field present, so 
-            // remove it if its found, but only in this version which the change was present in, so that
-            // future re-additions of it won't remove it (as long as they bump the version number.)
-            classElement.RemoveElementByName(AZ_CRC("InterpolateScale", 0x9d00b831));
-        }
-
-        return true;
-    }
-
-    TransformComponent::TransformComponent(const TransformComponent& copy)
-        : m_localTM(copy.m_localTM)
-        , m_worldTM(copy.m_worldTM)
-        , m_parentId(copy.m_parentId)
-        , m_parentTM(copy.m_parentTM)
-        , m_parentActive(copy.m_parentActive)
-        , m_notificationBus(nullptr)
-        , m_onNewParentKeepWorldTM(copy.m_onNewParentKeepWorldTM)
-        , m_parentActivationTransformMode(copy.m_parentActivationTransformMode)
-        , m_isStatic(copy.m_isStatic)
-    {
-        ;
-    }
-
-    bool TransformComponent::ReadInConfig(const AZ::ComponentConfig* baseConfig)
-    {
-        if (auto config = azrtti_cast<const AZ::TransformConfig*>(baseConfig))
-        {
-            m_localTM = config->m_localTransform;
-            m_worldTM = config->m_worldTransform;
-            m_parentId = config->m_parentId;
-            m_parentActivationTransformMode = config->m_parentActivationTransformMode;
-            m_isStatic = config->m_isStatic;
-            return true;
-        }
-        return false;
-    }
-
-    bool TransformComponent::WriteOutConfig(AZ::ComponentConfig* baseConfig) const
-    {
-        if (auto config = azrtti_cast<AZ::TransformConfig*>(baseConfig))
-        {
-            config->m_localTransform = m_localTM;
-            config->m_worldTransform = m_worldTM;
-            config->m_parentId = m_parentId;
-            config->m_parentActivationTransformMode = m_parentActivationTransformMode;
-            config->m_isStatic = m_isStatic;
-            return true;
-        }
-        return false;
-    }
-
-    void TransformComponent::Activate()
-    {
-        AZ::TransformBus::Handler::BusConnect(m_entity->GetId());
-        AZ::TransformNotificationBus::Bind(m_notificationBus, m_entity->GetId());
 
         const bool keepWorldTm = (m_parentActivationTransformMode == ParentActivationTransformMode::MaintainCurrentWorldTransform || !m_parentId.IsValid());
         SetParentImpl(m_parentId, keepWorldTm);
@@ -1709,6 +377,10 @@ namespace AzFramework
             parentTransform->NotifyChildChangedEvent(AZ::ChildChangeType::Removed, GetEntityId());
         }
 
+#if defined(CARBONATED)
+        UnbindFromNetwork();
+#endif
+
         m_notificationBus = nullptr;
         if (m_parentId.IsValid())
         {
@@ -1739,11 +411,16 @@ namespace AzFramework
         m_childChangedEvent.Signal(changeType, entityId);
     }
 
+
     void TransformComponent::SetLocalTM(const AZ::Transform& tm)
     {
         if (AreMoveRequestsAllowed())
         {
             SetLocalTMImpl(tm);
+
+#if defined(CARBONATED)
+            UpdateReplicaChunk();
+#endif
         }
     }
 
@@ -1752,17 +429,39 @@ namespace AzFramework
         if (AreMoveRequestsAllowed())
         {
             SetWorldTMImpl(tm);
+
+#if defined(CARBONATED)
+            UpdateReplicaChunk();
+#endif
         }
     }
 
     void TransformComponent::SetParent(AZ::EntityId id)
     {
+#if defined(CARBONATED)
+        if (!IsNetworkControlled())
+        {
+            SetParentImpl(id, true);
+
+            UpdateReplicaChunk();
+        }
+#else
         SetParentImpl(id, true);
+#endif
     }
 
     void TransformComponent::SetParentRelative(AZ::EntityId id)
     {
+#if defined(CARBONATED)
+        if (!IsNetworkControlled())
+        {
+            SetParentImpl(id, m_isStatic);
+
+            UpdateReplicaChunk();
+        }
+#else
         SetParentImpl(id, m_isStatic);
+#endif
     }
 
     void TransformComponent::SetWorldTranslation(const AZ::Vector3& newPosition)
@@ -2065,9 +764,13 @@ namespace AzFramework
         {
             m_parentTM = parentEntity->GetTransform();
 
+#if defined(CARBONATED)
+           //Warning keeps going off for statics in layers... so its just noise.
+#else
             AZ_Warning("TransformComponent", !m_isStatic || m_parentTM->IsStaticTransform(),
                 "Entity '%s' %s has static transform, but parent has non-static transform. This may lead to unexpected movement.",
                 GetEntity()->GetName().c_str(), GetEntityId().ToString().c_str());
+#endif
 
             if (m_onNewParentKeepWorldTM)
             {
@@ -2078,15 +781,213 @@ namespace AzFramework
                 ComputeWorldTM();
             }
         }
+
+#if defined(CARBONATED)
+        UpdateReplicaChunk();
+#endif
     }
 
     void TransformComponent::OnEntityDeactivated([[maybe_unused]] const AZ::EntityId& parentEntityId)
     {
+#if defined(CARBONATED)
+        if (!IsNetworkControlled())
+        {
+            AZ_Assert(parentEntityId == m_parentId, "We expect to receive notifications only from the current parent!");
+            m_parentTM = nullptr;
+            m_parentActive = false;
+            ComputeLocalTM();
+            
+            UpdateReplicaChunk();
+        }
+        else
+        {
+            // If this transform is network controlled, then the localTM is updated by the network,
+            // so update m_parentTM and compute worldTM instead.
+            AZ_Assert(parentEntityId == m_parentId, "We expect to receive notifications only from the current parent!");
+            m_parentTM = nullptr;
+            m_parentActive = false;
+            ComputeWorldTM();
+        }
+#else
         AZ_Assert(parentEntityId == m_parentId, "We expect to receive notifications only from the current parent!");
         m_parentTM = nullptr;
         m_parentActive = false;
         ComputeLocalTM();
+#endif
     }
+
+#if defined(CARBONATED)
+    GridMate::ReplicaChunkPtr TransformComponent::GetNetworkBinding()
+    {
+        TransformReplicaChunk* replicaChunk = GridMate::CreateReplicaChunk<TransformReplicaChunk>();
+        replicaChunk->SetHandler(this);
+        m_replicaChunk = replicaChunk;
+
+        UpdateReplicaChunk();
+
+        return m_replicaChunk;
+    }
+
+    void TransformComponent::SetNetworkBinding(GridMate::ReplicaChunkPtr replicaChunk)
+    {
+        AZ_Assert(m_replicaChunk == nullptr, "Being bound to two ReplicaChunks");
+
+        bool isTransformChunk = replicaChunk != nullptr;
+
+        AZ_Assert(isTransformChunk, "Being bound to invalid chunk type");
+        if (isTransformChunk)
+        {
+            replicaChunk->SetHandler(this);
+            m_replicaChunk = replicaChunk;
+
+            TransformReplicaChunk* transformReplicaChunk = static_cast<TransformReplicaChunk*>(m_replicaChunk.get());
+
+            m_parentId = AZ::EntityId(transformReplicaChunk->m_parentId.Get());
+
+            m_worldTM = transformReplicaChunk->m_initialWorldTM;
+            m_localTM = transformReplicaChunk->GetLocalTransform();
+
+            CreateSamples();
+
+            m_netTargetTranslation->SetPreviousValue(
+                transformReplicaChunk->m_localTranslation.Get(),
+                transformReplicaChunk->m_localTranslation.GetLastUpdateTime());
+            m_netTargetTranslation->SetNewTarget(
+                transformReplicaChunk->m_localTranslation.Get(),
+                transformReplicaChunk->m_localTranslation.GetLastUpdateTime());
+            m_netTargetRotation->SetPreviousValue(
+                transformReplicaChunk->m_localRotation.Get(),
+                transformReplicaChunk->m_localRotation.GetLastUpdateTime());
+            m_netTargetRotation->SetNewTarget(
+                transformReplicaChunk->m_localRotation.Get(),
+                transformReplicaChunk->m_localRotation.GetLastUpdateTime());
+            m_netTargetScale = transformReplicaChunk->m_localScale.Get();
+
+            if (HasAnyInterpolation())
+            {
+                // only connect if interpolation was selected for either position or rotation
+                AZ::TickBus::Handler::BusConnect();
+            }
+        }
+
+        m_onNewParentKeepWorldTM = false;
+    }
+
+    void TransformComponent::UnbindFromNetwork()
+    {
+        if (HasAnyInterpolation())
+        {
+            AZ::TickBus::Handler::BusDisconnect();
+        }
+
+        if (m_replicaChunk)
+        {
+            m_replicaChunk->SetHandler(nullptr);
+            m_replicaChunk = nullptr;
+        }
+    }
+
+    void TransformComponent::OnNewNetTransformData(const AZ::Transform& transform, const GridMate::TimeContext& /*tc*/)
+    {
+        SetLocalTMImpl(transform);
+    }
+
+    void TransformComponent::OnNewNetParentData(const AZ::u64& parentId, const GridMate::TimeContext& /*tc*/)
+    {
+        SetParentImpl(AZ::EntityId(parentId), false);
+    }
+
+    bool TransformComponent::IsNetworkControlled() const
+    {
+        if (m_isClientSimulated)
+            return false;
+            
+        return m_replicaChunk && m_replicaChunk->GetReplica() && !m_replicaChunk->IsMaster();
+    }
+
+    void TransformComponent::SetClientSimulated(bool clientSim)
+    {
+        m_isClientSimulated = clientSim;
+    }
+
+    bool TransformComponent::IsPositionInterpolated()
+    {
+        return m_interpolatePosition != AZ::InterpolationMode::NoInterpolation;
+    }
+
+    bool TransformComponent::IsRotationInterpolated()
+    {
+        return m_interpolateRotation != AZ::InterpolationMode::NoInterpolation;
+    }
+
+    bool TransformComponent::HasAnyInterpolation()
+    {
+        return IsPositionInterpolated() || IsRotationInterpolated();
+    }
+
+    void TransformComponent::OnTick(float /*deltaTime*/, AZ::ScriptTimePoint /*currentTime*/)
+    {
+        if (GetEntity() && GetEntity()->GetState() == AZ::Entity::State::Active)
+        {
+            if (IsNetworkControlled())
+            {
+                const unsigned int localTime = m_replicaChunk->GetReplicaManager()->GetTime().m_localTime;
+                const AZ::Transform newXform = GetInterpolatedTransform(localTime);
+                SetLocalTMImpl(newXform);
+            }
+        }
+    }
+
+    AZ::Transform TransformComponent::GetInterpolatedTransform(unsigned localTime)
+    {
+        const AZ::Vector3 newTranslation = m_netTargetTranslation->GetInterpolatedValue(localTime);
+        const AZ::Quaternion newRotation = m_netTargetRotation->GetInterpolatedValue(localTime);
+        AZ::Transform newXform = AZ::Transform::CreateFromQuaternionAndTranslation(newRotation, newTranslation);
+        newXform.MultiplyByUniformScale(m_netTargetScale.GetX()); // local scale is setup as uniform scale
+        AZ_Assert(newXform.IsFinite(), "Interpolated Transform is invalid");
+        return newXform;
+    }
+
+    void TransformComponent::OnNewPositionData(const AZ::Vector3& translation, const GridMate::TimeContext& tc)
+    {
+        AZ_Assert(translation.IsFinite(), "TransformComponent:OnNewPositionData translation is invalid");
+        m_netTargetTranslation->SetNewTarget(translation, tc.m_realTime);
+        if (!HasAnyInterpolation())
+        {
+            unsigned int localTime = m_replicaChunk->GetReplicaManager()->GetTime().m_localTime;
+            AZ::Transform newXform = GetInterpolatedTransform(localTime);
+            SetLocalTMImpl(newXform);
+        }
+    };
+
+    void TransformComponent::OnNewRotationData(const AZ::Quaternion& rotation, const GridMate::TimeContext& tc)
+    {
+        m_netTargetRotation->SetNewTarget(rotation, tc.m_realTime);
+        if (!HasAnyInterpolation())
+        {
+            unsigned int localTime = m_replicaChunk->GetReplicaManager()->GetTime().m_localTime;
+            AZ::Transform newXform = GetInterpolatedTransform(localTime);
+            SetLocalTMImpl(newXform);
+        }
+    }
+
+    void TransformComponent::OnNewScaleData(const AZ::Vector3& scale, const GridMate::TimeContext& /*tc*/)
+    {
+        // no interpolation of scale by design, very unlikely somebody needs it
+        m_netTargetScale = scale;
+    }
+
+    void TransformComponent::UpdateReplicaChunk()
+    {
+        if (!IsNetworkControlled() && m_replicaChunk)
+        {
+            TransformReplicaChunk* transformReplicaChunk = static_cast<TransformReplicaChunk*>(m_replicaChunk.get());
+            transformReplicaChunk->SetInitialTM(GetWorldTM());
+            transformReplicaChunk->SetLocalTM(GetLocalTM());
+            transformReplicaChunk->m_parentId.Set(static_cast<AZ::u64>(GetParentId()));
+        }
+    }
+#endif
 
     void TransformComponent::SetParentImpl(AZ::EntityId parentId, bool isKeepWorldTM)
     {
@@ -2236,6 +1137,13 @@ namespace AzFramework
 
     bool TransformComponent::AreMoveRequestsAllowed() const
     {
+#if defined(CARBONATED)
+        if (IsNetworkControlled())
+        {
+            return false;
+        }
+#endif
+
         // Don't allow static transform to be moved while entity is activated.
         // But do allow a static transform to be moved when the entity is deactivated.
         if (m_isStatic && m_entity && (m_entity->GetState() > AZ::Entity::State::Init))
@@ -2256,20 +1164,29 @@ namespace AzFramework
         AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(reflection);
         if (serializeContext)
         {
+#if defined(CARBONATED)
+            serializeContext->Class<TransformComponent, AZ::Component, NetBindable>()
+                ->Version(5, &TransformComponentVersionConverter)
+#else
             serializeContext->ClassDeprecate("NetBindable", AZ::Uuid("{80206665-D429-4703-B42E-94434F82F381}"));
 
             serializeContext->Class<TransformComponent, AZ::Component>()
                 ->Version(5, &TransformComponentVersionConverter)
+#endif
                 ->Field("Parent", &TransformComponent::m_parentId)
                 ->Field("Transform", &TransformComponent::m_worldTM)
                 ->Field("LocalTransform", &TransformComponent::m_localTM)
                 ->Field("ParentActivationTransformMode", &TransformComponent::m_parentActivationTransformMode)
                 ->Field("IsStatic", &TransformComponent::m_isStatic)
+#if defined(CARBONATED)
+                ->Field("InterpolatePosition", &TransformComponent::m_interpolatePosition)
+                ->Field("InterpolateRotation", &TransformComponent::m_interpolateRotation)
+#endif
                 ;
         }
 
         AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(reflection);
-        if (behaviorContext)
+        if(behaviorContext)
         {
             behaviorContext->EBus<AZ::TransformNotificationBus>("TransformNotificationBus")->
                 Handler<AZ::BehaviorTransformNotificationBusHandler>();
@@ -2357,9 +1274,29 @@ namespace AzFramework
                     [](AZ::TransformConfig* config) { return (int&)(config->m_parentActivationTransformMode); },
                     [](AZ::TransformConfig* config, const int& i) { config->m_parentActivationTransformMode = (AZ::TransformConfig::ParentActivationTransformMode)i; })
                 ->Property("isStatic", BehaviorValueProperty(&AZ::TransformConfig::m_isStatic))
+#if defined(CARBONATED)
+                ->Property("netSyncEnabled", BehaviorValueProperty(&AZ::TransformConfig::m_netSyncEnabled))
+                ->Property("interpolatePosition",
+                    [](AZ::TransformConfig* config) { return (int&)(config->m_interpolatePosition); },
+                    [](AZ::TransformConfig* config, const int& i) { config->m_interpolatePosition = (AZ::InterpolationMode)i; })
+                ->Property("interpolateRotation",
+                    [](AZ::TransformConfig* config) { return (int&)(config->m_interpolateRotation); },
+                    [](AZ::TransformConfig* config, const int& i) { config->m_interpolateRotation = (AZ::InterpolationMode)i; })
+#endif
                 ;
         }
+
+#if defined(CARBONATED)
+        NetworkContext* netContext = azrtti_cast<NetworkContext*>(reflection);
+        if (netContext)
+        {
+            netContext->Class<TransformComponent>()
+                ->Chunk<TransformReplicaChunk, TransformReplicaChunk::Descriptor>()
+                    ->Field("ParentId", &TransformReplicaChunk::m_parentId)
+                    ->Field("LocalTranslationData", &TransformReplicaChunk::m_localTranslation)
+                    ->Field("LocalRotationData", &TransformReplicaChunk::m_localRotation)
+                    ->Field("LocalScaleData", &TransformReplicaChunk::m_localScale);
+        }
+#endif
     }
 } // namespace AZ
-
-#endif

--- a/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.h
+++ b/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.h
@@ -8,13 +8,15 @@
 
 #pragma once
 
-#if defined(CARBONATED)
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/TransformBus.h>
 #include <AzCore/Component/EntityBus.h>
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/EBus/Event.h>
+
+#if defined(CARBONATED)
 #include <AzFramework/Network/NetBindable.h>
+#endif
 
 namespace AzToolsFramework
 {
@@ -26,325 +28,10 @@ namespace AzToolsFramework
 
 namespace AzFramework
 {
+#if defined(CARBONATED)
     class TransformReplicaChunk;
-    class GameEntityContextComponent;
-
-    /// @deprecated Use AZ::TransformConfig
-    using TransformComponentConfiguration = AZ::TransformConfig;
-
-    /**
-    * Fundamental component that describes the entity in 3D space.
-    * It is net-bindable. Only local transform is synchronized,
-    * so when parented, it relies on the parent properly synchronizing
-    * his transform as well.
-    */
-    class TransformComponent
-        : public AZ::Component
-        , public AZ::TransformBus::Handler
-        , public AZ::TransformNotificationBus::Handler
-        , public AZ::EntityBus::Handler
-        , public AZ::TickBus::Handler
-        , private AZ::TransformHierarchyInformationBus::Handler
-        , public NetBindable
-    {
-        friend class TransformReplicaChunk;
-
-    public:
-        AZ_COMPONENT(TransformComponent, AZ::TransformComponentTypeId, NetBindable, AZ::TransformInterface);
-
-        friend class AzToolsFramework::Components::TransformComponent;
-
-        using ParentActivationTransformMode = AZ::TransformConfig::ParentActivationTransformMode;
-
-        TransformComponent();
-        TransformComponent(const TransformComponent& copy);
-        virtual ~TransformComponent();
-
-        //////////////////////////////////////////////////////////////////////////
-        // TransformBus events (publicly accessible)
-        void BindTransformChangedEventHandler(AZ::TransformChangedEvent::Handler& handler) override;
-        void BindParentChangedEventHandler(AZ::ParentChangedEvent::Handler& handler) override;
-        void BindChildChangedEventHandler(AZ::ChildChangedEvent::Handler& handler) override;
-        void NotifyChildChangedEvent(AZ::ChildChangeType changeType, AZ::EntityId entityId) override;
-
-        /// Returns true if the tm was set to the local transform
-        const AZ::Transform& GetLocalTM() override { return m_localTM; }
-        /// Returns true if the tm was set to the world transform
-        const AZ::Transform& GetWorldTM() override { return m_worldTM; }
-        /// Returns both local and world transforms.
-        void GetLocalAndWorld(AZ::Transform& localTM, AZ::Transform& worldTM) override { localTM = m_localTM; worldTM = m_worldTM; }
-        /// Returns parent EntityID or
-        AZ::EntityId  GetParentId() override { return m_parentId; }
-        /// Returns parent interface if available
-        AZ::TransformInterface* GetParent() override { return m_parentTM; }
-        /// Sets the local transform and notifies all interested parties
-        void SetLocalTM(const AZ::Transform& tm) override;
-        /// Sets the world transform and notifies all interested parties
-        void SetWorldTM(const AZ::Transform& tm) override;
-        /// Set parent entity and notifies all interested parties. The object localTM will be moved into
-        /// parent space so we will prerse the same worldTM.
-        void SetParent(AZ::EntityId id) override;
-        /// Set the parent entity and notifies all interested parties. The will use worldTM as an
-        /// a localTM and move the transform relative to the parent.
-        void SetParentRelative(AZ::EntityId id) override;
-
-        // Scale modifiers
-        // Get local scale as vector (deprecated)
-        // AZ::Vector3 GetLocalScale() override;    // Gruber patch. GetLocalScale is deprecated. Use GetLocalUniformScale
-        // Set the uniform scale value in local space.
-        void SetLocalUniformScale([[maybe_unused]] float scale) override;
-        // Get the uniform scale value in local space.
-        float GetLocalUniformScale() override;
-        // Get the uniform scale value in world space.
-        float GetWorldUniformScale() override;
-
-#if defined(CARBONATED)
-        //Ignore network updates... currently
-        void SetClientSimulated(bool clientSim) override;
-#endif
-        //////////////////////////////////////////////////////////////////////////
-
-    protected:
-        //////////////////////////////////////////////////////////////////////////
-        // Component
-        void Activate() override;
-        void Deactivate() override;
-        bool ReadInConfig(const AZ::ComponentConfig* baseConfig) override;
-        bool WriteOutConfig(AZ::ComponentConfig* outBaseConfig) const override;
-        //////////////////////////////////////////////////////////////////////////
-
-        //////////////////////////////////////////////////////////////////////////
-        // Translation modifiers
-
-        void SetWorldTranslation(const AZ::Vector3& newPosition) override;
-        void SetLocalTranslation(const AZ::Vector3& newPosition) override;
-
-        AZ::Vector3 GetWorldTranslation() override;
-        AZ::Vector3 GetLocalTranslation() override;
-
-        void MoveEntity(const AZ::Vector3& offset) override;
-
-        void SetWorldX(float x) override;
-        void SetWorldY(float y) override;
-        void SetWorldZ(float z) override;
-
-        float GetWorldX() override;
-        float GetWorldY() override;
-        float GetWorldZ() override;
-
-        void SetLocalX(float x) override;
-        void SetLocalY(float y) override;
-        void SetLocalZ(float z) override;
-
-        float GetLocalX() override;
-        float GetLocalY() override;
-        float GetLocalZ() override;
-
-        bool IsPositionInterpolated();
-        //////////////////////////////////////////////////////////////////////////
-#if 0
-        //////////////////////////////////////////////////////////////////////////
-        // Rotation modifiers
-        void SetRotation(const AZ::Vector3& eulerAnglesRadian) override;
-        void SetRotationQuaternion(const AZ::Quaternion& quaternion) override;
-        void SetRotationX(float eulerAngleRadian) override;
-        void SetRotationY(float eulerAngleRadian) override;
-        void SetRotationZ(float eulerAngleRadian) override;
-
-        void RotateByX(float eulerAngleRadian) override;
-        void RotateByY(float eulerAngleRadian) override;
-        void RotateByZ(float eulerAngleRadian) override;
-
-        AZ::Vector3 GetRotationEulerRadians() override;
-        AZ::Quaternion GetRotationQuaternion() override;
-
-        float GetRotationX() override;
-        float GetRotationY() override;
-        float GetRotationZ() override;
 #endif
 
-        AZ::Vector3 GetWorldRotation() override;
-        AZ::Quaternion GetWorldRotationQuaternion() override;
-
-        void SetLocalRotation(const AZ::Vector3& eulerAnglesRadian) override;
-        void SetLocalRotationQuaternion(const AZ::Quaternion& quaternion) override;
-
-        void RotateAroundLocalX(float eulerAngleRadian) override;
-        void RotateAroundLocalY(float eulerAngleRadian) override;
-        void RotateAroundLocalZ(float eulerAngleRadian) override;
-
-        AZ::Vector3 GetLocalRotation() override;
-        AZ::Quaternion GetLocalRotationQuaternion() override;
-
-        bool IsRotationInterpolated();
-        //////////////////////////////////////////////////////////////////////////
-#if 0
-        //////////////////////////////////////////////////////////////////////////
-        // Scale Modifiers
-
-        void SetScale(const AZ::Vector3& scale) override;
-        void SetScaleX(float scaleX) override;
-        void SetScaleY(float scaleY) override;
-        void SetScaleZ(float scaleZ) override;
-
-        AZ::Vector3 GetScale() override;
-        float GetScaleX() override;
-        float GetScaleY() override;
-        float GetScaleZ() override;
-        
-        void SetLocalScaleX(float scaleX) override;
-        void SetLocalScaleY(float scaleY) override;
-        void SetLocalScaleZ(float scaleZ) override;
-
-        AZ::Vector3 GetLocalScale() override;
-        AZ::Vector3 GetWorldScale() override;
-        void SetLocalScale(const AZ::Vector3& scale) override;
-#endif
-        //////////////////////////////////////////////////////////////////////////
-
-        AZStd::vector<AZ::EntityId> GetChildren() override;
-        AZStd::vector<AZ::EntityId> GetAllDescendants() override;
-        AZStd::vector<AZ::EntityId> GetEntityAndAllDescendants() override;
-        bool IsStaticTransform() override;
-        //////////////////////////////////////////////////////////////////////////
-
-        //////////////////////////////////////////////////////////////////////////
-        //////////////////////////////////////////////////////////////////////////
-        // Parent support
-
-        //////////////////////////////////////////////////////////////////////////
-        // TransformNotificationBus - for parent entity
-        /// Called when the world transform of its parent changed
-        void OnTransformChanged(const AZ::Transform& parentLocalTM, const AZ::Transform& parentWorldTM) override;
-        //////////////////////////////////////////////////////////////////////////
-
-        //////////////////////////////////////////////////////////////////////////
-        // EntityBus
-        /// Called when the parent entity activates
-        void OnEntityActivated(const AZ::EntityId& parentEntityId) override;
-        /// Called when the parent entity deactivates
-        void OnEntityDeactivated(const AZ::EntityId& parentEntityId) override;
-        //////////////////////////////////////////////////////////////////////////
-
-        // End of parent support
-        //////////////////////////////////////////////////////////////////////////
-        //////////////////////////////////////////////////////////////////////////
-
-        //////////////////////////////////////////////////////////////////////////
-        // NetBindable
-        GridMate::ReplicaChunkPtr GetNetworkBinding() override;
-        void SetNetworkBinding(GridMate::ReplicaChunkPtr chunk) override;
-        void UnbindFromNetwork() override;
-
-        //! Called by the net chunk when new transform data arrives from the network.
-        void OnNewNetTransformData(const AZ::Transform& transform, const GridMate::TimeContext& tc);
-
-        //! Called by the net chunk when new parent id arrives from the network.
-        void OnNewNetParentData(const AZ::u64& parentId, const GridMate::TimeContext& tc);
-
-        //! Returns true if this instance is non-authoritative.
-        bool    IsNetworkControlled() const;
-
-        //! Triggers an update of the chunk data. Should only be called on the authoritative instance.
-        void    UpdateReplicaChunk();
-        // End of NetBindable
-        //////////////////////////////////////////////////////////////////////////
-
-        //////////////////////////////////////////////////////////////////////////
-        // AZ::TickBus
-        void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
-        //////////////////////////////////////////////////////////////////////////
-
-        //////////////////////////////////////////////////////////////////////////
-        // Actual Implementation Functions
-        // They are protected so we can gate them when network-controlled
-        void SetParentImpl(AZ::EntityId parentId, bool isKeepWorldTM);
-        void SetLocalTMImpl(const AZ::Transform& tm);
-        void SetWorldTMImpl(const AZ::Transform& tm);
-        void OnTransformChangedImpl(const AZ::Transform& parentLocalTM, const AZ::Transform& parentWorldTM);
-        void OnEntityActivatedImpl(const AZ::EntityId& parentEntityId);
-        void OnEntityDeactivateImpl(const AZ::EntityId& parentEntityId);
-        void ComputeLocalTM();
-        void ComputeWorldTM();
-        //////////////////////////////////////////////////////////////////////////
-
-        //! Returns whether external calls are currently allowed to move the transform.
-        bool AreMoveRequestsAllowed() const;
-
-        /// \ref ComponentDescriptor::GetProvidedServices
-        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
-
-        /// \red ComponentDescriptor::Reflect
-        static void Reflect(AZ::ReflectContext* reflection);
-
-        AZ::TransformChangedEvent m_transformChangedEvent; ///< Event used to signal when a transform changes.
-        AZ::ParentChangedEvent m_parentChangedEvent; ///< Event used to signal when a transforms parent changes.
-        AZ::ChildChangedEvent m_childChangedEvent; ///< Event used to signal when a transform has a child entity added or removed.
-
-        AZ::Transform                           m_localTM;                  ///< Local transform relative to parent transform (same as worldTM if no parent)
-        AZ::Transform                           m_worldTM;                  ///< World transform including parent transform (same as localTM if no parent)
-        AZ::EntityId                            m_parentId;                 ///< If valid, this transform is parented to m_parentId.
-        AZ::TransformInterface*                 m_parentTM;                 ///< Cached - pointer to parent transform, to avoid extra calls. Valid only when if it's present
-        bool                                    m_parentActive;             ///< Keeps track of the state of the parent entity
-        AZ::TransformNotificationBus::BusPtr    m_notificationBus;          ///< Cached bus pointer to the notification bus.
-        bool                                    m_onNewParentKeepWorldTM;   ///< If set, recompute localTM instead of worldTM when parent becomes active.
-        ParentActivationTransformMode           m_parentActivationTransformMode;
-        GridMate::ReplicaChunkPtr               m_replicaChunk;
-        bool                                    m_isStatic;                 ///< If true, the transform is static and doesn't move while entity is active.
-        AZ::InterpolationMode                   m_interpolatePosition;      ///< Interpolation mode for net-synced position updates
-        AZ::InterpolationMode                   m_interpolateRotation;      ///< Interpolation mode for net-synced rotation updates
-
-#if defined(CARBONATED)
-        bool m_isClientSimulated;
-#endif  
-
-        //////////////////////////////////////////////////////////////////////////
-        // TransformHierarchyInformationBus
-        void GatherChildren(AZStd::vector<AZ::EntityId>& children) override;
-        //////////////////////////////////////////////////////////////////////////
-
-        //////////////////////////////////////////////////////////////////////////////
-        // Feedback from corresponding replica chunk
-        void OnNewPositionData(const AZ::Vector3&, const GridMate::TimeContext&);
-        void OnNewRotationData(const AZ::Quaternion&, const GridMate::TimeContext&);
-        void OnNewScaleData(const AZ::Vector3&, const GridMate::TimeContext&);
-        //////////////////////////////////////////////////////////////////////////////
-
-    private:
-
-        //////////////////////////////////////////////////////////////////////////////
-        bool HasAnyInterpolation();
-
-        void CreateSamples();
-        void CreateTranslationSample();
-        void CreateRotationSample();
-
-        AZStd::unique_ptr<AZ::Sample<AZ::Vector3>>    m_netTargetTranslation;
-        AZStd::unique_ptr<AZ::Sample<AZ::Quaternion>> m_netTargetRotation;
-        AZ::Vector3 m_netTargetScale;
-
-        AZ::Transform GetInterpolatedTransform(unsigned int localTime);
-        //////////////////////////////////////////////////////////////////////////////
-    };
-}   // namespace AZ
-
-#else
-#include <AzCore/Component/Component.h>
-#include <AzCore/Component/TransformBus.h>
-#include <AzCore/Component/EntityBus.h>
-#include <AzCore/Component/TickBus.h>
-#include <AzCore/EBus/Event.h>
-
-namespace AzToolsFramework
-{
-    namespace Components
-    {
-        class TransformComponent;
-    }
-}
-
-namespace AzFramework
-{
     class GameEntityContextComponent;
 
     /// @deprecated Use AZ::TransformConfig
@@ -357,9 +44,21 @@ namespace AzFramework
         , public AZ::TransformBus::Handler
         , public AZ::TransformNotificationBus::Handler
         , private AZ::TransformHierarchyInformationBus::Handler
+#if defined(CARBONATED)
+        , public AZ::TickBus::Handler
+        , public NetBindable
+#endif
     {
+#if defined(CARBONATED)
+        friend class TransformReplicaChunk;
+#endif
+
     public:
+#if defined(CARBONATED)
+        AZ_COMPONENT(TransformComponent, AZ::TransformComponentTypeId, NetBindable, AZ::TransformInterface);
+#else
         AZ_COMPONENT(TransformComponent, AZ::TransformComponentTypeId, AZ::TransformInterface);
+#endif
 
         friend class AzToolsFramework::Components::TransformComponent;
 
@@ -511,7 +210,71 @@ namespace AzFramework
         bool m_isStatic = false; ///< If true, the transform is static and doesn't move while entity is active.
         /// Behavior for this entity's transform when its parent's transform changes.
         AZ::OnParentChangedBehavior m_onParentChangedBehavior = AZ::OnParentChangedBehavior::Update;
+
+#if defined(CARBONATED)
+    public:
+        //Ignore network updates... currently
+        void SetClientSimulated(bool clientSim) override;
+
+    protected:
+        bool IsPositionInterpolated();
+        bool IsRotationInterpolated();
+        
+        void OnEntityActivatedImpl(const AZ::EntityId& parentEntityId);
+
+        //////////////////////////////////////////////////////////////////////////
+        // NetBindable
+        GridMate::ReplicaChunkPtr GetNetworkBinding() override;
+        void SetNetworkBinding(GridMate::ReplicaChunkPtr chunk) override;
+        void UnbindFromNetwork() override;
+
+        //! Called by the net chunk when new transform data arrives from the network.
+        void OnNewNetTransformData(const AZ::Transform& transform, const GridMate::TimeContext& tc);
+
+        //! Called by the net chunk when new parent id arrives from the network.
+        void OnNewNetParentData(const AZ::u64& parentId, const GridMate::TimeContext& tc);
+
+        //! Returns true if this instance is non-authoritative.
+        bool    IsNetworkControlled() const;
+
+        //! Triggers an update of the chunk data. Should only be called on the authoritative instance.
+        void    UpdateReplicaChunk();
+        // End of NetBindable
+        //////////////////////////////////////////////////////////////////////////
+
+        //////////////////////////////////////////////////////////////////////////
+        // AZ::TickBus
+        void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
+        //////////////////////////////////////////////////////////////////////////
+        
+        GridMate::ReplicaChunkPtr               m_replicaChunk;
+        AZ::InterpolationMode                   m_interpolatePosition;      ///< Interpolation mode for net-synced position updates
+        AZ::InterpolationMode                   m_interpolateRotation;      ///< Interpolation mode for net-synced rotation updates
+
+        bool m_isClientSimulated;
+        //////////////////////////////////////////////////////////////////////////////
+        // Feedback from corresponding replica chunk
+        void OnNewPositionData(const AZ::Vector3&, const GridMate::TimeContext&);
+        void OnNewRotationData(const AZ::Quaternion&, const GridMate::TimeContext&);
+        void OnNewScaleData(const AZ::Vector3&, const GridMate::TimeContext&);
+        //////////////////////////////////////////////////////////////////////////////
+
+    private:
+
+        //////////////////////////////////////////////////////////////////////////////
+        bool HasAnyInterpolation();
+
+        void CreateTranslationSample();
+        void CreateRotationSample();
+        void CreateSamples();
+
+        AZStd::unique_ptr<AZ::Sample<AZ::Vector3>>    m_netTargetTranslation;
+        AZStd::unique_ptr<AZ::Sample<AZ::Quaternion>> m_netTargetRotation;
+        AZ::Vector3 m_netTargetScale;
+
+        AZ::Transform GetInterpolatedTransform(unsigned int localTime);
+        //////////////////////////////////////////////////////////////////////////////
+#endif  
+
     };
 }   // namespace AZ
-
-#endif

--- a/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.h
+++ b/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.h
@@ -251,13 +251,14 @@ namespace AzFramework
         AZ::InterpolationMode                   m_interpolatePosition;      ///< Interpolation mode for net-synced position updates
         AZ::InterpolationMode                   m_interpolateRotation;      ///< Interpolation mode for net-synced rotation updates
 
-        bool m_isClientSimulated;
         //////////////////////////////////////////////////////////////////////////////
         // Feedback from corresponding replica chunk
         void OnNewPositionData(const AZ::Vector3&, const GridMate::TimeContext&);
         void OnNewRotationData(const AZ::Quaternion&, const GridMate::TimeContext&);
         void OnNewScaleData(const AZ::Vector3&, const GridMate::TimeContext&);
         //////////////////////////////////////////////////////////////////////////////
+
+        AZ::Transform GetInterpolatedTransform(unsigned int localTime);
 
     private:
 
@@ -268,11 +269,13 @@ namespace AzFramework
         void CreateRotationSample();
         void CreateSamples();
 
+    private:
+
+        bool m_isClientSimulated = false;
+
         AZStd::unique_ptr<AZ::Sample<AZ::Vector3>>    m_netTargetTranslation;
         AZStd::unique_ptr<AZ::Sample<AZ::Quaternion>> m_netTargetRotation;
         AZ::Vector3 m_netTargetScale;
-
-        AZ::Transform GetInterpolatedTransform(unsigned int localTime);
         //////////////////////////////////////////////////////////////////////////////
 #endif  
 


### PR DESCRIPTION
## What does this PR do?

Removes the giant #if carbonated block, and adds the specific changes to the tx component in.  Better for compatibility changes from o3de

## How was this PR tested?

On PC, editor - making sure the game still runs (since it depends on the netbinding component)

## Notes

Not to be merged in until after sept
