### PR TITLE
[MAD-15948] Fixed Motion loader

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionSet.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionSet.cpp
@@ -154,7 +154,11 @@ namespace EMotionFX
         , m_dirtyFlag(false)
     {
         m_id                 = aznumeric_caster(MCore::GetIDGenerator().GenerateID());
+#if defined (CARBONATED)
+        m_callback           = nullptr; // do not use MotionSetCallback as default loader callback class due to it does not work with platforms (e.g. with iOS)
+#else
         m_callback           = aznew MotionSetCallback(this);
+#endif
 
 #if defined(EMFX_DEVELOPMENT_BUILD)
         m_isOwnedByRuntime   = false;
@@ -523,7 +527,11 @@ namespace EMotionFX
         Motion* motion = entry->GetMotion();
 
         // If loading on demand is enabled and the motion hasn't loaded yet.
+#if defined (CARBONATED)
+        if (!motion && !entry->GetFilenameString().empty() && !entry->GetLoadingFailed() && m_callback) // ... and desired loader callback has been assigned
+#else
         if (!motion && !entry->GetFilenameString().empty() && !entry->GetLoadingFailed())
+#endif
         {
             motion = m_callback->LoadMotion(entry);
 

--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionSet.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionSet.cpp
@@ -74,11 +74,7 @@ namespace EMotionFX
 
     MotionSet::MotionEntry::MotionEntry()
         : m_motion(nullptr)
-#if defined (CARBONATED)
-        , m_loadAttempts(MaxAttemptsToLoad)
-#else
         , m_loadFailed(false)
-#endif
     {
     }
 
@@ -87,11 +83,7 @@ namespace EMotionFX
         : m_id(motionId)
         , m_filename(fileName)
         , m_motion(motion)
-#if defined (CARBONATED)
-        , m_loadAttempts(MaxAttemptsToLoad)
-#else
         , m_loadFailed(false)
-#endif
     {
     }
 
@@ -450,12 +442,6 @@ namespace EMotionFX
         }
 
         Motion* motion = entry->GetMotion();
-#if defined (CARBONATED)
-        if (!motion && !entry->GetLoadingFailed())
-        {
-            loadOnDemand = true;
-        }
-#endif
         if (loadOnDemand)
         {
             motion = LoadMotion(entry);
@@ -546,7 +532,7 @@ namespace EMotionFX
             {
                 entry->SetLoadingFailed(true);
 #if defined (CARBONATED)
-                AZ_Printf("EMotionFX", "Failed to load motion '%s' for motion set '%s'. Attempts left: %i", entry->GetFilename(), GetName(), entry->GetLoadAttempts());
+                AZ_Printf("EMotionFX", "Failed to load motion '%s' for motion set '%s'.", entry->GetFilename(), GetName());
 #endif
             }
 #if defined (CARBONATED)

--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionSet.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionSet.h
@@ -92,23 +92,14 @@ namespace EMotionFX
              * It is possible that the motion pointer is nullptr, but that this was because loading failed, rather than not having tried to load before.
              * @result Returns true when loading failed before, otherwise false is returned.
              */
-#if defined (CARBONATED)
-            bool GetLoadingFailed() const { return m_loadAttempts <= 0; }
-#else
             bool GetLoadingFailed() const                                                                       { return m_loadFailed; }
-#endif
 
             /**
              * Set the flag that specifies whether loading failed or not.
              * This flag is used to skip trying to reload the motion on demand when it is nullptr and failed to load before.
              * @param failed Set to true to skip trying to reload on demand again.
              */
-#if defined (CARBONATED)            
-            void SetLoadingFailed(bool failed) { m_loadAttempts = static_cast<int8_t>(failed ? std::max(m_loadAttempts - 1, 0) : MaxAttemptsToLoad); }
-            int8_t GetLoadAttempts() { return m_loadAttempts; }
-#else
             void SetLoadingFailed(bool failed)                                                                  { m_loadFailed = failed; }
-#endif
 
             /**
              * Reset the entry motion so that it will reload it next time automatically.
@@ -133,12 +124,7 @@ namespace EMotionFX
             AZStd::string   m_filename;     /**< The local filename of the motion. */
             AZStd::string   m_id;           /**< The motion name. */
             Motion*         m_motion;       /**< A pointer to the motion. */
-#if defined (CARBONATED)
-            static constexpr int8_t MaxAttemptsToLoad = 100;
-            int8_t          m_loadAttempts;
-#else
             bool            m_loadFailed;   /**< Did the last load attempt fail? */
-#endif
 
             void SetId(const AZStd::string& id);
         };


### PR DESCRIPTION
Ticket: MAD-15948

## What does this PR do?

Changes:
- Removed retry stuff workaround from PRs 305 & 312 (reverted back to original code)
- Do not use MotionSetCallback class as default loader because it does not work with platforms (e.g. with iOS)
- Waiting while asset loader  is initialized

## How was this PR tested?

Verified locally on PC, on iOS Jenkins build 27572
