### PR TITLE
[MAD-17011] Generate Android App Bundle with Play Asset Delivery pack module

### DIFF
--- a/Code/Tools/Android/ProjectBuilder/asset.build.gradle.in
+++ b/Code/Tools/Android/ProjectBuilder/asset.build.gradle.in
@@ -1,0 +1,22 @@
+//
+// Copyright (c) Contributors to the Open 3D Engine Project.
+// For complete copyright and license terms please see the LICENSE at the root of this distribution.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+
+// CARBONATED -- begin
+// Play Asset Delivery Pack 'build.gradle' file
+
+plugins {
+    id 'com.android.asset-pack'
+}
+
+assetPack {
+    // Directory name for the asset pack
+    packName = '${CARBONATED_ASSET_PACK_NAME}'
+    dynamicDelivery {
+        deliveryType = '${CARBONATED_ASSET_PACK_DELIVERY_TYPE}'
+    }
+}
+// CARBONATED -- end

--- a/Code/Tools/Android/ProjectBuilder/asset.build.gradle.in
+++ b/Code/Tools/Android/ProjectBuilder/asset.build.gradle.in
@@ -14,7 +14,7 @@ plugins {
 
 assetPack {
     // Directory name for the asset pack
-    packName = '${AAB_ASSET_PACK_NAME}'
+    packName = '${AAB_ASSET_PACK_DELIVERY_NAME}'
     dynamicDelivery {
         deliveryType = '${AAB_ASSET_PACK_DELIVERY_TYPE}'
     }

--- a/Code/Tools/Android/ProjectBuilder/asset.build.gradle.in
+++ b/Code/Tools/Android/ProjectBuilder/asset.build.gradle.in
@@ -14,9 +14,9 @@ plugins {
 
 assetPack {
     // Directory name for the asset pack
-    packName = '${CARBONATED_ASSET_PACK_NAME}'
+    packName = '${AAB_ASSET_PACK_NAME}'
     dynamicDelivery {
-        deliveryType = '${CARBONATED_ASSET_PACK_DELIVERY_TYPE}'
+        deliveryType = '${AAB_ASSET_PACK_DELIVERY_TYPE}'
     }
 }
 // CARBONATED -- end

--- a/Code/Tools/Android/ProjectBuilder/build.gradle.in
+++ b/Code/Tools/Android/ProjectBuilder/build.gradle.in
@@ -72,6 +72,10 @@ ${OVERRIDE_JAVA_SOURCESET}
     aaptOptions {
         noCompress 'pak'
     }
+
+    // CARBONATED -- begin
+    ${CARBONATED_ASSET_PACK_LIST}
+    // CARBONATED -- end    
 }
 
 // Inject the zip64 option into package task to allow 4GiB apks

--- a/Code/Tools/Android/ProjectBuilder/build.gradle.in
+++ b/Code/Tools/Android/ProjectBuilder/build.gradle.in
@@ -74,7 +74,7 @@ ${OVERRIDE_JAVA_SOURCESET}
     }
 
     // CARBONATED -- begin: assetPacks = [...]
-    ${CARBONATED_ASSET_PACK_LIST}
+    ${AAB_ASSET_PACK_LIST}
     // CARBONATED -- end    
 }
 

--- a/Code/Tools/Android/ProjectBuilder/build.gradle.in
+++ b/Code/Tools/Android/ProjectBuilder/build.gradle.in
@@ -73,7 +73,7 @@ ${OVERRIDE_JAVA_SOURCESET}
         noCompress 'pak'
     }
 
-    // CARBONATED -- begin
+    // CARBONATED -- begin: assetPacks = [...]
     ${CARBONATED_ASSET_PACK_LIST}
     // CARBONATED -- end    
 }

--- a/cmake/Tools/Platform/Android/android_support.py
+++ b/cmake/Tools/Platform/Android/android_support.py
@@ -836,6 +836,10 @@ class AndroidProjectGenerator(object):
         gradle_build_env['OVERRIDE_JAVA_SOURCESET'] = OVERRIDE_JAVA_SOURCESET_STR.format(absolute_azandroid_path=absolute_azandroid_path)
 
         gradle_build_env['OPTIONAL_JNI_SRC_LIB_SET'] = ', "outputs/native-lib"'
