### PR TITLE
Fixing o3de Script Deactivation Flow

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/ExecutionNotificationsBus.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/ExecutionNotificationsBus.cpp
@@ -193,7 +193,7 @@ namespace ScriptCanvas
         const auto userData = AZStd::any_cast<const RuntimeComponentUserData>(&executionState->GetUserData());
         if (!userData)
         {
-            AZ_Error("GraphInfo", false, "Failed to get user data from graph. Constructed with invalid values");
+            AZ_Error("GraphInfo", false, "Failed to get user data from graph. Constructed with invalid values. Asset Hint: %s", executionState->GetRuntimeData().m_script.GetHint().c_str());
             return;
         }
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/ExecutionStateHandler.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/ExecutionStateHandler.cpp
@@ -125,12 +125,21 @@ namespace ScriptCanvas
     {
         if (m_executionState)
         {
+#if defined(CARBONATED)
+            m_executionState->StopExecution();
+            auto graphInfo = GraphInfo(m_executionState);
+            Execution::Destruct(m_executionStateStorage);
+            SCRIPT_CANVAS_PERFORMANCE_FINALIZE_TIMER(m_executionState);
+            ScriptCanvas::ExecutionNotificationsBus::Broadcast(
+                &ScriptCanvas::ExecutionNotifications::GraphDeactivated, GraphDeactivation(graphInfo));
+#else
             m_executionState->StopExecution();
             Execution::Destruct(m_executionStateStorage);
             SCRIPT_CANVAS_PERFORMANCE_FINALIZE_TIMER(m_executionState);
             ScriptCanvas::ExecutionNotificationsBus::Broadcast(
                 &ScriptCanvas::ExecutionNotifications::GraphDeactivated, GraphActivation(GraphInfo(m_executionState)));
             m_executionState = nullptr;
+#endif
         }
     }
     void ExecutionStateHandler::StopAndKeepExecutable()

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/ExecutionStateHandler.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/ExecutionStateHandler.cpp
@@ -127,11 +127,11 @@ namespace ScriptCanvas
         {
 #if defined(CARBONATED)
             m_executionState->StopExecution();
-            auto graphInfo = GraphInfo(m_executionState);
-            Execution::Destruct(m_executionStateStorage);
             SCRIPT_CANVAS_PERFORMANCE_FINALIZE_TIMER(m_executionState);
             ScriptCanvas::ExecutionNotificationsBus::Broadcast(
-                &ScriptCanvas::ExecutionNotifications::GraphDeactivated, GraphDeactivation(graphInfo));
+                &ScriptCanvas::ExecutionNotifications::GraphDeactivated, GraphDeactivation(GraphInfo(m_executionState)));
+            Execution::Destruct(m_executionStateStorage);
+            m_executionState = nullptr;
 #else
             m_executionState->StopExecution();
             Execution::Destruct(m_executionStateStorage);


### PR DESCRIPTION
## What does this PR do?

o3de was disposing of script memory prior to using it for callbacks. Rearranged deactivation so this doesnt happen, resulting in the errors captured by bugsnag here
https://carbonated.atlassian.net/browse/MAD-16903

## How was this PR tested?

Verified the error didnt happen in editor/device after these changes