### PR TITLE
Changes for DLC support

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Archive/Archive.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Archive/Archive.cpp
@@ -1258,6 +1258,11 @@ namespace AZ::IO
         if (usePrefabSystemForLevels)
         {
             m_arrZips.insert(revItZip.base(), desc);
+#if defined (CARBONATED)
+            // Fixed issue: lock.unlock() is missed for this 'if' branch.
+            // Note: in the latest O3DE (Oct/2024) this 'if' was removed at all.
+            lock.unlock();
+#endif
         }
         else
         {

--- a/Code/Legacy/CryCommon/ILevelSystem.h
+++ b/Code/Legacy/CryCommon/ILevelSystem.h
@@ -58,6 +58,9 @@ struct ILevelSystem
 {
     virtual ~ILevelSystem() = default;
 
+#if defined (CARBONATED)
+    virtual void Activate() {}
+#endif
     virtual void Release() = 0;
 
     virtual void AddListener(ILevelSystemListener* pListener) = 0;

--- a/Code/Legacy/CryCommon/ILevelSystem.h
+++ b/Code/Legacy/CryCommon/ILevelSystem.h
@@ -59,7 +59,7 @@ struct ILevelSystem
     virtual ~ILevelSystem() = default;
 
 #if defined (CARBONATED)
-    virtual void LoadDefferedLevel() {} 
+    virtual void LoadDeferredLevel() {} 
 #endif
     virtual void Release() = 0;
 

--- a/Code/Legacy/CryCommon/ILevelSystem.h
+++ b/Code/Legacy/CryCommon/ILevelSystem.h
@@ -59,7 +59,7 @@ struct ILevelSystem
     virtual ~ILevelSystem() = default;
 
 #if defined (CARBONATED)
-    virtual void Activate() {}
+    virtual void LoadDefferedLevel() {} 
 #endif
     virtual void Release() = 0;
 

--- a/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
+++ b/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
@@ -90,7 +90,7 @@ namespace LegacyLevelSystem
     }
 
     // Move the deffered level load from the SpawnableLevelSystem constructor to a separate method
-    void SpawnableLevelSystem::LoadDefferedLevel()
+    void SpawnableLevelSystem::LoadDeferredLevel()
     {
 #endif
         // If there were LoadLevel command invocations before the creation of the level system

--- a/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
+++ b/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
@@ -89,8 +89,8 @@ namespace LegacyLevelSystem
 #if defined (CARBONATED)
     }
 
-    // Move the deffered level load from ctor to Activate method
-    void SpawnableLevelSystem::Activate()
+    // Move the deffered level load from the SpawnableLevelSystem constructor to a separate method
+    void SpawnableLevelSystem::LoadDefferedLevel()
     {
 #endif
         // If there were LoadLevel command invocations before the creation of the level system

--- a/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
+++ b/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
@@ -63,6 +63,30 @@ namespace LegacyLevelSystem
     AZ_CONSOLEFREEFUNC(LoadLevel, AZ::ConsoleFunctorFlags::Null, "Unloads the current level and loads a new one with the given asset name");
     AZ_CONSOLEFREEFUNC(UnloadLevel, AZ::ConsoleFunctorFlags::Null, "Unloads the current level");
 
+#if defined (CARBONATED)
+    static void LoadDefferedLevel([[maybe_unused]] const AZ::ConsoleCommandContainer&)
+    {
+        if (auto settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry != nullptr)
+        {
+            if (AZ::SettingsRegistryInterface::FixedValueString deferredLevelName;
+                settingsRegistry->Get(deferredLevelName, DeferredLoadLevelKey) && !deferredLevelName.empty())
+            {
+                // since this is the constructor any derived classes vtables aren't setup yet
+                // call this class LoadLevel function
+                AZ_TracePrintf("SpawnableLevelSystem", "The Level System is now available."
+                    " Loading level %s which could not be loaded earlier\n", deferredLevelName.c_str());
+                if (gEnv && gEnv->pSystem && gEnv->pSystem->GetILevelSystem() && !gEnv->IsEditor())
+                {
+                    gEnv->pSystem->GetILevelSystem()->LoadLevel(deferredLevelName.c_str());
+                }
+                // Delete the key with the deferred level name
+                settingsRegistry->Remove(DeferredLoadLevelKey);
+            }
+        }
+    }
+    AZ_CONSOLEFREEFUNC(LoadDefferedLevel, AZ::ConsoleFunctorFlags::Null, "Load Deffered Level");
+#endif
+
     //------------------------------------------------------------------------
     SpawnableLevelSystem::SpawnableLevelSystem([[maybe_unused]] ISystem* pSystem)
     {
@@ -86,6 +110,9 @@ namespace LegacyLevelSystem
         AZ_Error("SpawnableLevelSystem", AzFramework::LevelSystemLifecycleInterface::Get() == this,
             "Failed to register the SpawnableLevelSystem with the LevelSystemLifecycleInterface.");
 
+#if defined (CARBONATED)
+        // Do not load the defered level while CrySystem is not fully initialized
+#else
         // If there were LoadLevel command invocations before the creation of the level system
         // then those invocations were queued.
         // load the last level in the queue, since only one level can be loaded at a time
@@ -103,6 +130,7 @@ namespace LegacyLevelSystem
                 settingsRegistry->Remove(DeferredLoadLevelKey);
             }
         }
+#endif
     }
 
     //------------------------------------------------------------------------