+        
+# CARBONATED -- begin
+        gradle_build_env['CARBONATED_ASSET_PACK_LIST'] = ''
+# CARBONATED -- end
 
         for native_config in BUILD_CONFIGURATIONS:
 

--- a/cmake/Tools/Platform/Android/android_support.py
+++ b/cmake/Tools/Platform/Android/android_support.py
@@ -838,7 +838,7 @@ class AndroidProjectGenerator(object):
         gradle_build_env['OPTIONAL_JNI_SRC_LIB_SET'] = ', "outputs/native-lib"'
         
 # CARBONATED -- begin
-        gradle_build_env['CARBONATED_ASSET_PACK_LIST'] = ''
+        gradle_build_env['AAB_ASSET_PACK_LIST'] = ''
 # CARBONATED -- end
 
         for native_config in BUILD_CONFIGURATIONS:

--- a/scripts/o3de/o3de/android_support.py
+++ b/scripts/o3de/o3de/android_support.py
@@ -176,7 +176,7 @@ SETTINGS_EXTRA_CMAKE_ARGS       = register_setting(key='extra.cmake.args',
                                                    description='Optional string to set additional cmake arguments during the native project generation within the android gradle build process')
 
 # CARBONATED -- begin : supported a sole install-time asset pack with size up to 1.5 Gb
