### PR TITLE
Fix Projected shadow for simple spotlights on Metal

### DIFF
--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Conversions.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Conversions.cpp
@@ -241,13 +241,13 @@ namespace AZ
             return usageFlags;
         }
         
-        MTLTextureType ConvertTextureType(RHI::ImageDimension dimension, int arraySize, bool isCubeMap)
+        MTLTextureType ConvertTextureType(RHI::ImageDimension dimension, int arraySize, bool isCubeMap, bool isViewArray)
         {
             if(isCubeMap)
             {
                 AZ_Assert(arraySize % RHI::ImageDescriptor::NumCubeMapSlices == 0, "Incorrect array layers for Cube or CubeArray.");
                 int numCubeMaps = arraySize / RHI::ImageDescriptor::NumCubeMapSlices;
-                if(numCubeMaps>1)
+                if(numCubeMaps>1 || isViewArray)
                 {
                     return MTLTextureTypeCubeArray;
                 }
@@ -260,7 +260,7 @@ namespace AZ
             {
                 case RHI::ImageDimension::Image1D:
                 {
-                    if(arraySize>1)
+                    if(arraySize>1 || isViewArray)
                     {
                         return MTLTextureType1DArray;
                     }
@@ -271,7 +271,7 @@ namespace AZ
                 }
                 case RHI::ImageDimension::Image2D:
                 {
-                    if(arraySize>1)
+                    if(arraySize>1 || isViewArray)
                     {
                         return MTLTextureType2DArray;
                     }
@@ -293,6 +293,14 @@ namespace AZ
             }
         }
         
+        bool IsTextureTypeAnArray(MTLTextureType textureType)
+        {
+            return textureType == MTLTextureType1DArray ||
+                    textureType == MTLTextureType2DArray ||
+                    textureType == MTLTextureTypeCubeArray ||
+                    textureType == MTLTextureType2DMultisampleArray;
+        }
+    
         uint32_t GetArrayLength(int arraySize, bool isCubeMap)
         {            
             if(arraySize>1)
@@ -365,7 +373,6 @@ namespace AZ
             mtlTextureDesc.hazardTrackingMode = resourceDescriptor.m_mtlHazardTrackingMode;
             
             mtlTextureDesc.sampleCount = resourceDescriptor.m_sampleCount;
-            //NSLog(@"ConvertImageDescriptor %p\n", mtlTextureDesc);
             return mtlTextureDesc;
         }
     

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Conversions.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Conversions.h
@@ -48,7 +48,7 @@ namespace AZ
 
         MTLPixelFormat ConvertPixelFormat(RHI::Format format);
         MTLTextureUsage ConvertTextureUsageFlags(RHI::BufferBindFlags flags, RHI::Format format);
-        MTLTextureType ConvertTextureType(RHI::ImageDimension dimension, int arraySize, bool isCubeMap);
+        MTLTextureType ConvertTextureType(RHI::ImageDimension dimension, int arraySize, bool isCubeMap, bool isViewArray=false);
         MTLPixelFormat ConvertImageViewFormat( const Image& image, const RHI::ImageViewDescriptor& imageViewDescriptor);
         MTLBlendOperation ConvertBlendOp(RHI::BlendOp op);
         MTLBlendFactor ConvertBlendFactor(RHI::BlendFactor factor);
@@ -94,6 +94,7 @@ namespace AZ
         bool IsDepthStencilMerged(MTLPixelFormat mtlFormat);
         bool GetVertexFormatSizeInBytes(const MTLVertexFormat vertexFormat, uint32_t& size);
         bool GetIndexTypeSizeInBytes(const MTLIndexType indexType, uint32_t& size);
+        bool IsTextureTypeAnArray(MTLTextureType textureType);
         uint32_t GetArrayLength(int arraySize, bool isCubeMap);
         
         ResourceDescriptor ConvertBufferDescriptor(const RHI::BufferDescriptor& descriptor, RHI::HeapMemoryLevel heapMemoryLevel = RHI::HeapMemoryLevel::Device);

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/ImageView.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/ImageView.cpp
@@ -54,8 +54,8 @@ namespace AZ
             }
             
             MTLTextureType imgTextureType = mtlTexture.textureType;
-            //Recreate the texture if the existing texture is not flagged as an array but the view is of an array
-            //Essentially this will tag a 2d texture as 2darray texture to ensure that sampling works correctly
+            //Recreate the texture if the existing texture is not flagged as an array but the view is of an array.
+            //Essentially this will tag a 2d texture as 2darray texture to ensure that sampling works correctly.
             if(!IsTextureTypeAnArray(imgTextureType) && viewDescriptor.m_isArray)
             {
                 isViewFormatDifferent = true;

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/ImageView.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/ImageView.cpp
@@ -53,6 +53,15 @@ namespace AZ
                 textureLength = textureLength * RHI::ImageDescriptor::NumCubeMapSlices;
             }
             
+            MTLTextureType imgTextureType = mtlTexture.textureType;
+            //Recreate the texture if the existing texture is not flagged as an array but the view is of an array
+            //Essentially this will tag a 2d texture as 2darray texture to ensure that sampling works correctly
+            if(!IsTextureTypeAnArray(imgTextureType) && viewDescriptor.m_isArray)
+            {
+                isViewFormatDifferent = true;
+                imgTextureType = ConvertTextureType(imgDesc.m_dimension, imgDesc.m_arraySize, imgDesc.m_isCubemap, viewDescriptor.m_isArray);
+            }
+            
             //Create a new view if the format, mip range or slice range has changed
             if( isViewFormatDifferent ||
                 levelRange.length != mtlTexture.mipmapLevelCount ||
@@ -66,7 +75,7 @@ namespace AZ
                 }
 
                 textureView = [mtlTexture newTextureViewWithPixelFormat : textureViewFormat
-                                                            textureType : mtlTexture.textureType
+                                                            textureType : imgTextureType
                                                                  levels : levelRange
                                                                  slices : sliceRange];
             }


### PR DESCRIPTION
## What does this PR do?

Sometimes depending on the shadow atlas the shadow map texture would only have an array size of 1 which meant that the shadow map texture was getting tagged as texture 2d. This meant that the drivers were silently always returning the first pixel in the texture during the forward pass with no warning or api validation error (This is a driver issue which is getting addressed now). This fix recreates the view and tags the texture correctly as a texture2darray. 

## How was this PR tested?

Tested Editor by creating a simple spot light and enabling shadows.
