### PR TITLE
Don't copy pak assets from APK to SD

### DIFF
--- a/Code/Framework/AzAndroid/java/com/amazon/lumberyard/LumberyardActivity.java
+++ b/Code/Framework/AzAndroid/java/com/amazon/lumberyard/LumberyardActivity.java
@@ -233,10 +233,7 @@ public class LumberyardActivity extends NativeActivity
 
         ProcessImmersiveModeSetting();
 
-        // CARBONATED begin
-        // Don't copy *.pak assets from apk to sd
-        APKHandler.SetAssetManager(getAssets(), this, false);
-        // CARBONATED end
+        APKHandler.SetAssetManager(getAssets());
 
         AndroidDeviceManager.context = this;
 

--- a/Code/Framework/AzAndroid/java/com/amazon/lumberyard/LumberyardActivity.java
+++ b/Code/Framework/AzAndroid/java/com/amazon/lumberyard/LumberyardActivity.java
@@ -233,7 +233,10 @@ public class LumberyardActivity extends NativeActivity
 
         ProcessImmersiveModeSetting();
 
-        APKHandler.SetAssetManager(getAssets(), this, true);
+        // CARBONATED begin
+        // Don't copy *.pak assets from apk to sd
+        APKHandler.SetAssetManager(getAssets(), this, false);
+        // CARBONATED end
 
         AndroidDeviceManager.context = this;
 

--- a/Code/Framework/AzAndroid/java/com/amazon/lumberyard/io/APKHandler.java
+++ b/Code/Framework/AzAndroid/java/com/amazon/lumberyard/io/APKHandler.java
@@ -10,101 +10,14 @@ package com.amazon.lumberyard.io;
 import android.content.res.AssetManager;
 import android.util.Log;
 import java.io.IOException;
