### PR TITLE
Aefimov/mad 16337 highlight optimization

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR.materialtype
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR.materialtype
@@ -1,6 +1,6 @@
 {
     "description": "Material Type with properties used to define Standard PBR, a metallic-roughness Physically-Based Rendering (PBR) material shading model.",
-    "version": 5,
+    "version": 6,
     "versionUpdates": [
         {
             "toVersion": 4,
@@ -59,6 +59,9 @@
             },
             { 
                 "$import": "MaterialInputs/GeneralCommonPropertyGroup.json"
+            },
+            {
+                "$import": "MaterialInputs/SilhouetteBlockerPropertyGroup.json"
             }
         ]
     },

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Silhouette/Silhouette.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Silhouette/Silhouette.azsl
@@ -29,6 +29,17 @@ PSOutput MainPS(VSOutput IN, in uint sampleIndex : SV_SampleIndex)
 {
     PSOutput OUT;
 
+    real4 pixelSample = PassSrg::m_silhouettes.Load(IN.m_position.xy, sampleIndex);
+
+    // CARBONATED
+
+    if(pixelSample.a == 0.0)
+    {
+        discard;
+    }
+
+    // ELSE (this code piece makes outlines from silhouettes based on alpha-channel, we form outline a different way with variable alpha support
+    /*
     const int NUM_SAMPLES = 7;
     const real outline_opacity = 0.7;
     const real2 Silhouette_Width = 3.0;
@@ -48,7 +59,6 @@ PSOutput MainPS(VSOutput IN, in uint sampleIndex : SV_SampleIndex)
     PassSrg::m_silhouettes.GetDimensions(width, height, samples);
     real2 scale = Silhouette_Width;
 
-    real4 pixelSample = PassSrg::m_silhouettes.Load(IN.m_position.xy, sampleIndex);
     if(dot(pixelSample.xyz, pixelSample.xyz) > 0.0)
     {
         // this is a silhouette pixel
@@ -64,7 +74,7 @@ PSOutput MainPS(VSOutput IN, in uint sampleIndex : SV_SampleIndex)
             real4 sampleColor = PassSrg::m_silhouettes.Load(IN.m_position.xy + offset, sampleIndex);
             pixelSample = max(pixelSample, sampleColor);
         }
-
+        
         if(pixelSample.a == 0.0)
         {
             discard;
@@ -72,7 +82,8 @@ PSOutput MainPS(VSOutput IN, in uint sampleIndex : SV_SampleIndex)
 
         pixelSample.a = outline_opacity * step(0.001, pixelSample.a);
     }
-
+    */
+    
     OUT.m_color = pixelSample;
 
     return OUT;

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Silhouette/SilhouetteGather.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Silhouette/SilhouetteGather.shader
@@ -24,7 +24,7 @@
     },
     "DrawList": "silhouette",
     "RasterState": { 
-        "CullMode": "Front"
+        "CullMode": "Back"
     },
 
     "GlobalTargetBlendState": {

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
@@ -38,7 +38,11 @@ namespace AZ
         {
             AssetBuilderSDK::AssetBuilderDesc materialBuilderDescriptor;
             materialBuilderDescriptor.m_name = JobKey;
+#if defined(CARBONATED)
+            materialBuilderDescriptor.m_version = 143; // add silhouette blocker to StandardPBR
+#else
             materialBuilderDescriptor.m_version = 142; // Add support for small SRGs
+#endif
             materialBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern("*.material", AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
             materialBuilderDescriptor.m_busId = azrtti_typeid<MaterialBuilder>();
             materialBuilderDescriptor.m_createJobFunction = AZStd::bind(&MaterialBuilder::CreateJobs, this, AZStd::placeholders::_1, AZStd::placeholders::_2);

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
@@ -38,11 +38,11 @@ namespace AZ
         {
             AssetBuilderSDK::AssetBuilderDesc materialBuilderDescriptor;
             materialBuilderDescriptor.m_name = JobKey;
-#if defined(CARBONATED)
+//#if defined(CARBONATED)
             materialBuilderDescriptor.m_version = 143; // add silhouette blocker to StandardPBR
-#else
-            materialBuilderDescriptor.m_version = 142; // Add support for small SRGs
-#endif
+//#else
+            //materialBuilderDescriptor.m_version = 142; // Add support for small SRGs
+//#endif
             materialBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern("*.material", AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
             materialBuilderDescriptor.m_busId = azrtti_typeid<MaterialBuilder>();
             materialBuilderDescriptor.m_createJobFunction = AZStd::bind(&MaterialBuilder::CreateJobs, this, AZStd::placeholders::_1, AZStd::placeholders::_2);

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
@@ -38,11 +38,11 @@ namespace AZ
         {
             AssetBuilderSDK::AssetBuilderDesc materialBuilderDescriptor;
             materialBuilderDescriptor.m_name = JobKey;
-//#if defined(CARBONATED)
+#if defined(CARBONATED)
             materialBuilderDescriptor.m_version = 143; // add silhouette blocker to StandardPBR
-//#else
-            //materialBuilderDescriptor.m_version = 142; // Add support for small SRGs
-//#endif
+#else
+            materialBuilderDescriptor.m_version = 142; // Add support for small SRGs
+#endif
             materialBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern("*.material", AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
             materialBuilderDescriptor.m_busId = azrtti_typeid<MaterialBuilder>();
             materialBuilderDescriptor.m_createJobFunction = AZStd::bind(&MaterialBuilder::CreateJobs, this, AZStd::placeholders::_1, AZStd::placeholders::_2);

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
@@ -44,7 +44,11 @@ namespace AZ
         {
             AssetBuilderSDK::AssetBuilderDesc materialBuilderDescriptor;
             materialBuilderDescriptor.m_name = "Material Type Builder";
+#if defined(CARBONATED)
+            materialBuilderDescriptor.m_version = 52; // add silhouette blocker to StandardPBR
+#else
             materialBuilderDescriptor.m_version = 51; // Add support for small SRGs
+#endif
             materialBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern("*.materialtype", AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
             materialBuilderDescriptor.m_busId = azrtti_typeid<MaterialTypeBuilder>();
             materialBuilderDescriptor.m_createJobFunction = AZStd::bind(&MaterialTypeBuilder::CreateJobs, this, AZStd::placeholders::_1, AZStd::placeholders::_2);


### PR DESCRIPTION
## What does this PR do?

Add silhouette blocker property group to StandardPBR material type.
Change the outline drawing, use silhouette blocker flag instead of shader code outline.
This allows to avoid front face culling and so some visual glitches.

## How was this PR tested?

Tests on locally built standalone Windows and iOS clients.