-SETTINGS_AAB_ENABLE_ASSET_PACKS = register_setting(key='aab.enable.asset.packs',
+SETTINGS_AAB_ENABLE_ASSET_PACK = register_setting(key='aab.enable.asset.pack',
                                                    description='Integrate Play Asset Delivery pack into your project Android App Bundle.'
                                                    '(ref https://developer.android.com/guide/playcore/asset-delivery/integrate-native)',
                                                    is_boolean=True,
@@ -1001,7 +1001,7 @@ NATIVE_CMAKE_SECTION_ANDROID_FORMAT = """
 
 # CARBONATED -- begin : asset list description for the app/build.gradle
 AAB_ASSET_PACK_LIST_FORMAT = """
-            assetPacks = [':{asset_pack_names}']
+            assetPacks = [':{asset_pack_name}']
 """
 # CARBONATED -- end
 
@@ -1362,7 +1362,7 @@ class AndroidProjectGenerator(object):
         self._android_replacement_map_env = {}
         
 # CARBONATED -- begin : get the play delivery asset pack name
-        self._aab_enable_asset_packs = get_android_config(project_path=self._project_path).get_boolean_value(SETTINGS_AAB_ENABLE_ASSET_PACKS.key)
+        self._aab_enable_asset_pack = get_android_config(project_path=self._project_path).get_boolean_value(SETTINGS_AAB_ENABLE_ASSET_PACK.key)
 # CARBONATED -- end 
 
     def execute(self):
@@ -1400,7 +1400,7 @@ class AndroidProjectGenerator(object):
         project_names.extend(self.create_lumberyard_app(project_names))
 
 # CARBONATED -- begin : generate/append asset pack project to the project list 
-        if self._aab_enable_asset_packs:
+        if self._aab_enable_asset_pack:
             self.generate_aab_asset_pack_project()            
             project_names.append(AAB_ASSET_PACK_DELIVERY_NAME)
 # CARBONATED -- end
@@ -1610,7 +1610,7 @@ class AndroidProjectGenerator(object):
         This will create the asset module '{AAB_ASSET_PACK_DELIVERY_NAME}' which will be packaged as an extra assets.
         """
        
-        if not self._aab_enable_asset_packs:
+        if not self._aab_enable_asset_pack:
             return
         
         aab_asset_pack_path = self._build_dir / AAB_ASSET_PACK_DELIVERY_NAME
@@ -1705,8 +1705,8 @@ class AndroidProjectGenerator(object):
         gradle_build_env['NATIVE_CMAKE_SECTION_DEFAULT_CONFIG'] = NATIVE_CMAKE_SECTION_DEFAULT_CONFIG_NDK_FORMAT_STR.format(abi=ANDROID_ARCH)
 
 # CARBONATED -- begin : get the play delivery asset pack name        
-        if self._aab_enable_asset_packs:
-            gradle_build_env['AAB_ASSET_PACK_LIST'] = AAB_ASSET_PACK_LIST_FORMAT.format(asset_pack_names=AAB_ASSET_PACK_DELIVERY_NAME)            
+        if self._aab_enable_asset_pack:
+            gradle_build_env['AAB_ASSET_PACK_LIST'] = AAB_ASSET_PACK_LIST_FORMAT.format(asset_pack_name=AAB_ASSET_PACK_DELIVERY_NAME)            
             az_asset_android_dst_path = self._build_dir / AAB_ASSET_PACK_DELIVERY_NAME
         else:
             gradle_build_env['AAB_ASSET_PACK_LIST'] = ''

--- a/scripts/o3de/o3de/android_support.py
+++ b/scripts/o3de/o3de/android_support.py
@@ -179,7 +179,8 @@ SETTINGS_EXTRA_CMAKE_ARGS       = register_setting(key='extra.cmake.args',
 SETTINGS_INTEGRATE_AAB_ASSET_PACK = register_setting(key='integrate.aab.asset.pack',
                                                    description='Integrate Play Asset Delivery pack into your project Android App Bundle.'
                                                    '(ref https://developer.android.com/guide/playcore/asset-delivery/integrate-native)',
-                                                   is_boolean=False)
+                                                   is_boolean=True,
+                                                   default='False')
 # CARBONATED -- end
 
 def get_android_config(project_path: Path or None) -> command_utils.O3DEConfig:
@@ -1361,7 +1362,7 @@ class AndroidProjectGenerator(object):
         self._android_replacement_map_env = {}
         
 # CARBONATED -- begin : get the play delivery asset pack name
-        self._integrate_aab_asset_pack = get_android_config(project_path=self._project_path).get_value(SETTINGS_INTEGRATE_AAB_ASSET_PACK.key)
+        self._integrate_aab_asset_pack = get_android_config(project_path=self._project_path).get_boolean_value(SETTINGS_INTEGRATE_AAB_ASSET_PACK.key)
 # CARBONATED -- end 
 
     def execute(self):

--- a/scripts/o3de/o3de/android_support.py
+++ b/scripts/o3de/o3de/android_support.py
@@ -75,7 +75,7 @@ ANDROID_SETTINGS_FILE = '.command_settings'
 ANDROID_SETTINGS_SECTION_NAME = 'android'
 
 # CARBONATED -- begin : asset pack definitions
-AAB_ASSET_PACK_NAME = 'app_asset_pack'
+AAB_ASSET_PACK_DELIVERY_NAME = 'app_asset_pack'
 AAB_ASSET_PACK_DELIVERY_TYPE = 'install-time'
 # CARBONATED -- end
 
@@ -176,7 +176,7 @@ SETTINGS_EXTRA_CMAKE_ARGS       = register_setting(key='extra.cmake.args',
                                                    description='Optional string to set additional cmake arguments during the native project generation within the android gradle build process')
 
 # CARBONATED -- begin : supported a sole install-time asset pack with size up to 1.5 Gb
-SETTINGS_INTEGRATE_AAB_ASSET_PACK = register_setting(key='integrate.aab.asset.pack',
+SETTINGS_AAB_ENABLE_ASSET_PACKS = register_setting(key='aab.enable.asset.packs',
                                                    description='Integrate Play Asset Delivery pack into your project Android App Bundle.'
                                                    '(ref https://developer.android.com/guide/playcore/asset-delivery/integrate-native)',
                                                    is_boolean=True,
@@ -1001,7 +1001,7 @@ NATIVE_CMAKE_SECTION_ANDROID_FORMAT = """
 
 # CARBONATED -- begin : asset list description for the app/build.gradle
 AAB_ASSET_PACK_LIST_FORMAT = """
-            assetPacks = [':{asset_pack_name}']
+            assetPacks = [':{asset_pack_names}']
 """
 # CARBONATED -- end
 
@@ -1362,7 +1362,7 @@ class AndroidProjectGenerator(object):
         self._android_replacement_map_env = {}
         
 # CARBONATED -- begin : get the play delivery asset pack name
-        self._integrate_aab_asset_pack = get_android_config(project_path=self._project_path).get_boolean_value(SETTINGS_INTEGRATE_AAB_ASSET_PACK.key)
+        self._aab_enable_asset_packs = get_android_config(project_path=self._project_path).get_boolean_value(SETTINGS_AAB_ENABLE_ASSET_PACKS.key)
 # CARBONATED -- end 
 
     def execute(self):
@@ -1400,9 +1400,9 @@ class AndroidProjectGenerator(object):
         project_names.extend(self.create_lumberyard_app(project_names))
 
 # CARBONATED -- begin : generate/append asset pack project to the project list 
-        if self._integrate_aab_asset_pack:
+        if self._aab_enable_asset_packs:
             self.generate_aab_asset_pack_project()            
-            project_names.append(AAB_ASSET_PACK_NAME)
+            project_names.append(AAB_ASSET_PACK_DELIVERY_NAME)
 # CARBONATED -- end
 
         root_gradle_env = {
@@ -1607,13 +1607,13 @@ class AndroidProjectGenerator(object):
 
     def generate_aab_asset_pack_project(self):
         """
-        This will create the asset module '{AAB_ASSET_PACK_NAME}' which will be packaged as an extra assets.
+        This will create the asset module '{AAB_ASSET_PACK_DELIVERY_NAME}' which will be packaged as an extra assets.
         """
        
-        if not self._integrate_aab_asset_pack:
+        if not self._aab_enable_asset_packs:
             return
         
-        aab_asset_pack_path = self._build_dir / AAB_ASSET_PACK_NAME
+        aab_asset_pack_path = self._build_dir / AAB_ASSET_PACK_DELIVERY_NAME
             
         logging.debug("Create Play Asset Delivery pack to '%s'", aab_asset_pack_path.resolve())        
         
@@ -1639,7 +1639,7 @@ class AndroidProjectGenerator(object):
         # Prepare the 'build.gradle' template generation
         gradle_build_env = dict()
        
-        gradle_build_env['AAB_ASSET_PACK_NAME'] = AAB_ASSET_PACK_NAME            
+        gradle_build_env['AAB_ASSET_PACK_DELIVERY_NAME'] = AAB_ASSET_PACK_DELIVERY_NAME            
         gradle_build_env['AAB_ASSET_PACK_DELIVERY_TYPE'] = AAB_ASSET_PACK_DELIVERY_TYPE
         
         app_asset_pack_gradle_file = aab_asset_pack_path / 'build.gradle'
@@ -1705,9 +1705,9 @@ class AndroidProjectGenerator(object):
         gradle_build_env['NATIVE_CMAKE_SECTION_DEFAULT_CONFIG'] = NATIVE_CMAKE_SECTION_DEFAULT_CONFIG_NDK_FORMAT_STR.format(abi=ANDROID_ARCH)
 
 # CARBONATED -- begin : get the play delivery asset pack name        
-        if self._integrate_aab_asset_pack:
-            gradle_build_env['AAB_ASSET_PACK_LIST'] = AAB_ASSET_PACK_LIST_FORMAT.format(asset_pack_name=AAB_ASSET_PACK_NAME)            
-            az_asset_android_dst_path = self._build_dir / AAB_ASSET_PACK_NAME
+        if self._aab_enable_asset_packs:
+            gradle_build_env['AAB_ASSET_PACK_LIST'] = AAB_ASSET_PACK_LIST_FORMAT.format(asset_pack_names=AAB_ASSET_PACK_DELIVERY_NAME)            
+            az_asset_android_dst_path = self._build_dir / AAB_ASSET_PACK_DELIVERY_NAME
         else:
             gradle_build_env['AAB_ASSET_PACK_LIST'] = ''
             az_asset_android_dst_path = az_android_dst_path


### PR DESCRIPTION
Ticket: 17011

## What does this PR do?

Generate Android App Bundle with Play Asset Delivery pack module.

Note: currently we support a sole install-time asset pack with size up to 1.5 Gb because it is enough for us

## How was this PR tested?

Was verified locally on PC:

1) AAB file with a pack module was generated on PC for Release with AAB mode

2) Then AAB file was extracted to APKS via command line (with a local keystore):
`java -jar bundletool-all-1.17.2.jar build-apks --bundle=app-release.aab  --output=output.apks --local-testing --ks=gruber-development.jks --ks-key-alias=gruber-development`

3) Then APKS was installed to device via command line: 
`java -jar bundletool-all-1.17.2.jar install-apks --apks=output.apks `

Now: both PRs are being verified via Jenkins