-import android.content.Context;
-import java.io.File;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.file.*;
 
 ////////////////////////////////////////////////////////////////
 public class APKHandler
 {
     ////////////////////////////////////////////////////////////////
-    private static void copyFile(InputStream in, OutputStream out) throws IOException
-    {
-        byte[] buffer = new byte[64*1024];
-        int read;
-        while ((read = in.read(buffer)) != -1)
-        {
-            out.write(buffer, 0, read);
-        }
-    }
-
-    ////////////////////////////////////////////////////////////////
-    private static boolean isDir(String fileName)
-    {
-        Path path = new File(fileName).toPath();
-        if (!Files.exists(path))
-        {
-            return false;
-        }
-        return Files.isDirectory(path);
-    }
-
-    ////////////////////////////////////////////////////////////////
-    private static void copyPakFiles(AssetManager mgr, String apkAssetsRelativePath, Context context)
-    {
-        String outputDir = context.getFilesDir().getAbsolutePath();
-        copyAssetFiles(mgr, apkAssetsRelativePath, outputDir, ".pak");
-    }
-
-    ////////////////////////////////////////////////////////////////
-    private static void copyAssetFiles(AssetManager mgr, String apkAssetsRelativePath, String outputDir, String fileMask)
-    {
-        try 
-        {
-            String[] list = mgr.list(apkAssetsRelativePath);
-            if (list == null)
-            {
-                Log.i(s_tag, String.format("No asset files found in '%s'", apkAssetsRelativePath));
-                return;
-            }
-
-            for (String filename : list)
-            {
-                if (!isDir(filename) && filename.endsWith(fileMask))
-                {
-                    InputStream in = null;
-                    OutputStream out = null;
-                    try
-                    {
-                        in = mgr.open(filename);
-                        String outFileName = String.format("%s/%s", outputDir, filename);
-                        out = Files.newOutputStream(Paths.get(outFileName));
-                        Log.i(s_tag, String.format("Copying asset %s to %s", filename, outFileName));
-                        copyFile(in, out);
-                    } catch(IOException e)
-                    {
-                        Log.e(s_tag, "Failed to copy asset file: " + filename, e);
-                    } finally
-                    {
-                        try
-                        {
-                            in.close();
-                            out.flush();
-                            out.close();
-                        } catch(IOException e1)
-                        {
-                            Log.e(s_tag, "Failed to close: " + filename, e1);
-                        }
-                    }
-                }
-            }
-        } catch (IOException e)
-        {
-            Log.e(s_tag, String.format("AssetManager cannot list in '%s'", apkAssetsRelativePath), e);
-        }
-    }
-
-    ////////////////////////////////////////////////////////////////
-    public static void SetAssetManager(AssetManager assetManager, Context context, boolean copyPaks)
+    public static void SetAssetManager(AssetManager assetManager)
     {
         s_assetManager = assetManager;
-
-        if (copyPaks)
-        {
-            copyPakFiles(s_assetManager, "", context);
-        }
     }
 
     ////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzFramework/Platform/Android/AzFramework/IO/LocalFileIO_Android.cpp
+++ b/Code/Framework/AzFramework/Platform/Android/AzFramework/IO/LocalFileIO_Android.cpp
@@ -165,10 +165,11 @@ namespace AZ
             {
                 directoryPath /= pathSegment;
 #if defined(CARBONATED)
-                if (!Exists(directoryPath.c_str()))
+                const auto directoryPathCStr = directoryPath.c_str();
+                if (!Exists(directoryPathCStr))
                 {
-                    mkdir(directoryPath.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
-                    if (!IsDirectory(directoryPath.c_str()))
+                    mkdir(directoryPathCStr, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+                    if (!IsDirectory(directoryPathCStr))
                     {
                         return ResultCode::Error;
                     }

--- a/Code/Framework/AzFramework/Platform/Android/AzFramework/IO/LocalFileIO_Android.cpp
+++ b/Code/Framework/AzFramework/Platform/Android/AzFramework/IO/LocalFileIO_Android.cpp
@@ -164,11 +164,22 @@ namespace AZ
             for (AZ::IO::PathView pathSegment : resolvedPath.RelativePath())
             {
                 directoryPath /= pathSegment;
+#if defined(CARBONATED)
+                if (!Exists(directoryPath.c_str()))
+                {
+                    mkdir(directoryPath.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+                    if (!IsDirectory(directoryPath.c_str()))
+                    {
+                        return ResultCode::Error;
+                    }
+                }
+#else
                 mkdir(directoryPath.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
                 if (!IsDirectory(directoryPath.c_str()))
                 {
                     return ResultCode::Error;
                 }
+#endif
             }
 
             return IsDirectory(resolvedPath.c_str()) ? ResultCode::Success : ResultCode::Error;

--- a/Code/Tools/AWSNativeSDKInit/source/Platform/Android/InitializeCerts_Android.cpp
+++ b/Code/Tools/AWSNativeSDKInit/source/Platform/Android/InitializeCerts_Android.cpp
@@ -44,6 +44,9 @@ namespace AWSNativeSDKInit
             if (!fileResult)
             {
                 AZ_Error("AWSNativeSDKInit", false, "Failed to open certificate file with result %i\n", fileResult.GetResultCode());
+#if defined(CARBONATED)
+                return;
+#endif
             }
 
             AZ::u64 fileSize = 0;
@@ -52,36 +55,59 @@ namespace AWSNativeSDKInit
             if (fileSize == 0)
             {
                 AZ_Error("AWSNativeSDKInit", false, "Given empty file(%s) as the certificate bundle.\n", certificatePath.c_str());
+#if defined(CARBONATED)
+                fileBase->Close(fileHandle);
+                return;
+#endif
             }
 
             contents.resize(fileSize + 1);
             fileResult = fileBase->Read(fileHandle, contents.data(), fileSize);
-
+#if defined(CARBONATED)
+            fileBase->Close(fileHandle);
+#endif
             if (!fileResult)
             {
                 AZ_Error(
                     "AWSNativeSDKInit", false, "Failed to read from the certificate bundle(%s) with result code(%i).\n", certificatePath.c_str(),
                     fileResult.GetResultCode());
+#if defined(CARBONATED)
+                return;
+#endif
             }
 
             AZ_Printf("AWSNativeSDKInit", "Certificate bundle is read successfully from %s", certificatePath.c_str());
 
             AZ::IO::HandleType outFileHandle;
-
+#if defined(CARBONATED)
+            AZ::IO::Result outFileResult = fileBase->Open(publicStoragePath.c_str(), AZ::IO::OpenMode::ModeWrite | AZ::IO::OpenMode::ModeCreatePath, outFileHandle);
+#else
             AZ::IO::Result outFileResult = fileBase->Open(publicStoragePath.c_str(), AZ::IO::OpenMode::ModeWrite, outFileHandle);
+#endif
 
             if (!outFileResult)
             {
+#if defined(CARBONATED)
+                AZ_Error("AWSNativeSDKInit", false, "Failed to open the certificate bundle in %s with result %i\n", publicStoragePath.c_str(), fileResult.GetResultCode());
+                return;
+#else
                 AZ_Error("AWSNativeSDKInit", false, "Failed to open the certificate bundle with result %i\n", fileResult.GetResultCode());
+#endif
             }
 
             AZ::IO::Result writeFileResult = fileBase->Write(outFileHandle, contents.data(), fileSize);
             if (!writeFileResult)
             {
+#if defined(CARBONATED)
+                AZ_Error("AWSNativeSDKInit", false, "Failed to write the certificate bundle in %s with result %i\n", publicStoragePath.c_str(), writeFileResult.GetResultCode());
+#else
                 AZ_Error("AWSNativeSDKInit", false, "Failed to write the certificate bundle with result %i\n", writeFileResult.GetResultCode());
+#endif
             }
 
+#if !defined(CARBONATED)
             fileBase->Close(fileHandle);
+#endif
             fileBase->Close(outFileHandle);
 
             AZ_Printf("AWSNativeSDKInit", "Certificate bundle successfully copied to %s", publicStoragePath.c_str());

--- a/Code/Tools/AWSNativeSDKInit/source/Platform/Android/InitializeCerts_Android.cpp
+++ b/Code/Tools/AWSNativeSDKInit/source/Platform/Android/InitializeCerts_Android.cpp
@@ -105,7 +105,9 @@ namespace AWSNativeSDKInit
 #endif
             }
 
-#if !defined(CARBONATED)
+#if defined(CARBONATED)
+            // Removed - closed earlier
+#else
             fileBase->Close(fileHandle);
 #endif
             fileBase->Close(outFileHandle);

--- a/scripts/commit_validation/commit_validation/pal_allowedlist.txt
+++ b/scripts/commit_validation/commit_validation/pal_allowedlist.txt
@@ -63,3 +63,4 @@
 */Gems/WhiteBox/Code/Source/Rendering/Legacy/WhiteBoxLegacyRenderMesh.cpp
 */Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceAddon.h
 */restricted/*/Code/Framework/AzCore/AzCore/AzCore_Traits_*.h
+*/Gems/Atom/RHI/Metal/Code/Source/RHI/MetalViewController.mm

--- a/scripts/commit_validation/commit_validation/pal_allowedlist.txt
+++ b/scripts/commit_validation/commit_validation/pal_allowedlist.txt
@@ -63,4 +63,3 @@
 */Gems/WhiteBox/Code/Source/Rendering/Legacy/WhiteBoxLegacyRenderMesh.cpp
 */Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceAddon.h
 */restricted/*/Code/Framework/AzCore/AzCore/AzCore_Traits_*.h
-*/Gems/Atom/RHI/Metal/Code/Source/RHI/MetalViewController.mm


### PR DESCRIPTION
## What does this PR do?

Don't copy pak assets from APK to SD. During APK assembly pak assets stored in it without compression. This alleviates the previously existed issue with a very low reading rate of pak data due to double compression.

Additionally the PR fixes the issue with copying the AWS certificate from the pak to device storage. The issue was observed as a side-effect of non-copying paks from APK to the storage. When paks used to be copied, the target path was created correctly by means of the Java code. Now on a new device, this directory structure has to be created solely by the code of `CopyCaCertBundle()`. It is proved to fail as is, at least on Samsung S23+. The changes include the fix in the `LocalFileIO::CreatePath`, as well as the fix and safer code reorganization of `CopyCaCertBundle()`.

## How was this PR tested?

Tested on Samsung S23+