--- a/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.h
+++ b/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.h
@@ -65,7 +65,7 @@ class SpawnableLevelSystem
         bool ApplyLevelLoadScreenConfig(const char* levelName) const;
         // AssetLoadNotificatorBus interface implementation
         void WaitForAssetUpdate() override;
-        // ILevelSystem addon
+        // ILevelSystem override
         void Activate() override;
 #endif
 

--- a/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.h
+++ b/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.h
@@ -66,7 +66,7 @@ class SpawnableLevelSystem
         // AssetLoadNotificatorBus interface implementation
         void WaitForAssetUpdate() override;
         // ILevelSystem override
-        void Activate() override;
+        void LoadDefferedLevel() override;
 #endif
 
     private:

--- a/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.h
+++ b/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.h
@@ -66,7 +66,7 @@ class SpawnableLevelSystem
         // AssetLoadNotificatorBus interface implementation
         void WaitForAssetUpdate() override;
         // ILevelSystem override
-        void LoadDefferedLevel() override;
+        void LoadDeferredLevel() override;
 #endif
 
     private:

--- a/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.h
+++ b/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.h
@@ -65,6 +65,8 @@ class SpawnableLevelSystem
         bool ApplyLevelLoadScreenConfig(const char* levelName) const;
         // AssetLoadNotificatorBus interface implementation
         void WaitForAssetUpdate() override;
+        // ILevelSystem addon
+        void Activate() override;
 #endif
 
     private:

--- a/Code/Legacy/CrySystem/SystemInit.cpp
+++ b/Code/Legacy/CrySystem/SystemInit.cpp
@@ -1159,8 +1159,10 @@ bool CSystem::Init(const SSystemInitParams& startupParams)
     // Load the deffered level only after CrySystem has been fully initialized
     AZ::TickBus::QueueFunction(
        [this]()
-       { // Wait while RPI System is fully initialized
-           m_pLevelSystem->Activate();
+       {   // Load the deffered level after the queued system initializations are executed too,
+           // e.g. after the queued call of RPISystem::InitializeSystemAssets() is finished.
+           // The RPISystem can be required for the deffered level to access the graphics assets.
+           m_pLevelSystem->LoadDefferedLevel();
        });
 #endif
     

--- a/Code/Legacy/CrySystem/SystemInit.cpp
+++ b/Code/Legacy/CrySystem/SystemInit.cpp
@@ -1153,7 +1153,7 @@ bool CSystem::Init(const SSystemInitParams& startupParams)
     EBUS_EVENT(CrySystemEventBus, OnCrySystemInitialized, *this, startupParams);
 
 #if defined (CARBONATED)
-    // Load the defered level only after CrySystem has been fully initialized
+    // Load the deffered level only after CrySystem has been fully initialized
     m_pLevelSystem->Activate();
 #endif    
 

--- a/Code/Legacy/CrySystem/SystemInit.cpp
+++ b/Code/Legacy/CrySystem/SystemInit.cpp
@@ -1162,7 +1162,7 @@ bool CSystem::Init(const SSystemInitParams& startupParams)
        {   // Load the deffered level after the queued system initializations are executed too,
            // e.g. after the queued call of RPISystem::InitializeSystemAssets() is finished.
            // The RPISystem can be required for the deffered level to access the graphics assets.
-           m_pLevelSystem->LoadDefferedLevel();
+           m_pLevelSystem->LoadDeferredLevel();
        });
 #endif
     

