### PR TITLE
More info on mip errors, return assertsion (MAD-14291 )

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/StreamingImageAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/StreamingImageAsset.cpp
@@ -59,11 +59,18 @@ namespace AZ
 
         size_t StreamingImageAsset::GetMipChainIndex(size_t mipLevel) const
         {
+#if defined(CARBONATED)
             if (mipLevel >= m_imageDescriptor.m_mipLevels)
             {
-                AZ_Error("StreamingImageAsset", false, "Input mipLevel doesn't exist"); // Gruber patch begin // VMED // error instead mipmap assert (MADPORT-459)
+                // MAD-14291 extended diagnostic
+                AZ::Data::AssetInfo assetInfo;
+                AZ::Data::AssetCatalogRequestBus::BroadcastResult(assetInfo, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetInfoById, GetId());
+                AZ_Assert(false, "MipError: mipLevel %d is out of range, %d for %s",
+                    mipLevel, m_imageDescriptor.m_mipLevels, assetInfo.m_relativePath.c_str());
+
                 mipLevel = m_imageDescriptor.m_mipLevels - 1;
             }
+#endif
             return m_mipLevelToChainIndex[mipLevel];
         }
 


### PR DESCRIPTION
## What does this PR do?

Restore original assertions instead of error messages. Add more detail to the assert messages.

## How was this PR tested?

Tested iOS Jenkins build, no assertions. I believe there might be some if tested on many devices, so it can potentially endanger a beta-test if we are going to conduct it the next week.
