### PR TITLE
Double swipe to move app to background

### DIFF
--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/MetalViewController.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/MetalViewController.h
@@ -17,7 +17,6 @@
 @interface RHIMetalViewController : NativeViewControllerType {}
 - (BOOL)prefersStatusBarHidden;
 #if defined(CARBONATED) && defined(AZ_PLATFORM_IOS)
-- (BOOL)prefersHomeIndicatorAutoHidden;
 - (UIRectEdge)preferredScreenEdgesDeferringSystemGestures;
 #endif
 - (void)windowWillClose:(NSNotification *)notification;

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/MetalViewController.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/MetalViewController.h
@@ -8,10 +8,18 @@
 
 #pragma once
 
+#if defined(CARBONATED)
+#include <AzCore/PlatformDef.h>
+#endif
+
 #include <Atom_RHI_Metal_Platform.h>
 
 @interface RHIMetalViewController : NativeViewControllerType {}
 - (BOOL)prefersStatusBarHidden;
+#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS)
+- (BOOL)prefersHomeIndicatorAutoHidden;
+- (UIRectEdge)preferredScreenEdgesDeferringSystemGestures;
+#endif
 - (void)windowWillClose:(NSNotification *)notification;
 - (void)windowDidResize:(NSNotification *)notification;
 @end    

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/MetalViewController.mm
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/MetalViewController.mm
@@ -19,11 +19,6 @@
 }
 
 #if defined(CARBONATED) && defined(AZ_PLATFORM_IOS)
--(BOOL)prefersHomeIndicatorAutoHidden
-{
-    return FALSE;
-}
-
 - (UIRectEdge)preferredScreenEdgesDeferringSystemGestures
 {
     return UIRectEdgeBottom;

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/MetalViewController.mm
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/MetalViewController.mm
@@ -18,6 +18,18 @@
     return TRUE;
 }
 
+#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS)
+-(BOOL)prefersHomeIndicatorAutoHidden
+{
+    return FALSE;
+}
+
+- (UIRectEdge)preferredScreenEdgesDeferringSystemGestures
+{
+    return UIRectEdgeBottom;
+}
+#endif
+
 - (void)windowWillClose:(NSNotification *)notification
 {
     AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::ExitMainLoop);

--- a/scripts/commit_validation/commit_validation/pal_allowedlist.txt
+++ b/scripts/commit_validation/commit_validation/pal_allowedlist.txt
@@ -63,3 +63,5 @@
 */Gems/WhiteBox/Code/Source/Rendering/Legacy/WhiteBoxLegacyRenderMesh.cpp
 */Gems/Atom/RHI/Code/Include/Atom/RHI/DeviceAddon.h
 */restricted/*/Code/Framework/AzCore/AzCore/AzCore_Traits_*.h
+*/Gems/Atom/RHI/Metal/Code/Source/RHI/MetalViewController.mm
+*/Gems/Atom/RHI/Metal/Code/Source/RHI/MetalViewController.h


### PR DESCRIPTION
## What does this PR do?

The app is going into background mode on iPhone when performing a swipe from the bottom edge of the screen. This is a bad user experience in our game.

The PR introduces the double swipe from the bottom edge instead.

## How was this PR tested?

Tested on iPhone 15/ iOS 17.6.
