### PR TITLE
Niko/rigid body kinematic fix

### DIFF
--- a/Gems/PhysX/Code/Source/RigidBodyComponent.cpp
+++ b/Gems/PhysX/Code/Source/RigidBodyComponent.cpp
@@ -405,7 +405,9 @@ namespace PhysX
         m_interpolator->Reset(transform.GetTranslation(), rotation);
 
         // set the transform to not update when the parent's transform changes, to avoid conflict with physics transform updates
+#if defined(CARBONATED)
         if (!m_configuration.m_kinematic)
+#endif
             GetEntity()->GetTransform()->SetOnParentChangedBehavior(AZ::OnParentChangedBehavior::DoNotUpdate);
 
         Physics::RigidBodyNotificationBus::Event(GetEntityId(), &Physics::RigidBodyNotificationBus::Events::OnPhysicsEnabled, GetEntityId());

--- a/Gems/PhysX/Code/Source/RigidBodyComponent.cpp
+++ b/Gems/PhysX/Code/Source/RigidBodyComponent.cpp
@@ -405,7 +405,8 @@ namespace PhysX
         m_interpolator->Reset(transform.GetTranslation(), rotation);
 
         // set the transform to not update when the parent's transform changes, to avoid conflict with physics transform updates
-        GetEntity()->GetTransform()->SetOnParentChangedBehavior(AZ::OnParentChangedBehavior::DoNotUpdate);
+        if (!m_configuration.m_kinematic)
+            GetEntity()->GetTransform()->SetOnParentChangedBehavior(AZ::OnParentChangedBehavior::DoNotUpdate);
 
         Physics::RigidBodyNotificationBus::Event(GetEntityId(), &Physics::RigidBodyNotificationBus::Events::OnPhysicsEnabled, GetEntityId());
     }


### PR DESCRIPTION
## What does this PR do?

Kinematic Rigidbodies were not getting updates from the transform component (if their parent was moved) so they would not move.

This was exposed when our transform was updated, but this bug exists in o3de (they do have a weird stipulation that rigid bodies can only be on the absolute top of the hierarchy (check the note here: https://docs.o3de.org/docs/user-guide/components/reference/physx/rigid-body/) - may be related to this bug? But that note is a very unnecessary limitation

## How was this PR tested?

Tested in editor, as well as a build
