### PR TITLE
Fixes O3DE_IMGUI_RELEASE_ENABLED for release builds

### DIFF
--- a/Gems/ImGui/Code/CMakeLists.txt
+++ b/Gems/ImGui/Code/CMakeLists.txt
@@ -7,11 +7,6 @@
 #
 
 set(O3DE_IMGUI_RELEASE_ENABLED ON CACHE BOOL "Allow IMGUI in release builds")
-if($<CONFIG:release> AND NOT O3DE_IMGUI_RELEASE_ENABLED)
-    set(config_base_defines IMGUI_DISABLED)
-else()
-    set(config_base_defines IMGUI_ENABLED)
-endif()
 
 o3de_pal_dir(pal_source_dir ${CMAKE_CURRENT_LIST_DIR}/Source/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}" "${gem_parent_relative_path}")
 
@@ -33,7 +28,9 @@ ly_add_target(
             Include
     COMPILE_DEFINITIONS
         PUBLIC
-            ${config_base_defines}
+            $<$<AND:$<CONFIG:Release>,$<BOOL:${O3DE_IMGUI_RELEASE_ENABLED}>>:IMGUI_ENABLED>
+            $<$<AND:$<CONFIG:Release>,$<NOT:$<BOOL:${O3DE_IMGUI_RELEASE_ENABLED}>>>:IMGUI_DISABLED>
+            $<$<NOT:$<CONFIG:Release>>:IMGUI_ENABLED>
         INTERFACE
             $<$<NOT:$<BOOL:${LY_MONOLITHIC_GAME}>>:IMGUI_API_IMPORT>
             IMGUI_INCLUDE_IMGUI_USER_H


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where `IMGUI_ENABLED` was defined regardless of the value of `O3DE_IMGUI_RELEASE_ENABLED` 

## How was this PR tested?

Built for pc release/profile/debug with `O3DE_IMGUI_RELEASE_ENABLED` set to ON or OFF