--- a/Code/Legacy/CrySystem/SystemInit.cpp
+++ b/Code/Legacy/CrySystem/SystemInit.cpp
@@ -1152,6 +1152,11 @@ bool CSystem::Init(const SSystemInitParams& startupParams)
     // Send out EBus event
     EBUS_EVENT(CrySystemEventBus, OnCrySystemInitialized, *this, startupParams);
 
+#if defined (CARBONATED)
+    // Load the defered level only after CrySystem has been fully initialized
+    AZ::Interface<AZ::IConsole>::Get()->PerformCommand("LoadDefferedLevel");
+#endif    
+
     // Execute any deferred commands that uses the CVar commands that were just registered
     AZ::Interface<AZ::IConsole>::Get()->ExecuteDeferredConsoleCommands();
 

--- a/Code/Legacy/CrySystem/SystemInit.cpp
+++ b/Code/Legacy/CrySystem/SystemInit.cpp
@@ -1154,7 +1154,7 @@ bool CSystem::Init(const SSystemInitParams& startupParams)
 
 #if defined (CARBONATED)
     // Load the defered level only after CrySystem has been fully initialized
-    AZ::Interface<AZ::IConsole>::Get()->PerformCommand("LoadDefferedLevel");
+    m_pLevelSystem->Activate();
 #endif    
 
     // Execute any deferred commands that uses the CVar commands that were just registered

--- a/Code/Legacy/CrySystem/SystemInit.cpp
+++ b/Code/Legacy/CrySystem/SystemInit.cpp
@@ -1152,14 +1152,18 @@ bool CSystem::Init(const SSystemInitParams& startupParams)
     // Send out EBus event
     EBUS_EVENT(CrySystemEventBus, OnCrySystemInitialized, *this, startupParams);
 
-#if defined (CARBONATED)
-    // Load the deffered level only after CrySystem has been fully initialized
-    m_pLevelSystem->Activate();
-#endif    
-
     // Execute any deferred commands that uses the CVar commands that were just registered
     AZ::Interface<AZ::IConsole>::Get()->ExecuteDeferredConsoleCommands();
 
+#if defined (CARBONATED)
+    // Load the deffered level only after CrySystem has been fully initialized
+    AZ::TickBus::QueueFunction(
+       [this]()
+       { // Wait while RPI System is fully initialized
+           m_pLevelSystem->Activate();
+       });
+#endif
+    
     if (ISystemEventDispatcher* systemEventDispatcher = GetISystemEventDispatcher())
     {
         systemEventDispatcher->OnSystemEvent(ESYSTEM_EVENT_GAME_POST_INIT, 0, 0);


### PR DESCRIPTION
Ticket: 14368

This PR works together with PR https://github.com/carbonated-dev/o3de-gruber/pull/1080

## What does this PR do?

Issue (1):
On iOS the first level ("launch" level) was launched before the engine CrySystem is initialized and before the system UI canvas is loaded. It prevented to show confirmation DLC downloading message box on iOS and prevented to show DLC download progress bar on iOS (they are initialized on the ESYSTEM_EVENT_LEVEL_LOAD_END event).

Changes (1): 
For iOS DLC support - move the first level launch from SpawnableLevelSystem constructor into time after CrySystem is initialized and RPI is initialized

Issue (2):
On PC the game stay forever on DLC progress bar when DLC is fully loaded. It occurs when one pack recursively processed another dependent pack from the manifest.

Changes (2):
Added missed lock.unlock() to avoid to stay on unlocked AZStd::unique_lock in the recursive call

## How was this PR tested?

DLC downloading was verified locally on PC and iPhone14 using env 'dev10' and enabled DLC via cvars:
```
mw_env dev10
mw_dlc_enabled true
```
Also the changes were verified with disabled DLC and with env 'qa' to be sure so that they don't impact current build (locally on PC and via iOS build 27847)
