### PR TITLE
Adding option to only use half of available cores for asset processing

### DIFF
--- a/Code/Tools/AssetProcessor/native/resourcecompiler/rccontroller.cpp
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/rccontroller.cpp
@@ -31,10 +31,25 @@ namespace AssetProcessor
 
         maxJobs = qMax<int>(maxJobs - 1, 1);
 
+#if defined(CARBONATED)
+        if (cfg_maxJobs > 0)
+        {
+            // if the user has specified max jobs in the cfg file, then we obey their request
+            // regardless of whether they have chosen something bad or not - they would have had to explicitly
+            // pick this value (we ship with default 0 meaning auto), so if they've changed it, they intend it that way
+            m_maxJobs = cfg_maxJobs ? qMax(cfg_minJobs, cfg_maxJobs) : maxJobs;
+        }
+        else if (cfg_maxJobs == -1) 
+        {
+            // -1 indicates half of the ideal thread count
+            m_maxJobs = maxJobs / 2;
+        }
+#else
         // if the user has specified max jobs in the cfg file, then we obey their request
         // regardless of whether they have chosen something bad or not - they would have had to explicitly
         // pick this value (we ship with default 0 meaning auto), so if they've changed it, they intend it that way
         m_maxJobs = cfg_maxJobs ? qMax(cfg_minJobs, cfg_maxJobs) :  maxJobs;
+#endif
 
         m_RCQueueSortModel.AttachToModel(&m_RCJobListModel);
 


### PR DESCRIPTION
## What does this PR do?

Allows "maxJobs = -1" in setreg to use half of the available cores asset processing.  This is so that a given developer machine isn't entirely whalloped by heavy threads, both in processing and memory consumption.

Set: `Amazon/AssetProcessor/Settings/Jobs/maxJobs = -1` to enable.

## How was this PR tested?

Locally on PC Asset Processor.
