### PR TITLE
Extend video bus functionality to get video preload status

### DIFF
--- a/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
@@ -350,7 +350,7 @@ namespace AZ::Data
 // Gruber patch begin // AE -- update log while waiting for assets
 #if defined(CARBONATED)
                         // if we are here then it is the main thread, let deliver the log messages
-                        AZ::LogNotification::LogNotificatorBus::Broadcast(&AZ::LogNotification::LogNotificatorBus::Events::Update);
+                        AZ::LogNotification::LogNotificationBus::Broadcast(&AZ::LogNotification::LogNotificationBus::Events::Update);
                         // update subscribers while waiting for assets
                         currentWaitForAssetUpdate += MaxWaitBetweenDispatchMs;
                         if (currentWaitForAssetUpdate >= MaxWaitForAssetUpdateMs)

--- a/Code/Framework/AzCore/AzCore/Utils/LogNotification.h
+++ b/Code/Framework/AzCore/AzCore/Utils/LogNotification.h
@@ -33,7 +33,7 @@ namespace AZ
             {
             }
         };
-        typedef EBus<LogNotificator> LogNotificatorBus;
+        typedef EBus<LogNotificator> LogNotificationBus;
     }
 }
 

--- a/Code/Legacy/CryCommon/LoadScreenComponent.cpp
+++ b/Code/Legacy/CryCommon/LoadScreenComponent.cpp
@@ -10,6 +10,7 @@
 #include <AzFramework/API/ApplicationAPI.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Utils/LogNotification.h>
 #include <AzCore/Time/ITime.h>
 #include <CryCommon/ISystem.h>
 #include "IConsole.h"
@@ -353,6 +354,10 @@ void LoadScreenComponent::Stop()
             if (m_loadScreenState == LoadScreenState::Showing)
             {
                 EBUS_EVENT(LoadScreenBus, UpdateAndRender);
+#if defined(CARBONATED)
+                // deliver the log messages
+                AZ::LogNotification::LogNotificatorBus::Broadcast(&AZ::LogNotification::LogNotificatorBus::Events::Update);
+#endif
             }
 
             CrySleep(0);

--- a/Code/Legacy/CryCommon/LoadScreenComponent.cpp
+++ b/Code/Legacy/CryCommon/LoadScreenComponent.cpp
@@ -356,7 +356,7 @@ void LoadScreenComponent::Stop()
                 EBUS_EVENT(LoadScreenBus, UpdateAndRender);
 #if defined(CARBONATED)
                 // deliver the log messages
-                AZ::LogNotification::LogNotificatorBus::Broadcast(&AZ::LogNotification::LogNotificatorBus::Events::Update);
+                AZ::LogNotification::LogNotificationBus::Broadcast(&AZ::LogNotification::LogNotificationBus::Events::Update);
 #endif
             }
 

--- a/Code/Legacy/CrySystem/Log.cpp
+++ b/Code/Legacy/CrySystem/Log.cpp
@@ -78,7 +78,7 @@ static CLog::LogStringType indentString ("    ");
 // Gruber patch begin // AE -- update log while waiting for assets
 #if defined(CARBONATED)
 class LogNotificationProcessor
-    : public AZ::LogNotification::LogNotificatorBus::Handler
+    : public AZ::LogNotification::LogNotificationBus::Handler
 {
 public:
     LogNotificationProcessor()
@@ -91,11 +91,11 @@ public:
         if (m_log == nullptr && log != nullptr)
         {
             m_log = log;
-            AZ::LogNotification::LogNotificatorBus::Handler::BusConnect();
+            AZ::LogNotification::LogNotificationBus::Handler::BusConnect();
         }
         else if (m_log != nullptr && log == nullptr)
         {
-            AZ::LogNotification::LogNotificatorBus::Handler::BusDisconnect();
+            AZ::LogNotification::LogNotificationBus::Handler::BusDisconnect();
             m_log = log;
         }
         else
@@ -104,7 +104,7 @@ public:
         }
     }
 
-    // LogNotificatorBus implementation
+    // LogNotificationBus implementation
 
     void Update() override
     {

--- a/Gems/VideoPlaybackFramework/Code/Include/VideoPlaybackFramework/VideoPlaybackBus.h
+++ b/Gems/VideoPlaybackFramework/Code/Include/VideoPlaybackFramework/VideoPlaybackBus.h
@@ -58,6 +58,11 @@ namespace VideoPlaybackFramework
         * Load the video with given path name, and play video if auto play is active
         */
         virtual void LoadVideo() = 0;
+        
+        /*
+        * Returns if video preload is complete and the video is ready to play, if not waiting for this to return true there can be sound without image
+        */
+        virtual bool IsReadyToPlay() = 0;
 #endif
 
         /*

--- a/Gems/VideoPlaybackFramework/Code/Source/VideoPlaybackFrameworkSystemComponent.cpp
+++ b/Gems/VideoPlaybackFramework/Code/Source/VideoPlaybackFrameworkSystemComponent.cpp
@@ -97,6 +97,7 @@ namespace VideoPlaybackFramework
                 ->Event("ResetPlayback", &VideoPlaybackRequestBus::Events::ResetPlayback)
                 ->Event("ClearResourcesAndHide", &VideoPlaybackRequestBus::Events::ClearResourcesAndHide)
                 ->Event("LoadVideo", &VideoPlaybackRequestBus::Events::LoadVideo)
+                ->Event("IsReadyToPlay", &VideoPlaybackRequestBus::Events::IsReadyToPlay)
 #endif
                 ->Event("IsPlaying", &VideoPlaybackRequestBus::Events::IsPlaying)
                 ->Event("GetQueueAheadCount", &VideoPlaybackRequestBus::Events::GetQueueAheadCount)


### PR DESCRIPTION
## What does this PR do?

Add log output if level loading screen performs a wait cycle. This keeps the right order for non-main thread right messages.

Add video preload state bus call.

## How was this PR tested?

Local iOS build test, Jenkins iOS build test.
