### PR TITLE
[MAD-15563] Print out logs when decals are added to the o3de decal list or removed from this list

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.h
@@ -143,6 +143,9 @@ namespace AZ
             // Cull the decals for a view using the CPU.
             void CullDecals(const RPI::ViewPtr& view);
             void UpdateBounds(const DecalHandle handle);
+#if defined(CARBONATED)
+            void LogDecalDebugInfo(const AZStd::string& text, const DecalLocation& decalLocation) const;
+#endif
 
             MultiIndexedDataVector<DecalData, AZ::Aabb> m_decalData;
             RHI::Handle<uint32_t> m_decalMeshFlag;


### PR DESCRIPTION
Ticket: [MAD-15563]

## What does this PR do?

Printed out logs when decals are added to the o3de decal list or removed from this list

To switch this logger off/on use: 
`r_logDecals=0/1`

Example of logger output:

```
<18:19:46.829> (DecalTextureArrayFeatureProcessor) - Added decal: size=4x4 hint='dlc/environments/worldmap/materials/territories_decal.azmaterial' id='{27BC698C-3BEB-5015-8E0C-133E380A6EB8}:0' depth=1
<18:19:49.235> (DecalTextureArrayFeatureProcessor) - Added decal: size=2048x2048 hint='dlc/abilities/models/ability_cone.azmaterial' id='{FA37FD68-5394-5B1A-9582-210D8CD8FD32}:0' depth=1
<18:22:04.984> (DecalTextureArrayFeatureProcessor) - Removed decal: size=4x4 hint='dlc/environments/worldmap/materials/territories_decal.azmaterial' id='{27BC698C-3BEB-5015-8E0C-133E380A6EB8}:0' depth=1
<18:22:34.152> (DecalTextureArrayFeatureProcessor) - Added decal: size=512x512 hint='dlc/game_common/materials/coverraildecal.azmaterial' id='{6F8A9774-26A2-537F-83F3-EBAF5534E47B}:0' depth=1
<18:22:55.429> (DecalTextureArrayFeatureProcessor) - Added decal: size=112x112 hint='dlc/command_mode/materials/path_indicator.azmaterial' id='{10CDED9C-D7C2-5347-A2E4-299E76015529}:0' depth=1
```




## How was this PR tested?

Locally on PC


[MAD-15563]: https://carbonated.atlassian.net/browse/MAD-15563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