### PR TITLE
Fix for AP Batch not reflecting the PlatformConfiguration.

### DIFF
--- a/Code/Tools/AssetProcessor/native/utilities/BatchApplicationManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/BatchApplicationManager.cpp
@@ -83,6 +83,14 @@ void BatchApplicationManager::OnErrorMessage([[maybe_unused]] const char* error)
 void BatchApplicationManager::Reflect()
 {
     ApplicationManagerBase::Reflect();
+
+#if defined(CARBONATED)
+    AZ::SerializeContext* context;
+    AZ::ComponentApplicationBus::BroadcastResult(context, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
+    AZ_Assert(context, "No serialize context");
+
+    AssetProcessor::PlatformConfiguration::Reflect(context);
+#endif
 }
 
 const char* BatchApplicationManager::GetLogBaseName()


### PR DESCRIPTION
## What does this PR do?

Reflects PlatformConfiguration so that the APB can correctly read the settings.json for the shared assets cache.

## How was this PR tested?

Locally on PC
