### PR TITLE
MAD-16476 -- Keyboard Input to Command Line should never be passed to game

### DIFF
--- a/Code/Editor/Controls/ConsoleSCB.cpp
+++ b/Code/Editor/Controls/ConsoleSCB.cpp
@@ -178,7 +178,7 @@ bool ConsoleLineEdit::event(QEvent* ev)
 #if defined(CARBONATED)
         m_keyEvent = *ke;
         // Consume Enter (Return) key right now
-        return ke->key() == Qt::Key_Return ? keyPressEventImpl() : false;
+        return (ke->key() == Qt::Key_Return || ke->key() == Qt::Key_Enter) ? keyPressEventImpl() : false;
 #else
         return QLineEdit::event(ev);
 #endif
@@ -218,28 +218,32 @@ bool ConsoleLineEdit::event(QEvent* ev)
     return true;
 }
 
+#if defined(CARBONATED)
 void ConsoleLineEdit::keyPressEvent(QKeyEvent* ev)
 {
-#if defined(CARBONATED)
     m_keyEvent = *ev;
 
     // Consume Enter (Return) key right now
-    if (ev->key() == Qt::Key_Return)
+    if (ev->key() == Qt::Key_Return || ev->key() == Qt::Key_Enter)
     {
         keyPressEventImpl();
     }
 }
+#endif
 
+#if defined(CARBONATED)
 bool ConsoleLineEdit::keyPressEventImpl()
+#else
+void ConsoleLineEdit::keyPressEvent(QKeyEvent* ev)
+#endif
 {
+#if defined(CARBONATED)
     if (m_keyEvent.type() != QEvent::KeyPress)
     {
         return false;
     }
 
-    QKeyEvent keyEvCopy = m_keyEvent;
-    QKeyEvent* ev = &keyEvCopy;
-    m_keyEvent = invalidKeyEvent;
+    QKeyEvent* ev = &m_keyEvent;
 #endif
     IConsole* console = GetIEditor()->GetSystem()->GetIConsole();
     auto commandManager = GetIEditor()->GetCommandManager();
@@ -313,6 +317,7 @@ bool ConsoleLineEdit::keyPressEventImpl()
         QLineEdit::keyPressEvent(ev);
     }
 #if defined(CARBONATED)
+    m_keyEvent = invalidKeyEvent;
     return true;
 #endif
 }

--- a/Code/Editor/Controls/ConsoleSCB.h
+++ b/Code/Editor/Controls/ConsoleSCB.h
@@ -52,6 +52,9 @@ class ConsoleLineEdit
 public:
     explicit ConsoleLineEdit(QWidget* parent = nullptr);
 
+#if defined(CARBONATED)
+    bool keyPressEventImpl();
+#endif
 protected:
     void mouseDoubleClickEvent(QMouseEvent* ev) override;
     void keyPressEvent(QKeyEvent* ev) override;
@@ -67,6 +70,9 @@ private:
     QStringList m_history;
     unsigned int m_historyIndex;
     bool m_bReusedHistory;
+#if defined(CARBONATED)
+    QKeyEvent m_keyEvent;
+#endif
 };
 
 class ConsoleVariableItemDelegate
@@ -151,6 +157,9 @@ public:
 
     static void RegisterViewClass();
     void SetInputFocus();
+#if defined(CARBONATED)
+    ConsoleLineEdit* GetConsoleInput();
+#endif
     void AddToConsole(const QString& text, bool bNewLine);
     void FlushText();
     QSize sizeHint() const override;

