### PR TITLE
Fix UI compressed preset for Android to be on par with iOS

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/UserInterface_Compressed.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/UserInterface_Compressed.preset
@@ -16,7 +16,7 @@
                 "UUID": "{2828FBFE-BDF9-45A7-9370-F93822719CCF}",
                 "Name": "UserInterface_Compressed",
                 "SuppressEngineReduce": true,
-                "PixelFormat": "ASTC_4x4",
+                "PixelFormat": "ASTC_6x6",
                 "SourceColor": "sRGB",
                 "DestColor": "sRGB"
             },


### PR DESCRIPTION
## What does this PR do?

Change Android compressed UI preset to be on par with iOS. There was a bug in early o3de: everything other than 4x4 did not work on Android. I guess 4x4 is that bug legacy.

## How was this PR tested?
No testing on Android, build is in progress. but the change is trivial.
