### PR TITLE
Aefimov/mad 15696 shader opt index

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/ShaderCollection.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/ShaderCollection.h
@@ -22,6 +22,48 @@ namespace AZ
 
     namespace RPI
     {
+#if defined(CARBONATED)
+        class EffectiveBitset
+        {
+        public:
+            AZ_TYPE_INFO(EffectiveBitset, "{B1720E13-8927-4B85-89CB-165A1D1FE003}");
+            static void Reflect(ReflectContext* context);
+
+            EffectiveBitset()
+            {
+                static_assert(sizeof(u64) == 8);
+                static_assert(BitsPerUnit == 64);
+                static_assert(BitMask == 63);
+                static_assert(NumBits % BitsPerUnit == 0);
+                static_assert(NumUnits > 0);
+                for (AZStd::size_t u = 0; u < NumUnits; u++)
+                {
+                    m_bits[u] = 0;
+                }
+            }
+            void set(AZStd::size_t n)
+            {
+                AZ_Assert(n < NumBits, "over capacity");
+                m_bits[n >> NumShift] |= 1ull << (n & BitMask);
+            }
+            bool test(AZStd::size_t n) const
+            {
+                AZ_Assert(n < NumBits, "over capacity");
+                return (m_bits[n >> NumShift] & (1ull << (n & BitMask))) != 0;
+            }
+
+        private:
+            enum
+            {
+                NumBits = 128,
+                BitsPerUnit = 64,
+                BitMask = BitsPerUnit - 1,
+                NumUnits = NumBits / BitsPerUnit,
+                NumShift = 6 // 64 is 1 << 6
+            };
+            AZStd::array<u64, NumUnits> m_bits;
+        };
+#endif
         //! Collects the set of all possible shaders that a material could use at runtime,
         //! along with configuration that indicates how each shader should be used.
         //! Each shader item may be reconfigured at runtime, but items cannot be added
@@ -107,8 +149,12 @@ namespace AZ
                 ShaderOptionGroup m_shaderOptionGroup;   //!< Holds and manipulates the ShaderVariantId at runtime.
                 RHI::RenderStates m_renderStatesOverlay; //!< Holds and manipulates the RenderStates at runtime.
                 RHI::DrawListTag  m_drawListTagOverride; //!< Holds and manipulates the DrawList at runtime.
+#if defined(CARBONATED)
+                EffectiveBitset m_ownedShaderOptionIndices; //!< Set of shader options in this shader that are owned by the material.
+#else
                 //[GFX TODO][ATOM-5636]: This may need to use a more efficient data structure. Consider switching to vector_set class (which will need to be updated to support serialization).
                 AZStd::unordered_set<ShaderOptionIndex> m_ownedShaderOptionIndices; //!< Set of shader options in this shader that are owned by the material.
+#endif
                 bool m_enabled = true;                   //!< Disabled items will not be included in the final draw packet that gets sent to the renderer.
                 AZ::Name m_shaderTag;                    //!< Unique tag that identifies this item
             };

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
@@ -39,7 +39,7 @@ namespace AZ
             AssetBuilderSDK::AssetBuilderDesc materialBuilderDescriptor;
             materialBuilderDescriptor.m_name = JobKey;
 #if defined(CARBONATED)
-            materialBuilderDescriptor.m_version = 143; // add silhouette blocker to StandardPBR
+            materialBuilderDescriptor.m_version = 144; // 143 add silhouette blocker to StandardPBR, 144 use effective bitset to shader options
 #else
             materialBuilderDescriptor.m_version = 142; // Add support for small SRGs
 #endif

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialTypeBuilder.cpp
@@ -45,7 +45,7 @@ namespace AZ
             AssetBuilderSDK::AssetBuilderDesc materialBuilderDescriptor;
             materialBuilderDescriptor.m_name = "Material Type Builder";
 #if defined(CARBONATED)
