### PR TITLE
Non-Unity build fixes

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/ShaderUtils.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/ShaderUtils.cpp
@@ -6,7 +6,9 @@
  *
  */
 
+#if defined(CARBONATED)
 #include <RHI/DX12.h>
+#endif
 #include <RHI/ShaderUtils.h>
 #include <openssl/md5.h>
 #include <Atom/RHI.Reflect/DX12/ShaderStageFunction.h>

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/ShaderUtils.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/ShaderUtils.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <RHI/DX12.h>
 #include <RHI/ShaderUtils.h>
 #include <openssl/md5.h>
 #include <Atom/RHI.Reflect/DX12/ShaderStageFunction.h>

--- a/Gems/Profiler/Code/Include/Profiler/ProfilerImGuiBus.h
+++ b/Gems/Profiler/Code/Include/Profiler/ProfilerImGuiBus.h
@@ -9,6 +9,7 @@
 
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/Interface/Interface.h>
+#include <AzCore/std/string/string.h>
 
 namespace Profiler
 {

--- a/Gems/Profiler/Code/Include/Profiler/ProfilerImGuiBus.h
+++ b/Gems/Profiler/Code/Include/Profiler/ProfilerImGuiBus.h
@@ -9,7 +9,9 @@
 
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/Interface/Interface.h>
+#if defined(CARBONATED)
 #include <AzCore/std/string/string.h>
+#endif
 
 namespace Profiler
 {


### PR DESCRIPTION
## What does this PR do?

Fixes compilation errors for Non-Unity build.

## How was this PR tested?

Tested on Windows, `-DLY_UNITY_BUILD=OFF`
