### PR TITLE
Improve font reloading

### DIFF
--- a/Gems/AtomLyIntegration/AtomFont/Code/Source/AtomFont.cpp
+++ b/Gems/AtomLyIntegration/AtomFont/Code/Source/AtomFont.cpp
@@ -774,9 +774,6 @@ void AZ::AtomFont::ReleaseFontFamily(FontFamily* fontFamily)
     // the font family, so we need to remove that entry also.
     m_fontFamilyReverseLookup.erase(fontFamily);
 
-#if defined(CARBONATED)
-    fontFamily->familyName.clear(); // to know that the font was released
-#endif
     SAFE_RELEASE(fontFamily->normal);
     SAFE_RELEASE(fontFamily->bold);
     SAFE_RELEASE(fontFamily->italic);

--- a/Gems/AtomLyIntegration/AtomFont/Code/Source/AtomFont.cpp
+++ b/Gems/AtomLyIntegration/AtomFont/Code/Source/AtomFont.cpp
@@ -774,6 +774,9 @@ void AZ::AtomFont::ReleaseFontFamily(FontFamily* fontFamily)
     // the font family, so we need to remove that entry also.
     m_fontFamilyReverseLookup.erase(fontFamily);
 
+#if defined(CARBONATED)
+    fontFamily->familyName.clear(); // to know that the font was released
+#endif
     SAFE_RELEASE(fontFamily->normal);
     SAFE_RELEASE(fontFamily->bold);
     SAFE_RELEASE(fontFamily->italic);

--- a/Gems/LyShine/Code/Source/UiTextComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiTextComponent.cpp
@@ -3381,6 +3381,15 @@ void UiTextComponent::Activate()
     FontNotificationBus::Handler::BusConnect();
     LanguageChangeNotificationBus::Handler::BusConnect();
 
+#if defined(CARBONATED)
+    // Reload the font families if they were deleted while this UiTextComponent was inactive.
+    // It is important for UiTextComponent which can be activated and deactivated many times.
+    if (m_fontFamily->familyName.empty())
+    {
+        OnFontsReloaded();
+    }
+#endif
+
     // When we are activated the transform could have changed so we will always need to recompute the
     // draw batch lines before they are used. Also, we pass true to invalidate the layout,
     // if this is the first time the entity has been activated this has no effect since the canvas

--- a/Gems/LyShine/Code/Source/UiTextComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiTextComponent.cpp
@@ -3384,9 +3384,9 @@ void UiTextComponent::Activate()
 #if defined(CARBONATED)
     // Reload the font families if they were deleted while this UiTextComponent was inactive.
     // It is important for UiTextComponent which can be activated and deactivated many times.
-    if (m_fontFamily->familyName.empty())
+    if (!m_fontFamily->normal || !m_fontFamily->bold || !m_fontFamily->italic || !m_fontFamily->boldItalic)
     {
-        OnFontsReloaded();
+        ChangeFont(m_fontFilename.GetAssetPath());
     }
 #endif
 


### PR DESCRIPTION
Ticket: 16708

Reason of issue: the font reload notification occurs when UiTextComponent exists but unsubscribed from font notification bus. In this case UiTextComponent will use a link to released font family after UiTextComponent becomes active again. And it causes crash.


## What does this PR do?

Reload the font families if they were released while this UiTextComponent was inactive.
It is important for UiTextComponent which can be activated and deactivated many times.

## How was this PR tested?

Verified locally on PC
Verified on iOS via build #27873 