### PR TITLE
Increase the minimal size of CErrorsDlg

### DIFF
--- a/Code/Editor/Dialogs/ErrorsDlg.cpp
+++ b/Code/Editor/Dialogs/ErrorsDlg.cpp
@@ -30,6 +30,11 @@ CErrorsDlg::CErrorsDlg(QWidget* pParent /*=nullptr*/)
 
     m_bFirstMessage = true;
 
+#if defined(CARBONATED)
+    static constexpr QSize minSize(500, 300);
+    setMinimumSize(minSize);
+#endif
+
     OnInitDialog();
 
     connect(ui->m_buttonCopyErrors, &QPushButton::clicked, this, &CErrorsDlg::OnCopyErrors);


### PR DESCRIPTION
## What does this PR do?

Increase the minimal size of CErrorsDlg to make sure it can fit modest length messages w/o manual resizing

## How was this PR tested?

Tested locally using Editor on Windows