### PR TITLE
MAD-16400 Updated the slider component to do callbacks when the value is set

### DIFF
--- a/Gems/LyShine/Code/Source/UiSliderComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiSliderComponent.cpp
@@ -83,6 +83,9 @@ float UiSliderComponent::GetValue()
 // Bus event that also triggers the value changed callback
 void UiSliderComponent::SetValue(float value)
 {
+    if (GetValue() == value)
+        return;
+
     SetValueInternal(value);
     DoChangedActions();
 }

--- a/Gems/LyShine/Code/Source/UiSliderComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiSliderComponent.cpp
@@ -79,7 +79,19 @@ float UiSliderComponent::GetValue()
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+#if defined(CARBONATED)
+// Bus event that also triggers the value changed callback
 void UiSliderComponent::SetValue(float value)
+{
+    SetValueInternal(value);
+    DoChangedActions();
+}
+
+//Actually updates the value
+void UiSliderComponent::SetValueInternal(float value)
+#else
+void UiSliderComponent::SetValue(float value)
+#endif
 {
     if (m_minValue < m_maxValue)
     {
@@ -260,7 +272,11 @@ AZ::EntityId UiSliderComponent::GetManipulatorEntity()
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 void UiSliderComponent::InGamePostActivate()
 {
+#if defined(CARBONATED)
+    SetValueInternal(m_value);
+#else
     SetValue(m_value);
+#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -282,7 +298,11 @@ bool UiSliderComponent::HandleReleased(AZ::Vector2 point)
     if (m_isPressed && m_isHandlingEvents)
     {
         float value = GetValueFromPoint(point);
+#if defined(CARBONATED)
+        SetValueInternal(value);
+#else
         SetValue(value);
+#endif
 
         UiInteractableComponent::TriggerReleasedAction();
 
@@ -378,7 +398,11 @@ bool UiSliderComponent::HandleKeyInputBegan(const AzFramework::InputChannel::Sna
 
         if (newValue != m_value)
         {
+#if defined(CARBONATED)
+            SetValueInternal(newValue);
+#else
             SetValue(newValue);
+#endif
 
             AZ::Vector2 point(-1.0f, 1.0f);
             DoChangingActions();
@@ -420,7 +444,11 @@ void UiSliderComponent::InputPositionUpdate(AZ::Vector2 point)
         {
             float value = GetValueFromPoint(point);
 
+#if defined(CARBONATED)
+            SetValueInternal(value);
+#else
             SetValue(value);
+#endif
 
             DoChangingActions();
         }

--- a/Gems/LyShine/Code/Source/UiSliderComponent.h
+++ b/Gems/LyShine/Code/Source/UiSliderComponent.h
@@ -83,6 +83,10 @@ protected: // member functions
     bool IsAutoActivationSupported() override;
     // ~UiInteractableComponent
 
+    #if defined(CARBONATED)
+    void SetValueInternal(float value);
+    #endif
+
     UiInteractableStatesInterface::State ComputeInteractableState() override;
 
     static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)


### PR DESCRIPTION
## What does this PR do?

Slider component wasnt properly handling update callbacks when updates happened. 
To fix this, I moved setvalue logic into a new setvalueinternal so the bus event could issue callback events, while preserving current logic.

## How was this PR tested?

Tested on device and PC standalone
