### PR TITLE
[MAD-15619] Put the console commands into the deferred command queue until all modules are loaded

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
@@ -957,6 +957,13 @@ namespace AZ
 
         // Load the actual modules
         LoadModules();
+
+#if defined (CARBONATED)
+        // Enable to dispatch console commands when all modules are loaded and all their commands are registered.
+        AZ::Interface<AZ::IConsole>::Get()->EnableToDispatchConsoleCommands();
+        AZ::Interface<AZ::IConsole>::Get()->ExecuteDeferredConsoleCommands();
+#endif
+
         ComponentApplicationLifecycle::SignalEvent(*m_settingsRegistry, "GemsLoaded", R"({})");
 
         // Execute user.cfg after modules have been loaded but before processing any command-line overrides

--- a/Code/Framework/AzCore/AzCore/Console/Console.cpp
+++ b/Code/Framework/AzCore/AzCore/Console/Console.cpp
@@ -39,6 +39,9 @@ namespace AZ
 
     Console::Console()
         : m_head(nullptr)
+#if defined (CARBONATED)
+        , m_enableToDispatchConsoleCommands(false)
+#endif
     {
     }
 
@@ -238,6 +241,14 @@ namespace AZ
     {
         m_deferredCommands = {};
     }
+
+#if defined (CARBONATED)
+    void Console::EnableToDispatchConsoleCommands()
+    {
+        AZLOG_INFO("Number of registered commands : %i", m_commands.size());
+        m_enableToDispatchConsoleCommands = true;
+    }
+#endif
 
     bool Console::HasCommand(AZStd::string_view command, ConsoleFunctorFlags ignoreAnyFlags)
     {
@@ -469,6 +480,13 @@ namespace AZ
         ConsoleFunctorFlags requiredClear
     )
     {
+#if defined (CARBONATED)
+        if (!m_enableToDispatchConsoleCommands)
+        {
+            return false;
+        }
+#endif
+
         // incoming commands are assumed to be in the "C" locale as they might be from portable data files
         AZ::Locale::ScopedSerializationLocale scopedLocale;
 

--- a/Code/Framework/AzCore/AzCore/Console/Console.cpp
+++ b/Code/Framework/AzCore/AzCore/Console/Console.cpp
@@ -245,7 +245,7 @@ namespace AZ
 #if defined (CARBONATED)
     void Console::EnableToDispatchConsoleCommands()
     {
-        AZLOG_INFO("Number of registered commands : %i", m_commands.size());
+        AZLOG_INFO("Number of registered commands : %lu", m_commands.size());
         m_enableToDispatchConsoleCommands = true;
     }
 #endif

--- a/Code/Framework/AzCore/AzCore/Console/Console.h
+++ b/Code/Framework/AzCore/AzCore/Console/Console.h
@@ -63,6 +63,9 @@ namespace AZ
         bool ExecuteDeferredConsoleCommands() override;
 
         void ClearDeferredConsoleCommands() override;
+#if defined (CARBONATED)
+        void EnableToDispatchConsoleCommands() override;
+#endif
 
         bool HasCommand(AZStd::string_view command, ConsoleFunctorFlags ignoreAnyFlags = ConsoleFunctorFlags::IsInvisible) override;
         ConsoleFunctorBase* FindCommand(AZStd::string_view command, ConsoleFunctorFlags ignoreAnyFlags = ConsoleFunctorFlags::IsInvisible) override;
@@ -114,6 +117,10 @@ namespace AZ
         };
         using DeferredCommandQueue = AZStd::deque<DeferredCommand>;
         DeferredCommandQueue m_deferredCommands;
+
+#if defined (CARBONATED)
+        bool m_enableToDispatchConsoleCommands;
+#endif
 
         friend struct ConsoleCommandKeyNotificationHandler;
         friend class ConsoleFunctorBase;

--- a/Code/Framework/AzCore/AzCore/Console/IConsole.h
+++ b/Code/Framework/AzCore/AzCore/Console/IConsole.h
@@ -109,6 +109,10 @@ namespace AZ
         //! Clear out any deferred console commands queue
         virtual void ClearDeferredConsoleCommands() = 0;
 
+#if defined (CARBONATED)
+        //! Enable to dispatch console command
+        virtual void EnableToDispatchConsoleCommands() = 0;
+#endif
         //! HasCommand is used to determine if the console knows about a command.
         //! @param command the command we are checking for
         //! @return boolean true on if the command is registered, false otherwise


### PR DESCRIPTION
Ticket: 15619

## What does this PR do?

Put the console commands into the deferred command queue until all modules are loaded.
Start to dispatch the commands after LoadModules() method is finished.
It makes the very similar Console command execution behavior for Monolithic build (e.g. on iOS) and non-Monolithic build (e.g. on PC).

When the first command has been executed:
1) Before this fix (half year ago):
On iOS we had 437 registered commands and on PC we had only 107 registered commands (see report in the 1st ticket comment). 
2) After this fix (today):
On iOS we have 459 registered commands and on PC we have 464 registered commands (almost the same). 

Note1: Initially I wanted to wait until CSystem initialization is finished, but Console commands are executed actively during CSystem initialization.
Note2: I did nothing for CXConsole, because CXConsole is created and initialized too later, right before CSystem initialization is finished.

## How was this PR tested?

Verified: with local PC game/editor and local iOS game
and iOS build 28614 (dev/qa)