--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -810,19 +810,16 @@ QString FormatRichTextCopyrightNotice()
 #if defined(CARBONATED)
 void CCryEditApp::OnInputChannelEvent(const AzFramework::InputChannel& inputChannel, bool& hasBeenConsumed)
 {
-    if (!hasBeenConsumed)
+    const AzFramework::InputDeviceId& deviceId = inputChannel.GetInputDevice().GetInputDeviceId();
+    if (AzFramework::InputDeviceKeyboard::IsKeyboardDevice(deviceId))
     {
-        const AzFramework::InputDeviceId& deviceId = inputChannel.GetInputDevice().GetInputDeviceId();
-        if (AzFramework::InputDeviceKeyboard::IsKeyboardDevice(deviceId))
+        auto pConsoleSCB = CConsoleSCB::GetCreatedInstance();
+        if (pConsoleSCB)
         {
-            auto pConsoleSCB = CConsoleSCB::GetCreatedInstance();
-            if (pConsoleSCB)
+            auto pConsoleInput = pConsoleSCB->GetConsoleInput();
+            if (pConsoleInput && pConsoleInput->hasFocus())
             {
-                auto pConsoleInput = pConsoleSCB->GetConsoleInput();
-                if (pConsoleInput)
-                {
-                    hasBeenConsumed = pConsoleInput->keyPressEventImpl();
-                }
+                hasBeenConsumed = pConsoleInput->keyPressEventImpl();
             }
         }
     }

--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -59,6 +59,10 @@ AZ_POP_DISABLE_WARNING
 #include <AzFramework/Process/ProcessWatcher.h>
 #include <AzFramework/ProjectManager/ProjectManager.h>
 #include <AzFramework/Spawnable/RootSpawnableInterface.h>
+#if defined(CARBONATED)
+#include <AzFramework/Input/Devices/InputDevice.h>
+#include <AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard.h>
+#endif
 
 // AzToolsFramework
 #include <AzToolsFramework/ActionManager/ActionManagerSystemComponent.h>
@@ -360,6 +364,9 @@ CCryEditApp::CCryEditApp()
 
     AzFramework::AssetSystemInfoBus::Handler::BusConnect();
     AzFramework::AssetSystemStatusBus::Handler::BusConnect();
+#if defined(CARBONATED)
+    AzFramework::InputChannelNotificationBus::Handler::BusConnect();
+#endif
 
     m_disableIdleProcessingCounter = 0;
     EditorIdleProcessingBus::Handler::BusConnect();
@@ -368,6 +375,10 @@ CCryEditApp::CCryEditApp()
 //////////////////////////////////////////////////////////////////////////
 CCryEditApp::~CCryEditApp()
 {
+#if defined(CARBONATED)
+    AzFramework::InputChannelNotificationBus::Handler::BusDisconnect();
+#endif
+
     EditorIdleProcessingBus::Handler::BusDisconnect();
     AzFramework::AssetSystemStatusBus::Handler::BusDisconnect();
     AzFramework::AssetSystemInfoBus::Handler::BusDisconnect();
@@ -795,6 +806,28 @@ QString FormatRichTextCopyrightNotice()
 
     return copyrightString.arg(copyrightHtmlSymbol);
 }
+
+#if defined(CARBONATED)
+void CCryEditApp::OnInputChannelEvent(const AzFramework::InputChannel& inputChannel, bool& hasBeenConsumed)
+{
+    if (!hasBeenConsumed)
+    {
+        const AzFramework::InputDeviceId& deviceId = inputChannel.GetInputDevice().GetInputDeviceId();
+        if (AzFramework::InputDeviceKeyboard::IsKeyboardDevice(deviceId))
+        {
+            auto pConsoleSCB = CConsoleSCB::GetCreatedInstance();
+            if (pConsoleSCB)
+            {
+                auto pConsoleInput = pConsoleSCB->GetConsoleInput();
+                if (pConsoleInput)
+                {
+                    hasBeenConsumed = pConsoleInput->keyPressEventImpl();
+                }
+            }
+        }
+    }
+}
+#endif
 
 void CCryEditApp::AssetSystemWaiting()
 {

--- a/Code/Editor/CryEdit.h
+++ b/Code/Editor/CryEdit.h
@@ -18,6 +18,10 @@
 #include "ViewPane.h"
 
 #include <QSettings>
+#if defined(CARBONATED)
+#include <AzFramework/Input/Buses/Notifications/InputChannelNotificationBus.h>
+#include <AzFramework/Input/Channels/InputChannel.h>
+#endif
 
 #endif
 
@@ -89,6 +93,9 @@ class SANDBOX_API CCryEditApp
     , protected AzFramework::AssetSystemInfoBus::Handler
     , protected EditorIdleProcessingBus::Handler
     , protected AzFramework::AssetSystemStatusBus::Handler
+#if defined(CARBONATED)
+    , public AzFramework::InputChannelNotificationBus::Handler
+#endif
 {
 AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
@@ -227,6 +234,10 @@ public:
     void OnToolsLogMemoryUsage();
     void OnToolsPreferences();
 
+#if defined(CARBONATED)
+    // AzFramework::InputChannelNotificationBus
+    void OnInputChannelEvent(const AzFramework::InputChannel& inputChannel, bool& hasBeenConsumed) override;
+#endif
 protected:
     // ------- AzFramework::AssetSystemInfoBus::Handler ------
     void OnError(AzFramework::AssetSystem::AssetSystemErrors error) override;


### PR DESCRIPTION
## What does this PR do?

We are observing the issue when a) the game started in the Editor, b) the focus in the Editor is set on the console input bar, c) the discrete input is off, d) the user enters a command, the entered symbols leak into the game.
This leads to the problem with the WASD keys since they interfere with the gameplay.
From what I see, the Qt ConsoleLineEdit class is unware about the O3DE input event marshaling (InputChannelNotifications::OnInputChannelEvent). Thus there is no way for the game to know that the key event has been consumed by ConsoleLineEdit.

The PR attempts to take the control of ConsoleLineEdit and include it into the O3DE input event marshaling.

## How was this PR tested?

Locally, Windows
