### PR TITLE
[MAD-16898] Editor & Standalone console input is stolen by imgui and the game

### DIFF
--- a/Code/Editor/Controls/ConsoleSCB.cpp
+++ b/Code/Editor/Controls/ConsoleSCB.cpp
@@ -487,6 +487,13 @@ void CConsoleSCB::SetInputFocus()
     ui->lineEdit->setText(QString());
 }
 
+#if defined(CARBONATED)
+bool CConsoleSCB::HasInputFocus()
+{
+    return ui->lineEdit->hasFocus();
+}
+#endif
+
 void CConsoleSCB::AddToConsole(const QString& text, bool bNewLine)
 {
     m_lines.push_back({ text, bNewLine });

--- a/Code/Editor/Controls/ConsoleSCB.cpp
+++ b/Code/Editor/Controls/ConsoleSCB.cpp
@@ -488,7 +488,7 @@ void CConsoleSCB::SetInputFocus()
 }
 
 #if defined(CARBONATED)
-bool CConsoleSCB::HasInputFocus()
+bool CConsoleSCB::HasInputFocus() const
 {
     return ui->lineEdit->hasFocus();
 }

--- a/Code/Editor/Controls/ConsoleSCB.h
+++ b/Code/Editor/Controls/ConsoleSCB.h
@@ -152,7 +152,7 @@ public:
     static void RegisterViewClass();
     void SetInputFocus();
 #if defined(CARBONATED)
-    bool HasInputFocus();
+    bool HasInputFocus() const;
 #endif
     void AddToConsole(const QString& text, bool bNewLine);
     void FlushText();

--- a/Code/Editor/Controls/ConsoleSCB.h
+++ b/Code/Editor/Controls/ConsoleSCB.h
@@ -151,6 +151,9 @@ public:
 
     static void RegisterViewClass();
     void SetInputFocus();
+#if defined(CARBONATED)
+    bool HasInputFocus();
+#endif
     void AddToConsole(const QString& text, bool bNewLine);
     void FlushText();
     QSize sizeHint() const override;

--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -2297,6 +2297,13 @@ int CCryEditApp::IdleProcessing(bool bBackgroundUpdate)
     return res;
 }
 
+#if defined(CARBONATED)
+bool CCryEditApp::HasConsoleSCBInputFocus() const
+{
+    return CConsoleSCB::GetCreatedInstance() && CConsoleSCB::GetCreatedInstance()->HasInputFocus();
+}
+#endif
+
 void CCryEditApp::DisplayLevelLoadErrors()
 {
     CCryEditDoc* currentLevel = GetIEditor()->GetDocument();

--- a/Code/Editor/CryEdit.h
+++ b/Code/Editor/CryEdit.h
@@ -159,6 +159,10 @@ public:
     QString GetRootEnginePath() const;
     void RedirectStdoutToNull();
 
+#if defined(CARBONATED)
+    bool HasConsoleSCBInputFocus() const;
+#endif
+
     // Overrides
 public:
     virtual bool InitInstance();

--- a/Gems/ImGui/Code/Source/ImGuiManager.cpp
+++ b/Gems/ImGui/Code/Source/ImGuiManager.cpp
@@ -93,6 +93,14 @@ namespace
         const auto& it = AZStd::find(touches.cbegin(), touches.cend(), inputChannelId);
         return it != touches.cend() ? static_cast<unsigned int>(it - touches.cbegin()) : UINT_MAX;
     }
+
+#if defined(CARBONATED)
+    bool IsAnyWindowFocusedExcludingMainMenuBar()
+    {
+        ImGuiWindow* window = ImGui::GetCurrentContext()->NavWindow;
+        return !(window && (window->Flags & ImGuiWindowFlags_MenuBar) && strcmp(window->Name, "##MainMenuBar") == 0);
+    }
+#endif
 }
 
 void ImGuiManager::Initialize()
@@ -602,6 +610,14 @@ bool ImGuiManager::OnInputChannelEventFiltered(const InputChannel& inputChannel)
         {
             return true;
         }
+
+#if defined(CARBONATED)
+        // If we have the Discrete Input Mode Disabled but any window is focused (excluding MainMenuBar).. then consume the input here.
+        if (IsAnyWindowFocusedExcludingMainMenuBar())
+        {
+            return true;
+        }
+#endif
 
         return consumeEvent;
     }


### PR DESCRIPTION
Ticket: 16898
## What does this PR do?

Issue: Editor & Standalone console input is stolen by imgui and the game

This PR contains two parts:
a) For Editor: it checks that the Editor ConsoleSCB has input focus
b) For Standalone: do not enable to stole keyboard/mouse/button/scroll_wheel input by the game when imgui menus have focus. To remove focus from imgui window(s) just press a mouse button somewhere outside the imgui windows

This PR requires PR-1171 in the game.

## How was this PR tested?

Verified locally on PC Editor & Standalone