-            materialBuilderDescriptor.m_version = 52; // add silhouette blocker to StandardPBR
+            materialBuilderDescriptor.m_version = 53; // 52 add silhouette blocker to StandardPBR, 53 use effective bitset to shader indexes
 #else
             materialBuilderDescriptor.m_version = 51; // Add support for small SRGs
 #endif

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialTypeAssetCreator.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialTypeAssetCreator.cpp
@@ -162,7 +162,11 @@ namespace AZ
                     ShaderOptionIndex index = shaderItem.GetShaderOptions()->FindShaderOptionIndex(shaderOptionName);
                     if (index.IsValid())
                     {
+#if defined(CARBONATED)
+                        shaderItem.m_ownedShaderOptionIndices.set(index.GetIndex());
+#else
                         shaderItem.m_ownedShaderOptionIndices.insert(index);
+#endif
                         optionFound = true;
                     }
                     return true;
@@ -448,7 +452,11 @@ namespace AZ
                     outputId.m_itemIndex = RHI::Handle<uint32_t>{optionIndex.GetIndex()};
 
                     m_wipMaterialProperty.m_outputConnections.push_back(outputId);
+#if defined(CARBONATED)
+                    shaderItem.m_ownedShaderOptionIndices.set(optionIndex.GetIndex());
+#else
                     shaderItem.m_ownedShaderOptionIndices.insert(optionIndex);
+#endif
                 }
 
                 return true;

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/ShaderCollection.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/ShaderCollection.cpp
@@ -16,6 +16,18 @@ namespace AZ
 {
     namespace RPI
     {
+#if defined(CARBONATED)
+        void EffectiveBitset::Reflect(AZ::ReflectContext* context)
+        {
+            if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+            {
+                serializeContext->Class<EffectiveBitset>()
+                    ->Version(1)
+                    ->Field("bits", &EffectiveBitset::m_bits);
+                    ;
+            }
+        }
+#endif
         //! This allows ShaderCollection::Item to serialize only a ShaderVariantId rather than the ShaderOptionsGroup object,
         //! but still provide the corresponding ShaderOptionsGroup for use at runtime.
         //! RenderStates will be modified at runtime as well. It will be merged into the RenderStates stored in the corresponding ShaderVariant.
@@ -70,10 +82,17 @@ namespace AZ
 
         void ShaderCollection::Item::Reflect(AZ::ReflectContext* context)
         {
+#if defined(CARBONATED)
+            EffectiveBitset::Reflect(context);
+#endif
             if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
             {
                 serializeContext->Class<ShaderCollection::Item>()
+#if defined(CARBONATED)
+                    ->Version(7)  // because of m_ownedShaderOptionIndices change
+#else
                     ->Version(6)
+#endif
                     ->EventHandler<ShaderVariantReferenceSerializationEvents>()
                     ->Field("ShaderAsset", &ShaderCollection::Item::m_shaderAsset)
                     ->Field("ShaderVariantId", &ShaderCollection::Item::m_shaderVariantId)
@@ -212,12 +231,29 @@ namespace AZ
 
         bool ShaderCollection::Item::MaterialOwnsShaderOption(const AZ::Name& shaderOptionName) const
         {
+#if defined(CARBONATED)
+            ShaderOptionIndex index = m_shaderOptionGroup.FindShaderOptionIndex(shaderOptionName);
+            if (!index.IsValid())
+            {
+                return false;
+            }
+            return m_ownedShaderOptionIndices.test(index.GetIndex());
+#else
             return m_ownedShaderOptionIndices.contains(m_shaderOptionGroup.FindShaderOptionIndex(shaderOptionName));
+#endif
         }
 
         bool ShaderCollection::Item::MaterialOwnsShaderOption(ShaderOptionIndex shaderOptionIndex) const
         {
+#if defined(CARBONATED)
+            if (!shaderOptionIndex.IsValid())
+            {
+                return false;
+            }
+            return m_ownedShaderOptionIndices.test(shaderOptionIndex.GetIndex());
+#else
             return m_ownedShaderOptionIndices.contains(shaderOptionIndex);
+#endif
         }
 
         const RHI::RenderStates* ShaderCollection::Item::GetRenderStatesOverlay() const


### PR DESCRIPTION
## What does this PR do?

Use fixed size bit set instead of unordered set, this saves significant amount of memory and decreases defragmentation and improves the performance a bit. The drawback is the shader option index limit of 128, which is twice enough for MadWorld.

This change passed a code review once, but I reverted it because it requires full material rebuild, I did not know how to make it that time.

## How was this PR tested?

Local Windows standalone build, Jenkins iOS build.
