### PR TITLE
Fix double mouse pointer visible in Windows standalone build when ImGui enabled

### DIFF
--- a/Gems/ImGui/Code/CMakeLists.txt
+++ b/Gems/ImGui/Code/CMakeLists.txt
@@ -71,6 +71,7 @@ ly_add_target(
             Gem::ImGui.ImGuiLYUtils
         PRIVATE
             Gem::LmbrCentral
+            Gem::LyShine
 )
 
 ly_add_target(

--- a/Gems/ImGui/Code/Source/ImGuiManager.cpp
+++ b/Gems/ImGui/Code/Source/ImGuiManager.cpp
@@ -692,16 +692,7 @@ void ImGuiManager::ToggleThroughImGuiVisibleState()
             m_clientMenuBarState = DisplayState::Visible;
 
 #if defined(CARBONATED)
-            {
-                bool isCursorVisible = false;
-                UiCursorBus::BroadcastResult(isCursorVisible, &UiCursorInterface::IsUiCursorVisible);
-                m_restoreUiCursor = isCursorVisible;
-                while (isCursorVisible)
-                {
-                    UiCursorBus::Broadcast(&UiCursorBus::Events::DecrementVisibleCounter);
-                    UiCursorBus::BroadcastResult(isCursorVisible, &UiCursorInterface::IsUiCursorVisible);
-                }
-            }
+            UiCursorBus::Broadcast(&UiCursorBus::Events::DecrementVisibleCounter);
 #endif
             
             if (gEnv->IsEditor() && !gEnv->IsEditorGameMode())
@@ -742,17 +733,7 @@ void ImGuiManager::ToggleThroughImGuiVisibleState()
             m_clientMenuBarState = DisplayState::Hidden;
 
 #if defined(CARBONATED)
-            if (m_restoreUiCursor)
-            {
-                m_restoreUiCursor = false;
-                bool isCursorVisible = false;
-                UiCursorBus::BroadcastResult(isCursorVisible, &UiCursorInterface::IsUiCursorVisible);                
-                while (!isCursorVisible)
-                {
-                    UiCursorBus::Broadcast(&UiCursorBus::Events::IncrementVisibleCounter);
-                    UiCursorBus::BroadcastResult(isCursorVisible, &UiCursorInterface::IsUiCursorVisible);
-                }
-            }
+            UiCursorBus::Broadcast(&UiCursorBus::Events::IncrementVisibleCounter);
 #endif
 
             // Avoid hiding the cursor when in the Editor and not in game mode

--- a/Gems/ImGui/Code/Source/ImGuiManager.h
+++ b/Gems/ImGui/Code/Source/ImGuiManager.h
@@ -92,10 +92,6 @@ namespace ImGui
         ImGuiContext* m_imguiContext = nullptr;
         DisplayState m_clientMenuBarState = DisplayState::Hidden;
 #if defined(CARBONATED)
-        bool m_restoreUiCursor {};
-#endif
-        
-#if defined(CARBONATED)
         // True when the current on-screen keyboard is owned by ImGui.
         bool m_textEntryOwned {};
 #endif

--- a/Gems/ImGui/Code/Source/ImGuiManager.h
+++ b/Gems/ImGui/Code/Source/ImGuiManager.h
@@ -91,6 +91,7 @@ namespace ImGui
 
         ImGuiContext* m_imguiContext = nullptr;
         DisplayState m_clientMenuBarState = DisplayState::Hidden;
+
 #if defined(CARBONATED)
         // True when the current on-screen keyboard is owned by ImGui.
         bool m_textEntryOwned {};

--- a/Gems/ImGui/Code/Source/ImGuiManager.h
+++ b/Gems/ImGui/Code/Source/ImGuiManager.h
@@ -91,7 +91,7 @@ namespace ImGui
 
         ImGuiContext* m_imguiContext = nullptr;
         DisplayState m_clientMenuBarState = DisplayState::Hidden;
-
+        
 #if defined(CARBONATED)
         // True when the current on-screen keyboard is owned by ImGui.
         bool m_textEntryOwned {};

--- a/Gems/ImGui/Code/Source/ImGuiManager.h
+++ b/Gems/ImGui/Code/Source/ImGuiManager.h
@@ -91,6 +91,9 @@ namespace ImGui
 
         ImGuiContext* m_imguiContext = nullptr;
         DisplayState m_clientMenuBarState = DisplayState::Hidden;
+#if defined(CARBONATED)
+        bool m_restoreUiCursor {};
+#endif
         
 #if defined(CARBONATED)
         // True when the current on-screen keyboard is owned by ImGui.


### PR DESCRIPTION
## What does this PR do?

Fix double mouse pointer visible in Windows standalone build when ImGui enabled. Please see the screenshot demonstrating the issue.
![double_pointer1](https://github.com/user-attachments/assets/51121ffb-f606-4f9d-a754-a50561400a9f)

## How was this PR tested?

Tested locally, Windows standalone build
