### PR TITLE
Pulling in a handful of recommended PRs from developer

### DIFF
--- a/Code/Framework/AtomCore/AtomCore/Instance/InstanceDatabase.h
+++ b/Code/Framework/AtomCore/AtomCore/Instance/InstanceDatabase.h
@@ -17,6 +17,7 @@
 #include <AzCore/Module/Environment.h>
 #include <AzCore/std/parallel/shared_mutex.h>
 
+
 namespace AZStd
 {
     class any;
@@ -246,6 +247,12 @@ namespace AZ
             mutable AZStd::recursive_mutex m_databaseMutex;
             AZStd::unordered_map<InstanceId, Type*> m_database;
 
+            // There are several classes in Atom, like ShaderResourceGroup, that are not threadsafe
+            // because they share the same ShaderResourceGroupPool, so it is important that for each
+            // InstanceType there's a mutex that prevents several of those classes from being instantiated
+            // simultaneously.
+            AZStd::recursive_mutex m_instanceCreationMutex;
+
             // All instances created by this InstanceDatabase will be for assets derived from this type.
             AssetType m_baseAssetType;
 
@@ -316,19 +323,6 @@ namespace AZ
                 return nullptr;
             }
 
-            // Take a lock to guard the insertion.  Note that this will not guard against recursive insertions on the same thread.
-            AZStd::scoped_lock<AZStd::recursive_mutex> lock(m_databaseMutex);
-
-            // Search again in case someone else got here first.
-            auto iter = m_database.find(id);
-            if (iter != m_database.end())
-            {
-                InstanceData* data = static_cast<InstanceData*>(iter->second);
-                ValidateSameAsset(data, asset);
-
-                return iter->second;
-            }
-
             return EmplaceInstance(id, assetLocal, param);
         }
 
@@ -351,8 +345,6 @@ namespace AZ
                 return nullptr;
             }
 
-            // Take a lock to guard the insertion.  Note that this will not guard against recursive insertions on the same thread.
-            AZStd::scoped_lock<AZStd::recursive_mutex> lock(m_databaseMutex);
             return EmplaceInstance(id, assetLocal, param);
         }
 
@@ -391,41 +383,55 @@ namespace AZ
         Data::Instance<Type> InstanceDatabase<Type>::EmplaceInstance(
             const InstanceId& id, const Data::Asset<AssetData>& asset, const AZStd::any* param)
         {
-            // This assert is here to catch any potential non-randomness in our id generation. If it triggers,
-            // there might be a bug / race condition in the id generator. The same assert also occurs *after*
-            // instance creation to help differentiate between a non-random id vs recursive creation of the same id.
-            AZ_Assert(
-                !m_database.contains(id),
-                "Database already contains an instance for this id (%s), possibly a random id generation collision?",
-                id.ToString<AZStd::fixed_string<64>>().c_str());
+            // It's very important to have m_databaseMutex unlocked while an instance is being created because
+            // there can be cases like in StreamingImage(s), where multiple threads are involved and some of those threads
+            // attempt to release a StreamingImage, which in turn will lock m_databaseMutex and it could incurr
+            // in potential deadlocks.
 
-            // Emplace a new instance and return it.
+            // If the instance was created redundantly, it will be temporarily stored here for destruction
+            // before this function returns.
+            Data::Instance<Type> redundantInstance = nullptr;
+
             // It's possible for the m_createFunction call to recursively trigger another FindOrCreate call, so be aware that
             // the contents of m_database may change within this call.
             Data::Instance<Type> instance = nullptr;
-            if (!param)
+
             {
-                instance = m_instanceHandler.m_createFunction(asset.Get());
-            }
-            else
-            {
-                instance = m_instanceHandler.m_createFunctionWithParam(asset.Get(), param);
+                AZStd::scoped_lock<decltype(m_instanceCreationMutex)> lock(m_instanceCreationMutex);
+                if (!param)
+                {
+                    instance = m_instanceHandler.m_createFunction(asset.Get());
+                }
+                else
+                {
+                    instance = m_instanceHandler.m_createFunctionWithParam(asset.Get(), param);
+                }
             }
 
+            // Lock the database. There's still a chance that the same instance was created in parallel.
+            // in such case we return the first one that made it into the database and gracefully release the
+            // redundant one.
             if (instance)
             {
-                AZ_Assert(
-                    !m_database.contains(id),
-                    "Instance creation for asset id %s resulted in a recursive creation of that asset, which was unexpected. "
-                    "This asset might be erroneously referencing itself as a dependent asset.",
-                    asset.GetHint().c_str());
-
-                instance->m_id = id;
-                instance->m_parentDatabase = this;
-                instance->m_assetId = asset.GetId();
-                instance->m_assetType = asset.GetType();
-                m_database.emplace(id, instance.get());
+                AZStd::scoped_lock<AZStd::recursive_mutex> lock(m_databaseMutex);
+                auto iter = m_database.find(id);
+                if (iter != m_database.end())
+                {
+                    InstanceData* data = static_cast<InstanceData*>(iter->second);
+                    ValidateSameAsset(data, asset);
+                    redundantInstance = instance; // Will be destroyed as soon as we return from this function.
+                    instance = iter->second;
+                }
+                else
+                {
+                    instance->m_id = id;
+                    instance->m_parentDatabase = this;
+                    instance->m_assetId = asset.GetId();
+                    instance->m_assetType = asset.GetType();
+                    m_database.emplace(id, instance.get());
+                }
             }
+
             return instance;
         }
 

--- a/Code/Framework/AzCore/AzCore/Memory/SystemAllocator.cpp
+++ b/Code/Framework/AzCore/AzCore/Memory/SystemAllocator.cpp
@@ -26,6 +26,11 @@
 #define AZCORE_SYSTEM_ALLOCATOR_MALLOC 2
 
 #if !defined(AZCORE_SYSTEM_ALLOCATOR)
+    // We are using here AZCORE_SYSTEM_ALLOCATOR_HPHA for the sake of passing unit tests.
+    // But it's been found that, when using Vulkan, and working with levels that have
+    // large amount of meshes, entering/Exiting game mode puts lost of stress in memory allocation that crashes
+    // when using HPHA. With AZCORE_SYSTEM_ALLOCATOR_MALLOC crashes don't occur.
+    // TODO: Review Github Issue #18597
     #define AZCORE_SYSTEM_ALLOCATOR AZCORE_SYSTEM_ALLOCATOR_HPHA
 #endif
 

--- a/Code/Framework/AzCore/AzCore/Serialization/Json/JsonDeserializer.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/Json/JsonDeserializer.cpp
@@ -191,6 +191,12 @@ namespace AZ
 
         AZ_Assert(context.GetRegistrationContext() && context.GetSerializeContext(), "Expected valid registration context and serialize context.");
 
+        // Compatibility with Reflection Serialize - it expects this callback after before into a C++ class.
+        if (classData.m_eventHandler)
+        {
+            classData.m_eventHandler->OnWriteBegin(object);
+        }
+
         size_t numLoads = 0;
         ResultCode retVal(Tasks::ReadField);
         for (auto iter = value.MemberBegin(); iter != value.MemberEnd(); ++iter)
@@ -230,6 +236,12 @@ namespace AZ
         if (elementCount > numLoads)
         {
             retVal.Combine(ResultCode(Tasks::ReadField, numLoads == 0 ? Outcomes::DefaultsUsed : Outcomes::PartialDefaults));
+        }
+
+        // Compatibility with Reflection Serialize - it expects this callback after reading into a C++ class.
+        if (classData.m_eventHandler)
+        {
+            classData.m_eventHandler->OnWriteEnd(object);
         }
 
         return retVal;

--- a/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.h
@@ -1191,27 +1191,53 @@ namespace AZ::Serialize
 
     /**
      * Serialize class events.
+     * These can be used to hook certain events that occur when reading/writing objects using the Serialize Reflection Context
+     * Note that these events will NOT be called if you have installed a custom serializer for your custom class, since
+     * in that case, your class will be entirely handled by that custom serializer installed.  This is true for both the ObjectStream (XML, binary)
+     * and JSON serializers - using a custom serializer skips this part, so if you do need to do anything special, do it in the custom serializer.
      * IMPORTANT: Serialize events can be called from serialization thread(s). So all functions should be thread safe.
+     *
+     *  Important note:
+     * OnReadBegin and OnReadEnd are not called when using the Json serializer, because the Json serializer's API assumes that
+     * reading from C++ objects into JSON has no side effects on the objects being serialized, and thus will not call a non-const
+     * callback such as these.
+     *
+     * The ObjectStream serializer has no problem with this and will in fact const-cast the const ptr fed into it, just so that it can
+     * invoke OnReadBegin and OnReadEnd.
+     * 
+     * OnReadBegin and OnReadEnd are called during serialization - that is, when reading FROM a C++ object INTO an ObjectStream stream,
+     * and the purpose of which is to fixup data in the c++ object before / after saving it to a data stream.
+     * If you want to fix up data after LOADING it into a C++ object, use OnWriteEnd, not OnReadEnd.
+     *
+     * Additional Caveat:  It is possible to tell the serialize context to walk a tree of reflected C++ objects and invoke a callback
+     * for each element on them - this is, in fact, how serializing works (it walks the tree of reflected objects and serializes them).
+     * If you are using this feature, you should be aware that OnReadBegin and OnReadEnd will be called for each element in the tree,
+     * since it is "reading from" the objects.  However, if you pass the ENUM_ACCESS_FOR_WRITE flag, it will INSTEAD call OnWriteBegin
+     * and OnWriteEnd for the c++ objects it is visiting, despite the fact that you are technically enumerating them.
      */
     class IEventHandler
     {
     public:
         virtual ~IEventHandler() {}
 
+        /// the Read**** functions are called when SERIALIZING.  Do not use them to do post-load fixups.
         /// Called right before we start reading from the instance pointed by classPtr.
         virtual void OnReadBegin(void* classPtr) { (void)classPtr; }
         /// Called after we are done reading from the instance pointed by classPtr.
         virtual void OnReadEnd(void* classPtr) { (void)classPtr; }
 
+        /// The Write**** functions are called when DESERIALIZING.  You can use these to do post-load fixups.
         /// Called right before we start writing to the instance pointed by classPtr.
         virtual void OnWriteBegin(void* classPtr) { (void)classPtr; }
         /// Called after we are done writing to the instance pointed by classPtr.
         /// NOTE: Care must be taken when using this callback. It is called when ID remapping occurs,
-        /// an instance is clone or an instance is loaded from an objectstream.
+        /// an instance is cloned or an instance is loaded from an ObjectStream.
         /// This means that this function can be invoked multiple times in the course of serializing a new instance from an ObjectStream
         /// or cloning an object.
         virtual void OnWriteEnd(void* classPtr) { (void)classPtr; }
 
+        /// PATCHING
+        /// These functions will not be called when using the Json serializer, as patching operates entirely differently.
         /// Called right before we start data patching the instance pointed by classPtr.
         virtual void OnPatchBegin(void* classPtr, const DataPatchNodeInfo& patchInfo) { (void)classPtr; (void)patchInfo; }
         /// Called after we are done data patching the instance pointed by classPtr.

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/Script/SpawnableScriptAssetRef.h
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/Script/SpawnableScriptAssetRef.h
@@ -38,7 +38,8 @@ namespace AzFramework::Scripts
     private:
         class SerializationEvents : public AZ::SerializeContext::IEventHandler
         {
-            void OnReadEnd(void* classPtr) override
+            // Called when the Serializer has completed writing TO the c++ object in memory.
+            void OnWriteEnd(void* classPtr) override
             {
                 SpawnableScriptAssetRef* spawnableScriptAssetRef = reinterpret_cast<SpawnableScriptAssetRef*>(classPtr);
                 // Call SetAsset to connect AssetBus handler as soon as m_asset field is set

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/EditorViewportIconDisplayInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/EditorViewportIconDisplayInterface.h
@@ -60,9 +60,22 @@ namespace AzToolsFramework
             Error
         };
 
-        //! Draws an icon to a viewport given a set of draw parameters.
+        //! Draws an icon (immediately) to a viewport given a set of draw parameters.
         //! Requires an IconId retrieved from GetOrLoadIconForPath.
+        //! Note that this is an immediate draw request for backward compatability.
+        //! For more efficient rendering, use the AddIcon method.
         virtual void DrawIcon(const DrawParameters& drawParameters) = 0;
+
+        //! Adds an icon to the upcoming draw batch.
+        //! Use DrawIcons() after adding them all to actually commit them to the renderer.
+        //! DrawParameters.m_viewport must be set to a valid viewport and must be the same viewport
+        //! as all other invocations of AddIcon since the last call to DrawIcons (do one viewport at a time!)
+        virtual void AddIcon(const DrawParameters& drawParameters) = 0;
+
+        //! Call this after adding all of the icons via AddIcon.
+        //! This commits all of them to the renderer, in batches organized per icon texture.
+        virtual void DrawIcons() = 0;
+
         //! Retrieves a reusable IconId for an icon at a given path.
         //! This will load the icon, if it has not already been loaded.
         //! @param path should be a relative asset path to an icon image asset.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityHelpers.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityHelpers.h
@@ -8,13 +8,15 @@
 #pragma once
 
 #include <AzCore/Component/Component.h>
+#include <AzCore/Component/ComponentApplication.h>
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/std/optional.h>
+
 #include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
 #include <AzToolsFramework/ToolsComponents/EditorDisabledCompositionBus.h>
 #include <AzToolsFramework/ToolsComponents/EditorPendingCompositionBus.h>
 #include <AzToolsFramework/API/EntityCompositionRequestBus.h>
-#include <AzCore/Component/ComponentApplication.h>
 
 namespace AzToolsFramework
 {
@@ -109,6 +111,30 @@ namespace AzToolsFramework
     /// Return true if the editor should show this component to users,
     /// false if the component should be hidden from users.
     bool ShouldInspectorShowComponent(const AZ::Component* component);
+
+    //! Components can set an attribute (@ref AZ::Edit::Attributes::FixedComponentListIndex) to specify
+    //! that they should appear at a fixed position in the property editor and should not be draggable.
+    //! This helper function will return that index if it is set, or an empty optional if it is not.
+    AZStd::optional<int> GetFixedComponentListIndex(const AZ::Component* component);
+
+    //! Returns true if the component can be removed by the entity inspector.
+    bool IsComponentRemovable(const AZ::Component* component);
+
+    //! Returns true if the given component is draggable in the entity inspector.
+    bool IsComponentDraggable(const AZ::Component* component);
+
+    //! Given a ComponentArrayType, sort them into the order they would by default be sorted
+    //! based on various attributes such as whether they can be dragged, deleted, whether they are
+    //! visible, etc, but does not take into account the user modified order from dragging and dropping
+    //! Note that this sort will try its best to keep things in the order they were in the original array
+    //! and will attempt to only move elements around if necessary, so they can be sorted in another way first,
+    //! then sorted by this function to ensure any additional constraints are met.
+    void SortComponentsByPriority(AZ::Entity::ComponentArrayType& componentsOnEntity);
+
+    //! Sorts the components on the entity based on the order specified in the componentOrder array on the entity.
+    //! The order will shuffle around since this is not a stable sort, but it can be sorted by priority afterwards to stabilize.
+    //! Helper function, same as above, but sorts components by order by getting the order from the given entityId.
+    void SortComponentsByOrder(const AZ::EntityId entityId, AZ::Entity::ComponentArrayType& componentsOnEntity);
 
     AZ::EntityId GetEntityIdForSortInfo(const AZ::EntityId parentId);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorEntityIconComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorEntityIconComponent.cpp
@@ -14,6 +14,7 @@
 #include <AzToolsFramework/API/EditorAssetSystemAPI.h>
 #include <AzToolsFramework/API/EditorViewportIconDisplayInterface.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
+#include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 #include <AzToolsFramework/ToolsComponents/EditorVisibilityBus.h>
 #include <AzToolsFramework/ToolsComponents/GenericComponentWrapper.h>
 #include <AzToolsFramework/ToolsComponents/TransformComponent.h>
@@ -65,8 +66,8 @@ namespace AzToolsFramework
 
         void EditorEntityIconComponent::Activate()
         {
+            m_needsInitialUpdate = true;
             EditorComponentBase::Activate();
-            AZ::EntityBus::Handler::BusConnect(GetEntityId());
             EditorEntityIconComponentRequestBus::Handler::BusConnect(GetEntityId());
             EditorInspectorComponentNotificationBus::Handler::BusConnect(GetEntityId());
         }
@@ -75,7 +76,6 @@ namespace AzToolsFramework
         {
             EditorInspectorComponentNotificationBus::Handler::BusDisconnect();
             EditorEntityIconComponentRequestBus::Handler::BusDisconnect();
-            AZ::EntityBus::Handler::BusDisconnect();
             EditorComponentBase::Deactivate();
         }
 
@@ -83,8 +83,14 @@ namespace AzToolsFramework
         {
             if (m_entityIconAssetId != assetId)
             {
+                // Note that we could be going from a situation where we had an icon, to one where we don't so the cache needs refreshing.
+                if (!assetId.IsValid())
+                {
+                    m_needsInitialUpdate = true;
+                }
                 m_entityIconAssetId = assetId;
-                m_entityIconCache.SetEntityIconPath(CalculateEntityIconPath(m_firstComponentIdCache));
+                m_entityIconCache.SetEntityIconPath(CalculateEntityIconPath());
+                                
                 EditorEntityIconComponentNotificationBus::Event(GetEntityId(), &EditorEntityIconComponentNotificationBus::Events::OnEntityIconChanged, m_entityIconAssetId);
                 SetDirty();
             }
@@ -97,36 +103,38 @@ namespace AzToolsFramework
 
         AZStd::string EditorEntityIconComponent::GetEntityIconPath()
         {
-            if (m_entityIconCache.Empty())
-            {
-                UpdateFirstComponentIdCache();
-                m_entityIconCache.SetEntityIconPath(CalculateEntityIconPath(m_firstComponentIdCache));
-            }
-
+            RefreshCachesIfNecessary();
             return m_entityIconCache.GetEntityIconPath();
         }
 
         int EditorEntityIconComponent::GetEntityIconTextureId()
         {
+            RefreshCachesIfNecessary();
             return m_entityIconCache.GetEntityIconTextureId();
+        }
+
+        void EditorEntityIconComponent::RefreshCachesIfNecessary()
+        {
+            if (!m_needsInitialUpdate)
+            {
+                return;
+            }
+
+            m_needsInitialUpdate = false;
+
+            if (m_firstComponentIdCache == AZ::InvalidComponentId)
+            {
+                UpdatePreferNoViewportIconFlag();
+                UpdateFirstComponentIdCache();
+            }
+
+            m_entityIconCache.SetEntityIconPath(CalculateEntityIconPath());
         }
 
         bool EditorEntityIconComponent::IsEntityIconHiddenInViewport()
         {
+            RefreshCachesIfNecessary();
             return (!m_entityIconAssetId.IsValid() && m_preferNoViewportIcon);
-        }
-
-        void EditorEntityIconComponent::OnEntityActivated(const AZ::EntityId&)
-        {
-            if (m_entityIconCache.Empty())
-            {
-                /* The case where the entity is activated the first time. */
-
-                UpdatePreferNoViewportIconFlag();
-                UpdateFirstComponentIdCache();
-                m_entityIconCache.SetEntityIconPath(CalculateEntityIconPath(m_firstComponentIdCache));
-                EditorEntityIconComponentNotificationBus::Event(GetEntityId(), &EditorEntityIconComponentNotificationBus::Events::OnEntityIconChanged, m_entityIconAssetId);
-            }
         }
 
         void EditorEntityIconComponent::OnComponentOrderChanged()
@@ -138,22 +146,23 @@ namespace AzToolsFramework
 
                 if (firstComponentIdChanged)
                 {
-                    m_entityIconCache.SetEntityIconPath(GetDefaultEntityIconPath(m_firstComponentIdCache));
+                    m_entityIconCache.SetEntityIconPath(GetDefaultEntityIconPath());
                     EditorEntityIconComponentNotificationBus::Event(GetEntityId(), &EditorEntityIconComponentNotificationBus::Events::OnEntityIconChanged, m_entityIconAssetId);
                 }
                 else if (preferNoViewportIconFlagChanged)
                 {
                     EditorEntityIconComponentNotificationBus::Event(GetEntityId(), &EditorEntityIconComponentNotificationBus::Events::OnEntityIconChanged, m_entityIconAssetId);
                 }
+                m_needsInitialUpdate = false; // avoid doing the work twice.
             }
         }
 
-        AZStd::string EditorEntityIconComponent::CalculateEntityIconPath(AZ::ComponentId firstComponentId)
+        AZStd::string EditorEntityIconComponent::CalculateEntityIconPath()
         {
             AZStd::string entityIconPath = GetEntityIconAssetPath();
             if (entityIconPath.empty())
             {
-                entityIconPath = GetDefaultEntityIconPath(firstComponentId);
+                entityIconPath = GetDefaultEntityIconPath();
             }
             return entityIconPath;
         }
@@ -182,9 +191,12 @@ namespace AzToolsFramework
             }
         }
 
-        AZStd::string EditorEntityIconComponent::GetDefaultEntityIconPath(AZ::ComponentId firstComponentId)
+        AZStd::string EditorEntityIconComponent::GetDefaultEntityIconPath()
         {
             AZStd::string entityIconPath;
+
+            RefreshCachesIfNecessary();
+            AZ::ComponentId firstComponentId = m_firstComponentIdCache;
 
             if (firstComponentId != AZ::InvalidComponentId)
             {
@@ -210,32 +222,48 @@ namespace AzToolsFramework
 
         bool EditorEntityIconComponent::UpdateFirstComponentIdCache()
         {
+            // The idea here is to find the first component that is not a fixed component (like TransformComponent, UniformScaleComponent,
+            // etc.) on the entity and use that as the default icon.
+            // The entity only stores its component order if the component order is different from the default order, which is only the case
+            // if the user has personally modified the order of the components, which is not the case for the vast majority of entities in real levels.
+            // So to figure out the icon, we need to essentially do the same work the inspector would do, which is to take the components on the entity
+            // and filter out the invisible ones, then sort them by order if order is present, and then by priority.
             bool firstComponentIdChanged = false;
             ComponentOrderArray componentOrderArray;
             EditorInspectorComponentRequestBus::EventResult(componentOrderArray, GetEntityId(), &EditorInspectorComponentRequests::GetComponentOrderArray);
-            if (componentOrderArray.empty())
+            AZ::Entity::ComponentArrayType components;
+            components = GetEntity()->GetComponents();
+            RemoveHiddenComponents(components);
+            SortComponentsByOrder(GetEntity()->GetId(), components);
+            SortComponentsByPriority(components);
+
+            AZ::ComponentId componentIdToSet = AZ::InvalidComponentId;
+            // we want to use the first "non-fixed" component on the entity (ie, not the uniform scale, or transform) but we'll settle for
+            // the first visible component if we can't find one.
+            if (!components.empty())
             {
-                if (m_firstComponentIdCache != AZ::InvalidComponentId)
+                for (const AZ::Component* component : components)
                 {
-                    m_firstComponentIdCache = AZ::InvalidComponentId;
-                    firstComponentIdChanged = true;
-                }
-            }
-            else
-            {
-                if (componentOrderArray.size() > 1)
-                {
-                    if (m_firstComponentIdCache != componentOrderArray[1])
+                    if (componentIdToSet == AZ::InvalidComponentId)
                     {
-                        m_firstComponentIdCache = componentOrderArray[1];
-                        firstComponentIdChanged = true;
+                        // initialize it to the first one as a fallback
+                        componentIdToSet = component->GetId();
+                    }
+                    else
+                    {
+                        if (IsComponentDraggable(component))
+                        {
+                            componentIdToSet = component->GetId();
+                            break;
+                        }
                     }
                 }
-                else if(m_firstComponentIdCache != componentOrderArray.front())
-                {
-                    m_firstComponentIdCache = componentOrderArray.front();
-                    firstComponentIdChanged = true;
-                }
+            }
+
+            if (m_firstComponentIdCache != componentIdToSet)
+            {
+                m_firstComponentIdCache = componentIdToSet;
+                firstComponentIdChanged = true;
             }
 
             return firstComponentIdChanged;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorEntityIconComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorEntityIconComponent.h
@@ -77,22 +77,20 @@ namespace AzToolsFramework
             int GetEntityIconTextureId() override;
             bool IsEntityIconHiddenInViewport() override;
 
-            // EntityBus
-            void OnEntityActivated(const AZ::EntityId&) override;
-
             // EditorInspectorComponentNotificationBus
             void OnComponentOrderChanged() override;
 
             /// Return the path of the entity icon asset identified by \ref m_entityIconAssetId if it's valid,
             /// else return the path of the icon of the first component in this entity's EditorInspector list,
             /// otherwise return the path of the default entity icon.
-            AZStd::string CalculateEntityIconPath(AZ::ComponentId firstComponentId);
+            AZStd::string CalculateEntityIconPath();
             AZStd::string GetEntityIconAssetPath();
-            AZStd::string GetDefaultEntityIconPath(AZ::ComponentId firstComponentId);
+            AZStd::string GetDefaultEntityIconPath();
 
             /// Return a boolean indicating if \ref m_firstComponentIdCache has been changed.
             bool UpdateFirstComponentIdCache();
             bool UpdatePreferNoViewportIconFlag();
+            void RefreshCachesIfNecessary();
 
             AZ::Data::AssetId m_entityIconAssetId = AZ::Data::AssetId();
 
@@ -103,6 +101,8 @@ namespace AzToolsFramework
 
             bool m_preferNoViewportIcon = false; ///< Indicates if any component of this entity
                                                  ///< has the PreferNoViewportIcon Edit Attribute.
+
+            bool m_needsInitialUpdate = true;
         };
     }
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorInspectorComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorInspectorComponent.cpp
@@ -8,6 +8,7 @@
 #include "EditorInspectorComponent.h"
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/std/sort.h>
+#include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 
 namespace AzToolsFramework
 {
@@ -124,12 +125,6 @@ namespace AzToolsFramework
 
         void EditorInspectorComponent::PrepareSave()
         {
-            // If we didn't dirty the component order, we do not need to regenerate the serialized entry array
-            if (!m_componentOrderIsDirty)
-            {
-                return;
-            }
-
             // Clear the actual persistent id storage to get rebuilt from the order entry array
             m_componentOrderEntryArray.clear();
             m_componentOrderEntryArray.reserve(m_componentOrderArray.size());
@@ -139,8 +134,6 @@ namespace AzToolsFramework
             {
                 m_componentOrderEntryArray.push_back({ m_componentOrderArray[componentIndex], componentIndex });
             }
-
-            m_componentOrderIsDirty = false;
         }
 
         void EditorInspectorComponent::PostLoad()
@@ -163,8 +156,6 @@ namespace AzToolsFramework
             {
                 m_componentOrderArray.push_back(componentOrderEntry.m_componentId);
             }
-
-            m_componentOrderIsDirty = false;
         }
 
         ComponentOrderArray EditorInspectorComponent::GetComponentOrderArray()
@@ -176,16 +167,49 @@ namespace AzToolsFramework
         {
             if (m_componentOrderArray == componentOrderArray)
             {
+                // the order is unchanged, not necessary to set or invoke callbacks.
                 return;
             }
 
-            m_componentOrderArray = componentOrderArray;
+            // If we get here, the caller is requesting a new order, but, we only want to persist this if the order is actually
+            // different from what default would be.
+            AZ::Entity::ComponentArrayType components;
+            components = GetEntity()->GetComponents();
+            RemoveHiddenComponents(components);
+            SortComponentsByPriority(components);
 
+            ComponentOrderArray defaultOrderArray;
+            defaultOrderArray.reserve(components.size());
+
+            for (const auto& component : components)
+            {
+                defaultOrderArray.push_back(component->GetId());
+            }
+
+            if (defaultOrderArray == componentOrderArray)
+            {
+                // the new order is the same as the default order
+                if (m_componentOrderArray.empty())
+                {
+                    // the new order is default and the previous order is default, nothing to do.
+                    return;
+                }
+
+                m_componentOrderArray.clear();
+            }
+            else
+            {
+                // the new order is non-default and the previous order is different from it, we need to persist it.
+                m_componentOrderArray = componentOrderArray;
+            }
+
+            // if we get here, we either went from a default order to a user-specified order
+            // or vice versa.  Either way, the order has changed and needs to persist the change.
+            // We should only get in here from user interaction - dragging things around, cut and paste, etc
+            // so we are in an undo state.
             SetDirty();
+            PrepareSave();
 
-            // mark the order as dirty before sending the OnComponentOrderChanged event in order for PrepareSave to be properly handled in the case 
-            // one of the event listeners needs to build the InstanceDataHierarchy
-            m_componentOrderIsDirty = true;
             EditorInspectorComponentNotificationBus::Event(GetEntityId(), &EditorInspectorComponentNotificationBus::Events::OnComponentOrderChanged);
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorInspectorComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorInspectorComponent.h
@@ -58,17 +58,8 @@ namespace AzToolsFramework
             class ComponentOrderSerializationEvents
                 : public AZ::SerializeContext::IEventHandler
             {
-                /** 
-                 * Called right before we start reading from the instance pointed by classPtr.
-                 */
-                void OnReadBegin(void* classPtr) override
-                {
-                    EditorInspectorComponent* component = reinterpret_cast<EditorInspectorComponent*>(classPtr);
-                    component->PrepareSave();
-                }
-
                 /**
-                 * Called right after we finish writing data to the instance pointed at by classPtr.
+                 * Called after reading from a serialized file into a EditorInspectorComponent object.
                  */
                 void OnWriteEnd(void* classPtr) override
                 {
@@ -95,8 +86,6 @@ namespace AzToolsFramework
             ComponentOrderEntryArray m_componentOrderEntryArray; ///< The serialized order array which uses the persistent id mechanism as described above*/
 
             ComponentOrderArray m_componentOrderArray; ///< The simple vector of component id is what is used by the component order ebus and is generated from the serialized data
-            
-            bool m_componentOrderIsDirty = true; ///< This flag indicates our stored serialization order data is out of date and must be rebuilt before serialization occurs
         };
     } // namespace Components
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
@@ -1415,86 +1415,7 @@ namespace AzToolsFramework
             RemoveHiddenComponents(componentsOnEntity);
             SortComponentsByOrder(entityId, componentsOnEntity);
             SortComponentsByPriority(componentsOnEntity);
-            SaveComponentOrder(entityId, componentsOnEntity);
         }
-    }
-
-    void EntityPropertyEditor::SortComponentsByPriority(AZ::Entity::ComponentArrayType& componentsOnEntity)
-    {
-        // Create list of components with their current order. AZStd::sort isn't guaranteed to maintain order for equivalent entities.
-
-        AZStd::vector< OrderedSortComponentEntry> sortedComponents;
-        int index = 0;
-        for (AZ::Component* component : componentsOnEntity)
-        {
-            sortedComponents.push_back(OrderedSortComponentEntry(component, index++));
-        }
-
-        // shuffle immovable components back to the front
-        AZStd::sort(
-            sortedComponents.begin(),
-            sortedComponents.end(),
-            [](const OrderedSortComponentEntry& component1, const OrderedSortComponentEntry& component2)
-            {
-                AZStd::optional<int> fixedComponentListIndex1 = GetFixedComponentListIndex(component1.m_component);
-                AZStd::optional<int> fixedComponentListIndex2 = GetFixedComponentListIndex(component2.m_component);
-
-                // If both components have fixed list indices, sort based on those indices
-                if (fixedComponentListIndex1.has_value() && fixedComponentListIndex2.has_value())
-                {
-                    return fixedComponentListIndex1.value() < fixedComponentListIndex2.value();
-                }
-
-                // If component 1 has a fixed list index, sort it first
-                if (fixedComponentListIndex1.has_value())
-                {
-                    return true;
-                }
-
-                // If component 2 has a fixed list index, component 1 should not be sorted before it
-                if (fixedComponentListIndex2.has_value())
-                {
-                    return false;
-                }
-
-                if (!IsComponentRemovable(component1.m_component) && IsComponentRemovable(component2.m_component))
-                {
-                    return true;
-                }
-
-                if (IsComponentRemovable(component1.m_component) && !IsComponentRemovable(component2.m_component))
-                {
-                    return false;
-                }
-
-                //maintain original order if they don't need swapping
-                return component1.m_originalOrder < component2.m_originalOrder;
-            });
-
-        //create new order array from sorted structure
-        componentsOnEntity.clear();
-        for (OrderedSortComponentEntry& component : sortedComponents)
-        {
-            componentsOnEntity.push_back(component.m_component);
-        }
-    }
-
-    void SortComponentsByOrder(const AZ::EntityId entityId, AZ::Entity::ComponentArrayType& componentsOnEntity)
-    {
-        // sort by component order, shuffling anything not found in component order to the end
-        ComponentOrderArray componentOrder;
-        EditorInspectorComponentRequestBus::EventResult(
-            componentOrder, entityId, &EditorInspectorComponentRequests::GetComponentOrderArray);
-
-        AZStd::sort(
-            componentsOnEntity.begin(),
-            componentsOnEntity.end(),
-            [&componentOrder](const AZ::Component* component1, const AZ::Component* component2)
-            {
-                return
-                    AZStd::find(componentOrder.begin(), componentOrder.end(), component1->GetId()) <
-                    AZStd::find(componentOrder.begin(), componentOrder.end(), component2->GetId());
-            });
     }
 
     void SaveComponentOrder(const AZ::EntityId entityId, AZStd::span<AZ::Component* const> componentsInOrder)
@@ -1521,42 +1442,7 @@ namespace AzToolsFramework
         return componentClassData && filter(*componentClassData);
     }
 
-    bool EntityPropertyEditor::IsComponentRemovable(const AZ::Component* component)
-    {
-        // Determine if this component can be removed.
-        auto componentClassData = component ? GetComponentClassData(component) : nullptr;
-        if (componentClassData && componentClassData->m_editData)
-        {
-            if (auto editorDataElement = componentClassData->m_editData->FindElementData(AZ::Edit::ClassElements::EditorData))
-            {
-                if (auto attribute = editorDataElement->FindAttribute(AZ::Edit::Attributes::RemoveableByUser))
-                {
-                    if (auto attributeData = azdynamic_cast<AZ::Edit::AttributeData<bool>*>(attribute))
-                    {
-                        return attributeData->Get(nullptr);
-                    }
-                }
-            }
-        }
-
-        if (componentClassData && AppearsInAnyComponentMenu(*componentClassData))
-        {
-            return true;
-        }
-
-        // If this is a GenericComponentWrapper which wraps a nullptr, let the user remove it
-        if (auto genericComponentWrapper = azrtti_cast<const Components::GenericComponentWrapper*>(component))
-        {
-            if (!genericComponentWrapper->GetTemplate())
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    bool EntityPropertyEditor::AreComponentsRemovable(AZStd::span<AZ::Component* const> components) const
+   bool EntityPropertyEditor::AreComponentsRemovable(AZStd::span<AZ::Component* const> components) const
     {
         for (auto component : components)
         {
@@ -1568,35 +1454,12 @@ namespace AzToolsFramework
         return true;
     }
 
-    AZStd::optional<int> EntityPropertyEditor::GetFixedComponentListIndex(const AZ::Component* component)
-    {
-        auto componentClassData = component ? GetComponentClassData(component) : nullptr;
-        if (componentClassData && componentClassData->m_editData)
-        {
-            if (auto editorDataElement = componentClassData->m_editData->FindElementData(AZ::Edit::ClassElements::EditorData))
-            {
-                if (auto attribute = editorDataElement->FindAttribute(AZ::Edit::Attributes::FixedComponentListIndex))
-                {
-                    if (auto attributeData = azdynamic_cast<AZ::Edit::AttributeData<int>*>(attribute))
-                    {
-                        return { attributeData->Get(nullptr) };
-                    }
-                }
-            }
-        }
-        return {};
-    }
 
     bool EntityPropertyEditor::AllowAnyComponentModification() const
     {
         const InspectorLayout currentLayout = GetCurrentInspectorLayout();
         return currentLayout != InspectorLayout::ContainerEntityOfFocusedPrefab &&
                currentLayout != InspectorLayout::ContainerEntity;
-    }
-
-    bool EntityPropertyEditor::IsComponentDraggable(const AZ::Component* component)
-    {
-        return !GetFixedComponentListIndex(component).has_value();
     }
 
     bool EntityPropertyEditor::AreComponentsDraggable(AZStd::span<AZ::Component* const> components) const
@@ -5442,6 +5305,11 @@ namespace AzToolsFramework
 
     void EntityPropertyEditor::OnComponentOrderChanged()
     {
+        if (m_isBuildingProperties)
+        {
+            return;
+        }
+
         QueuePropertyRefresh();
         m_shouldScrollToNewComponents = true;
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.hxx
@@ -94,18 +94,6 @@ namespace AzToolsFramework
 
     using ComponentEditorVector = AZStd::vector<ComponentEditor*>;
 
-    struct OrderedSortComponentEntry
-    {
-        AZ::Component* m_component;
-        int m_originalOrder;
-
-        OrderedSortComponentEntry(AZ::Component* component, int originalOrder)
-        {
-            m_component = component;
-            m_originalOrder = originalOrder;
-        }
-    };
-
     /**
      * the entity property editor shows all components for a given entity or set of entities.
      * it displays their values and lets you edit them.  The editing actually happens through the sub editor parts, though.
@@ -185,8 +173,6 @@ namespace AzToolsFramework
         void SetOverrideEntityIds(const AzToolsFramework::EntityIdSet& entities);
 
         void SetSystemEntityEditor(bool isSystemEntityEditor);
-
-        static void SortComponentsByPriority(AZ::Entity::ComponentArrayType& componentsOnEntity);
 
         bool IsLockedToSpecificEntities() const { return !m_overrideSelectedEntityIds.empty(); }
 
@@ -306,10 +292,7 @@ namespace AzToolsFramework
         void UpdateEntityIcon();
         void UpdateEntityDisplay();
         static bool DoesComponentPassFilter(const AZ::Component* component, const ComponentFilter& filter);
-        static bool IsComponentRemovable(const AZ::Component* component);
         bool AreComponentsRemovable(AZStd::span<AZ::Component* const> components) const;
-        static AZStd::optional<int> GetFixedComponentListIndex(const AZ::Component* component);
-        static bool IsComponentDraggable(const AZ::Component* component);
         bool AllowAnyComponentModification() const;
         bool AreComponentsDraggable(AZStd::span<AZ::Component* const> components) const;
         bool AreComponentsCopyable(AZStd::span<AZ::Component* const> components) const;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UnitTest/Mocks/MockEditorViewportIconDisplayInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UnitTest/Mocks/MockEditorViewportIconDisplayInterface.h
@@ -21,7 +21,9 @@ namespace UnitTest
 
         //! AzToolsFramework::EditorViewportIconDisplayInterface overrides ...
         MOCK_METHOD1(DrawIcon, void(const DrawParameters&));
+        MOCK_METHOD1(AddIcon, void(const DrawParameters&));
         MOCK_METHOD1(GetOrLoadIconForPath, IconId(AZStd::string_view path));
         MOCK_METHOD1(GetIconLoadStatus, IconLoadStatus(IconId icon));
+        MOCK_METHOD0(DrawIcons, void());
     };
 } // namespace UnitTest

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorHelpers.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorHelpers.cpp
@@ -372,11 +372,13 @@ namespace AzToolsFramework
                     EditorEntityIconComponentRequestBus::EventResult(
                         iconTextureId, entityId, &EditorEntityIconComponentRequestBus::Events::GetEntityIconTextureId);
 
-                    editorViewportIconDisplay->DrawIcon(EditorViewportIconDisplayInterface::DrawParameters{
+                    editorViewportIconDisplay->AddIcon(EditorViewportIconDisplayInterface::DrawParameters{
                         viewportInfo.m_viewportId, iconTextureId, iconHighlight, entityPosition,
                         EditorViewportIconDisplayInterface::CoordinateSpace::WorldSpace, AZ::Vector2(GetIconSize(distanceFromCamera)) });
                 }
             }
+
+            editorViewportIconDisplay->DrawIcons();
         }
     }
 

--- a/Code/Framework/AzToolsFramework/Tests/EditorViewportIconTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/EditorViewportIconTests.cpp
@@ -83,6 +83,9 @@ namespace UnitTest
             .WillByDefault(Return(AZ::Vector3(0.0f, insideNearClip, 0.0f)));
 
         EXPECT_CALL(*m_editorViewportIconDisplayMock, DrawIcon(_)).Times(0);
+        EXPECT_CALL(*m_editorViewportIconDisplayMock, AddIcon(_)).Times(0);
+        EXPECT_CALL(*m_editorViewportIconDisplayMock, DrawIcons()).Times(1);
+
 
         // when
         m_editorHelpers->DisplayHelpers(
@@ -104,6 +107,8 @@ namespace UnitTest
         ON_CALL(*m_entityVisibleEntityDataCacheMock, GetVisibleEntityPosition(_)).WillByDefault(Return(AZ::Vector3(0.0f, -1.0f, 0.0f)));
 
         EXPECT_CALL(*m_editorViewportIconDisplayMock, DrawIcon(_)).Times(0);
+        EXPECT_CALL(*m_editorViewportIconDisplayMock, AddIcon(_)).Times(0);
+        EXPECT_CALL(*m_editorViewportIconDisplayMock, DrawIcons()).Times(1);
 
         // when
         m_editorHelpers->DisplayHelpers(

--- a/Code/Framework/AzToolsFramework/Tests/EntityInspectorTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/EntityInspectorTests.cpp
@@ -23,10 +23,15 @@
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
+#include <AzToolsFramework/ToolsComponents/EditorInspectorComponent.h>
 #include <AzToolsFramework/UnitTest/ToolsTestApplication.h>
+#include <AzToolsFramework/ToolsComponents/EditorInspectorComponentBus.h>
 
 // Inspector Test Includes
 #include <AzToolsFramework/UI/ComponentPalette/ComponentPaletteUtil.hxx>
+
+#include <gmock/gmock.h>
+
 
 namespace UnitTest
 {
@@ -269,6 +274,7 @@ namespace UnitTest
             m_application = aznew ToolsTestApplication("ComponentPaletteTests");
             AZ::ComponentApplication::StartupParameters startupParameters;
             startupParameters.m_loadSettingsRegistry = false;
+            startupParameters.m_loadAssetCatalog = false;
             m_application->Start(componentApplicationDesc, startupParameters);
             // Without this, the user settings component would attempt to save on finalize/shutdown. Since the file is
             // shared across the whole engine, if multiple tests are run in parallel, the saving could cause a crash 
@@ -369,5 +375,211 @@ namespace UnitTest
 
         // Verify that true is returned here when a system component is editable
         EXPECT_TRUE(AzToolsFramework::ComponentPaletteUtil::ContainsEditableComponents(context, &Filter_IsTestComponent3, AZ::ComponentDescriptor::DependencyArrayType()));
+    }
+
+    // helperfunction to reflect serialize for all these components to keep code short
+    template<typename ComponentType>
+    void RegisterSerialize(AZ::ReflectContext* context, bool visible, const char* iconPath, int fixedIndex = -1)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<ComponentType, AZ::Component>();
+
+            if (AZ::EditContext* editContext = serializeContext->GetEditContext())
+            {
+                auto reflectionBuilder = editContext->Class<ComponentType>(AZ_STRINGIZE(ComponentType), AZ_STRINGIZE(ComponentType));
+                auto classElement = reflectionBuilder->ClassElement(AZ::Edit::ClassElements::EditorData, "");
+                classElement->Attribute(AZ::Edit::Attributes::AddableByUser, true)
+                    ->Attribute(AZ::Edit::Attributes::Visibility, visible ? AZ::Edit::PropertyVisibility::Show :  AZ::Edit::PropertyVisibility::Hide)
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
+                    ->Attribute(AZ::Edit::Attributes::Category, "Inspector Test Components")
+                    ->Attribute(AZ::Edit::Attributes::Icon, iconPath)
+                    ->Attribute(AZ::Edit::Attributes::ViewportIcon, iconPath);
+
+                if (fixedIndex != -1)
+                {
+                    classElement->Attribute(AZ::Edit::Attributes::FixedComponentListIndex, fixedIndex);
+                }
+            }
+        }
+    }
+    
+    class EditorInspectorTestComponentBase : public AZ::Component
+    {
+    public:
+        // These functions are mandatory to provide but are of no use in this case.
+        void Activate() override {}
+        void Deactivate() override {}
+    };
+    
+    class EditorInspectorTestComponent1 : public EditorInspectorTestComponentBase
+    {
+        public:
+            AZ_COMPONENT(EditorInspectorTestComponent1, "{EF3D8047-4FAA-4615-93E1-C2B5B6EB3C08}", AZ::Component);
+            static void Reflect(AZ::ReflectContext* context)
+            {
+                // A component that is user movable and is visible
+                RegisterSerialize<EditorInspectorTestComponent1>(context, true, "Component1.png");
+            }
+    };
+
+    class EditorInspectorTestComponent2 : public EditorInspectorTestComponentBase
+    {
+        public:
+            AZ_COMPONENT(EditorInspectorTestComponent2, "{42BE5BEE-A7B9-4D8D-8F61-C0E0FDAA1450}", AZ::Component);
+            static void Reflect(AZ::ReflectContext* context)
+            {
+                // A component that is not movable, but is visible
+                RegisterSerialize<EditorInspectorTestComponent2>(context, true, "Component2.png", 0);
+            }
+    };
+
+    class EditorInspectorTestComponent3 : public EditorInspectorTestComponentBase
+    {
+        public:
+            AZ_COMPONENT(EditorInspectorTestComponent3, "{71329B94-76B3-4C8B-AF4B-159D51BDE820}", AZ::Component);
+            static void Reflect(AZ::ReflectContext* context)
+            {
+                // A component that is not visible
+                RegisterSerialize<EditorInspectorTestComponent3>(context, false, "Component3.png");
+            }
+    };
+
+    class EditorInspectorTestComponent4 : public EditorInspectorTestComponentBase
+    {
+        public:
+            AZ_COMPONENT(EditorInspectorTestComponent4, "{10385AEF-88AA-4682-AF1E-3EBE21E4632B}", AZ::Component);
+            static void Reflect(AZ::ReflectContext* context)
+            {
+                // Another component that is visible and movable
+                RegisterSerialize<EditorInspectorTestComponent4>(context, true, "Component4.png");
+            }
+    };
+    
+    class MockEditorInspectorNotificationBusHandler : public AzToolsFramework::EditorInspectorComponentNotificationBus::Handler
+    {
+    public:
+        MOCK_METHOD0(OnComponentOrderChanged, void());
+    };
+
+    class InspectorComponentOrderingTest
+        : public ComponentPaletteTests
+    {
+        void SetUp() override
+        {
+            ComponentPaletteTests::SetUp();
+            m_application->RegisterComponentDescriptor(EditorInspectorTestComponent1::CreateDescriptor());
+            m_application->RegisterComponentDescriptor(EditorInspectorTestComponent2::CreateDescriptor());
+            m_application->RegisterComponentDescriptor(EditorInspectorTestComponent3::CreateDescriptor());
+            m_application->RegisterComponentDescriptor(EditorInspectorTestComponent4::CreateDescriptor());
+            m_mockedInspectorBusHandler = AZStd::make_unique<::testing::NiceMock<MockEditorInspectorNotificationBusHandler>>();
+        }
+
+        void TearDown() override
+        {
+            m_mockedInspectorBusHandler->BusDisconnect();
+            m_mockedInspectorBusHandler.reset();
+            ComponentPaletteTests::TearDown();
+        }
+
+        protected:
+        AZStd::unique_ptr<::testing::NiceMock<MockEditorInspectorNotificationBusHandler>> m_mockedInspectorBusHandler;
+    };
+
+    // Makes sure that the inspector component (responsible for keeping track of any order overrides of components on it)
+    // only stores data and only emits events when the components are in a non default order.
+    // Also makes sure (since it invokes them) that the actual ordering utility functions, such as RemoveHiddenComponents,
+    // SortComponentsByPriority, and the functions they call, all work as expected.
+    TEST_F(InspectorComponentOrderingTest, AddingComponents_InspectorComponent_PersistsDataOnlyIfDifferentFromDefault)
+    {
+        using namespace AzToolsFramework;
+
+        AZ::EntityId entityId(123);
+
+        AZ::Entity testEntity(entityId);
+        testEntity.AddComponent(aznew EditorInspectorTestComponent1);
+        testEntity.AddComponent(aznew EditorInspectorTestComponent2);
+        testEntity.AddComponent(aznew EditorInspectorTestComponent3);
+        testEntity.AddComponent(aznew EditorInspectorTestComponent4);
+        testEntity.AddComponent(aznew Components::EditorInspectorComponent);
+
+        m_mockedInspectorBusHandler->BusConnect(entityId);
+
+        // activating the entity should not invoke the component order change bus at all, anything that cares about activation should listen for activation, not reorder.
+        EXPECT_CALL(*m_mockedInspectorBusHandler, OnComponentOrderChanged()).Times(0);
+        
+        // Activating an entity does reorder the actual components on the entity itself.
+        // They will not be in the order added.
+        // The actual order on the entity is not relevant to this test, but the stable sort function itself will place
+        // the components that provide services (EditorInspectorComponent) in this case, ahead of ones which don't, and
+        // if there is a tie, it will sort them by their typeid (their GUID).  In this case, it means the order will be:
+        // * EditorInspectorComponent (because it has services provided)
+        // * EditorInspectorTestComponent4 // TypeID starts with 10385AEF
+        // * EditorInspectorTestComponent2 // TypeID starts with 42BE5BEE
+        // * EditorInspectorTestComponent3 // TypeID starts with 71329B94
+        // * EditorInspectorTestComponent1 // TypeID starts with EF3D8047
+
+        testEntity.Init();
+        testEntity.Activate();
+
+        AZ::Entity::ComponentArrayType componentsOnEntity = testEntity.GetComponents();
+
+        EXPECT_EQ(componentsOnEntity.size(), 5);
+
+        // An empty component order array sent to an already empty entity should result in no callbacks.
+        ComponentOrderArray componentOrderArray;
+        EditorInspectorComponentRequestBus::Event(entityId, &EditorInspectorComponentRequests::SetComponentOrderArray, componentOrderArray);
+        EditorInspectorComponentRequestBus::EventResult(componentOrderArray, entityId, &EditorInspectorComponentRequests::GetComponentOrderArray);
+        EXPECT_TRUE(componentOrderArray.empty());
+
+        // Setting an empty component order when its already empty should result in no calls to the "Component order changed!" event.
+        EXPECT_CALL(*m_mockedInspectorBusHandler, OnComponentOrderChanged()).Times(0);
+
+        // Setting the component order array to what is already the default order should result in no callbacks:
+        AZ::Entity::ComponentArrayType components;
+        components = testEntity.GetComponents();
+        EXPECT_EQ(components.size(), 5);
+        RemoveHiddenComponents(components);
+        EXPECT_EQ(components.size(), 3); // the inspector component and the test Component 3 are hidden.
+        SortComponentsByPriority(components);
+        ASSERT_EQ(components.size(), 3); // sorting components should not change the number of components.
+
+        // After the sort, the first one in the array should be the fixed order one, that says it "must be in position 0"
+        EXPECT_EQ(components[0]->RTTI_GetType(), azrtti_typeid<EditorInspectorTestComponent2>());
+
+        // the others should remain in their original order, but be after it:
+        EXPECT_EQ(components[1]->RTTI_GetType(), azrtti_typeid<EditorInspectorTestComponent4>()); // Note the above, 4 comes before 1 due to the stable sort
+        EXPECT_EQ(components[2]->RTTI_GetType(), azrtti_typeid<EditorInspectorTestComponent1>());
+
+        // convert the vector of Component* to a vector of ComponentId
+        ComponentOrderArray defaultComponentOrder;
+        for (const AZ::Component* component : components)
+        {
+            defaultComponentOrder.push_back(component->GetId());
+        }
+        
+        // set the order.  Since its the default order, this should again not emit an event, nor update any data that would be persisted:
+        EditorInspectorComponentRequestBus::Event(entityId, &EditorInspectorComponentRequests::SetComponentOrderArray, defaultComponentOrder);
+        EditorInspectorComponentRequestBus::EventResult(componentOrderArray, entityId, &EditorInspectorComponentRequests::GetComponentOrderArray);
+        EXPECT_TRUE(componentOrderArray.empty());
+
+        // Setting the component order array to a different order than default should result in a callback and result in data to save.
+        // in this case, we swap the order of element [1] and [2], so that the final order should be [Component2, Component1, Component4]
+        ComponentOrderArray nonDefaultOrder = defaultComponentOrder;
+        AZStd::iter_swap(nonDefaultOrder.begin() + 1, nonDefaultOrder.begin() + 2);
+        EXPECT_CALL(*m_mockedInspectorBusHandler, OnComponentOrderChanged()).Times(1);
+        EditorInspectorComponentRequestBus::Event(entityId, &EditorInspectorComponentRequests::SetComponentOrderArray, nonDefaultOrder);
+        EditorInspectorComponentRequestBus::EventResult(componentOrderArray, entityId, &EditorInspectorComponentRequests::GetComponentOrderArray);
+        EXPECT_EQ(componentOrderArray.size(), 3);
+        EXPECT_EQ(componentOrderArray, nonDefaultOrder);
+
+        // Setting the component order array back to default, should result in it emptying it out and notifying since its changing (from non-default to default)
+        EXPECT_CALL(*m_mockedInspectorBusHandler, OnComponentOrderChanged()).Times(1);
+        EditorInspectorComponentRequestBus::Event(entityId, &EditorInspectorComponentRequests::SetComponentOrderArray, defaultComponentOrder);
+        EditorInspectorComponentRequestBus::EventResult(componentOrderArray, entityId, &EditorInspectorComponentRequests::GetComponentOrderArray);
+        EXPECT_TRUE(componentOrderArray.empty());
+
+        m_mockedInspectorBusHandler->BusDisconnect();
+        testEntity.Deactivate();
     }
 }

--- a/Code/Framework/AzToolsFramework/Tests/UI/EntityPropertyEditorTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/UI/EntityPropertyEditorTests.cpp
@@ -6,27 +6,27 @@
  *
  */
 
-#include <AzCore/UnitTest/TestTypes.h>
+#include <AzCore/Asset/AssetManagerComponent.h>
 #include <AzCore/Serialization/SerializeContext.h>
-#include <AzTest/AzTest.h>
-#include <AzToolsFramework/ComponentMode/ComponentModeCollection.h>
+#include <AzCore/std/sort.h>
+#include <AzCore/UnitTest/TestTypes.h>
 
-#include <AzToolsFramework/Application/ToolsApplication.h>
-#include <AzToolsFramework/ViewportSelection/EditorInteractionSystemViewportSelectionRequestBus.h>
-#include <AzToolsFramework/ToolsComponents/TransformComponent.h>
-#include <AzToolsFramework/ToolsComponents/ScriptEditorComponent.h>
-#include <AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.hxx>
+#include <AzTest/AzTest.h>
+
 #include <AzToolsFramework/API/EntityPropertyEditorRequestsBus.h>
+#include <AzToolsFramework/Application/ToolsApplication.h>
+#include <AzToolsFramework/ComponentMode/ComponentModeCollection.h>
+#include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 #include <AzToolsFramework/ToolsComponents/EditorLockComponent.h>
 #include <AzToolsFramework/ToolsComponents/EditorVisibilityComponent.h>
+#include <AzToolsFramework/ToolsComponents/ScriptEditorComponent.h>
+#include <AzToolsFramework/ToolsComponents/TransformComponent.h>
+#include <AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.hxx>
+#include <AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h>
 #include <AzToolsFramework/ViewportSelection/EditorDefaultSelection.h>
-
-#include <AzCore/Asset/AssetManagerComponent.h>
-#include <AzCore/std/sort.h>
+#include <AzToolsFramework/ViewportSelection/EditorInteractionSystemViewportSelectionRequestBus.h>
 
 #include <QApplication>
-
-#include <AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h>
 
 namespace UnitTest
 {
@@ -78,7 +78,7 @@ namespace UnitTest
 
         // When this sort happens, the transformComponent should move to the top, the AssetDatabase should move to second, the order of the others should be unaltered, 
         // merely moved to after the AssetDatabase.
-        EntityPropertyEditor::SortComponentsByPriority(orderedComponents);
+        SortComponentsByPriority(orderedComponents);
 
         // Check the component arrays are intact.
         EXPECT_EQ(orderedComponents.size(), unorderedComponents.size());

--- a/Code/Legacy/CryCommon/MultiThread_Containers.h
+++ b/Code/Legacy/CryCommon/MultiThread_Containers.h
@@ -22,14 +22,14 @@ namespace CryMT
     //////////////////////////////////////////////////////////////////////////
 
     //////////////////////////////////////////////////////////////////////////
-    // Multi-Thread safe queue container, can be used instead of std::vector.
+    // Multi-Thread safe queue container.
     //////////////////////////////////////////////////////////////////////////
     template <class T, class Alloc = std::allocator<T> >
     class queue
     {
     public:
         typedef T   value_type;
-        typedef std::vector<T, Alloc>   container_type;
+        typedef std::queue<T, std::deque<T, Alloc>>   container_type;
         typedef AZStd::lock_guard<AZStd::recursive_mutex> AutoLock;
 
         //////////////////////////////////////////////////////////////////////////
@@ -37,7 +37,7 @@ namespace CryMT
         //////////////////////////////////////////////////////////////////////////
         const T& front() const      { AutoLock lock(m_cs); return v.front(); };
         const T& back() const { AutoLock lock(m_cs);    return v.back(); }
-        void    push(const T& x)    { AutoLock lock(m_cs); return v.push_back(x); };
+        void    push(const T& x)    { AutoLock lock(m_cs); return v.push(x); };
         void reserve(const size_t n) { AutoLock lock(m_cs); v.reserve(n); };
 
         AZStd::recursive_mutex& get_lock() const { return m_cs; }
@@ -57,7 +57,7 @@ namespace CryMT
             if (!v.empty())
             {
                 returnValue = v.front();
-                v.erase(v.begin());
+                v.pop();
                 return true;
             }
             return false;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/Material.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Material/Material.h
@@ -144,7 +144,8 @@ namespace AZ
             bool NeedsCompile() const;
 
             using OnMaterialShaderVariantReadyEvent = AZ::Event<>;
-            //! Connect a handler to listen to the event that a shader variant asset of the shaders used by this material is ready
+            //! Connect a handler to listen to the event that a shader variant asset of the shaders used by this material is ready.
+            //! This is a thread safe function.
             void ConnectEvent(OnMaterialShaderVariantReadyEvent::Handler& handler);
 
         private:
@@ -225,6 +226,9 @@ namespace AZ
 
             MaterialPropertyPsoHandling m_psoHandling = MaterialPropertyPsoHandling::Warning;
 
+            //! AZ::Event is not thread safe, so we have to do our own thread safe code
+            //! because MeshDrawPacket can connect to this event from different threads.
+            AZStd::recursive_mutex m_shaderVariantReadyEventMutex;
             OnMaterialShaderVariantReadyEvent m_shaderVariantReadyEvent;
         };
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
@@ -87,6 +87,7 @@ namespace AZ
             m_generalShaderCollection = {};
             m_materialPipelineData = {};
             m_materialAsset = { &materialAsset, AZ::Data::AssetLoadBehavior::PreLoad };
+
             ShaderReloadNotificationBus::MultiHandler::BusDisconnect();
             if (!m_materialAsset.IsReady())
             {
@@ -349,10 +350,32 @@ namespace AZ
         {
             ShaderReloadDebugTracker::ScopedSection reloadSection("{%p}->Material::OnShaderVariantReinitialized %s", this, shaderVariant.GetShaderVariantAsset().GetHint().c_str());
 
+            // Move m_shaderVariantReadyEvent to a local AZ::Event in order to allow
+            // the handlers to be signaled outside of the mutex lock.
+            // This allows other threads to register their handlers while this thread
+            // is invoking Signal() on the current snapshot of handlers.
+            decltype(m_shaderVariantReadyEvent) localShaderVariantReadyEvent;
+            {
+                AZStd::scoped_lock lock(m_shaderVariantReadyEventMutex);
+                localShaderVariantReadyEvent = AZStd::move(m_shaderVariantReadyEvent);
+            }
+
             // Note: we don't need to re-compile the material if a shader variant is ready or changed
             // The DrawPacket created for the material need to be updated since the PSO need to be re-creaed.
-            // This event can be used to notify the owners to update their DrawPackets
-            m_shaderVariantReadyEvent.Signal();
+            // This event can be used to notify the owners to update their DrawPackets.
+            localShaderVariantReadyEvent.Signal();
+
+            // Finally restore m_shaderVariantReadyEvent but making sure to claim any new handlers that were added
+            // in other threads while Signal() was being called.
+            {
+                // Swap the local handlers with the current m_notifiers which
+                // will contain any handlers added during the signaling of the
+                // local event
+                AZStd::scoped_lock lock(m_shaderVariantReadyEventMutex);
+                AZStd::swap(m_shaderVariantReadyEvent, localShaderVariantReadyEvent);
+                // Append any added handlers to the m_notifier structure
+                m_shaderVariantReadyEvent.ClaimHandlers(AZStd::move(localShaderVariantReadyEvent));
+            }
         }
 
         void Material::ReInitKeepPropertyValues()
@@ -404,6 +427,7 @@ namespace AZ
 
         void Material::ConnectEvent(OnMaterialShaderVariantReadyEvent::Handler& handler)
         {
+            AZStd::scoped_lock lock(m_shaderVariantReadyEventMutex);
             handler.Connect(m_shaderVariantReadyEvent);
         }
 

--- a/Gems/AtomLyIntegration/AtomViewportDisplayIcons/Code/Source/AtomViewportDisplayIconsSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayIcons/Code/Source/AtomViewportDisplayIconsSystemComponent.cpp
@@ -20,6 +20,8 @@
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
 #include <AzToolsFramework/API/EditorAssetSystemAPI.h>
 
+#include <AtomCore/Instance/Instance.h>
+
 #include <Atom/RPI.Public/View.h>
 #include <Atom/RPI.Public/Scene.h>
 #include <Atom/RPI.Public/ViewportContextBus.h>
@@ -94,7 +96,7 @@ namespace AZ::Render
         Data::AssetBus::Handler::BusDisconnect();
         Bootstrap::NotificationBus::Handler::BusDisconnect();
 
-        auto perViewportDynamicDrawInterface = AtomBridge::PerViewportDynamicDraw::Get();
+        AZ::AtomBridge::PerViewportDynamicDrawInterface* perViewportDynamicDrawInterface = AtomBridge::PerViewportDynamicDraw::Get();
         if (!perViewportDynamicDrawInterface)
         {
             return;
@@ -108,113 +110,229 @@ namespace AZ::Render
         AzToolsFramework::EditorViewportIconDisplay::Unregister(this);
     }
 
-    void AtomViewportDisplayIconsSystemComponent::DrawIcon(const DrawParameters& drawParameters)
+    void AtomViewportDisplayIconsSystemComponent::AddIcon(const DrawParameters& drawParameters)
     {
-        // Ensure we have a valid viewport context & dynamic draw interface
-        auto viewportContext = RPI::ViewportContextRequests::Get()->GetViewportContextById(drawParameters.m_viewport);
+        if (drawParameters.m_viewport == AzFramework::InvalidViewportId)
+        {
+            AZ_WarningOnce("AtomViewportDisplayIconsSystemComponent", false, "Invalid viewport ID provided for icon draw request, discarded.");
+            return;
+        }
+
+        if (m_drawRequestViewportId == AzFramework::InvalidViewportId)
+        {
+            // this is the first request, initialize m_drawRequestViewportId.
+            m_drawRequestViewportId = drawParameters.m_viewport;
+        }
+        else if (m_drawRequestViewportId != drawParameters.m_viewport)
+        {
+            AZ_WarningOnce("AtomViewportDisplayIconsSystemComponent", false, "Multiple viewports provided for a single icon draw batch, discarded.");
+            return;
+        }
+        m_drawRequests[drawParameters.m_icon].emplace_back(drawParameters);
+
+        // the maximum we can batch at a time would be the largest index that can fit into a u16, (65535), and it eats 4 index values per icon
+        // since the indices go (0, 1, 2, 0, 2, 3), ie, 2 triangles making up 6 indices per quad but only using four actual index numbers (0,1,2,3) per.
+        // So we can only batch (max_uint16 / 4) icons at a time before the u16 would overflow (about 16k icons).
+        constexpr AZStd::vector<IconIndexData>::size_type maxQuads = (AZStd::numeric_limits<IconIndexData>::max() / 4) - 1;
+        if (m_drawRequests[drawParameters.m_icon].size() >= maxQuads)
+        {
+            DrawIcons(); // flush all buffers immediately.
+        }
+    }
+
+    // create a SRG specific to the viewport dimensions and icon.
+    AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> AtomViewportDisplayIconsSystemComponent::CreateIconSRG(AzFramework::ViewportId viewportId, AZ::Data::Instance<AZ::RPI::Image> image)
+    {
+        using namespace AZ;
+
+        RHI::Ptr<RPI::DynamicDrawContext> dynamicDraw = GetDynamicDrawContextForViewport(m_drawRequestViewportId);
+
+        AZ::RPI::ViewportContextPtr viewportContext = RPI::ViewportContextRequests::Get()->GetViewportContextById(viewportId);
         if (viewportContext == nullptr)
         {
-            return;
-        }
-
-        auto perViewportDynamicDrawInterface = AtomBridge::PerViewportDynamicDraw::Get();
-        if (!perViewportDynamicDrawInterface)
-        {
-            return;
-        } 
-
-        RHI::Ptr<RPI::DynamicDrawContext> dynamicDraw =
-            perViewportDynamicDrawInterface->GetDynamicDrawContextForViewport(m_drawContextName, drawParameters.m_viewport);
-        if (dynamicDraw == nullptr)
-        {
-            return;
-        }
-
-        // Find our icon, falling back on a gray placeholder if its image is unavailable
-        AZ::Data::Instance<AZ::RPI::Image> image = AZ::RPI::ImageSystemInterface::Get()->GetSystemImage(AZ::RPI::SystemImage::Grey);
-        if (auto iconIt = m_iconData.find(drawParameters.m_icon); iconIt != m_iconData.end())
-        {
-            auto& iconData = iconIt->second;
-            if (iconData.m_image)
-            {
-                image = iconData.m_image;
-            }
-        }
-        else
-        {
-            return;
+            return {};
         }
 
         const auto [viewportWidth, viewportHeight] = viewportContext->GetViewportSize();
         const auto viewportSize = AzFramework::ScreenSize(viewportWidth, viewportHeight);
 
-        // Initialize our shader
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> drawSrg = dynamicDraw->NewDrawSrg();
         drawSrg->SetConstant(m_viewportSizeIndex, AzFramework::Vector2FromScreenSize(viewportSize));
         drawSrg->SetImageView(m_textureParameterIndex, image->GetImageView());
         drawSrg->Compile();
+        return drawSrg;
+    }
 
+    RHI::Ptr<RPI::DynamicDrawContext> AtomViewportDisplayIconsSystemComponent::GetDynamicDrawContextForViewport(AzFramework::ViewportId viewportId)
+    {
+        AZ::AtomBridge::PerViewportDynamicDrawInterface* perViewportDynamicDrawInterface = AtomBridge::PerViewportDynamicDraw::Get();
+        if (!perViewportDynamicDrawInterface)
+        {
+            return {};
+        }
+        return perViewportDynamicDrawInterface->GetDynamicDrawContextForViewport(m_drawContextName, viewportId);
+    }
+
+    AZ::Data::Instance<AZ::RPI::Image> AtomViewportDisplayIconsSystemComponent::GetImageForIconId(IconId iconId)
+    {
+        if (auto iconIt = m_iconData.find(iconId); iconIt != m_iconData.end())
+        {
+            auto& iconData = iconIt->second;
+            if (iconData.m_image)
+            {
+                return iconData.m_image;
+            }
+        }
+
+        return AZ::RPI::ImageSystemInterface::Get()->GetSystemImage(AZ::RPI::SystemImage::Grey);
+    }
+
+    void AtomViewportDisplayIconsSystemComponent::DrawIcons()
+    {
+        // the strategy for drawing icons here is to do the expensive stuff once, and then draw all of the icons using the same texture
+        // in one go.
+
+        // To achieve this, we initialize all the variables that are per-viewport just one time in this function,
+        // then we initialize the variables that are per-texture just once per texture,
+        // then we build the vertex list once per texture by accumulating all the quads.
+        // Note that the index cache is a special case - becuase the indexes for quads are always 0,1,2, 0,2,3, etc, we don't need to update
+        // them every frame, just make sure that the index cache has ENOUGH initialized data for the amount of quads we intend to render.
+        // This allows us to re-use the index cache even between viewports and textures, the only rapidly changing data is the vertex data,
+        // and we store that in a vector so that its memory stays stable.
+
+        using ViewportRequestBus = AzToolsFramework::ViewportInteraction::ViewportInteractionRequestBus;
+        
+        if (m_drawRequestViewportId == AzFramework::InvalidViewportId)
+        {
+            // its possible for the hash map to have entries in it (since they represent texture slots) with no currently rendering quads.
+            return;
+        }
+
+        if (m_drawRequests.empty())
+        {
+            return;
+        }
+
+        AZ_Assert(m_drawRequestViewportId != AzFramework::InvalidViewportId, "Viewport ID is somehow invalid despite icons being in the list.");
+
+        RHI::Ptr<RPI::DynamicDrawContext> dynamicDraw = GetDynamicDrawContextForViewport(m_drawRequestViewportId);
+        AZ::RPI::ViewportContextPtr viewportContext = RPI::ViewportContextRequests::Get()->GetViewportContextById(m_drawRequestViewportId);
+        if ((viewportContext == nullptr) || (dynamicDraw == nullptr))
+        {
+            // this is not an error or assert as we might be running headlessly.
+            m_drawRequests.clear();
+            m_drawRequestViewportId = AzFramework::InvalidViewportId;
+            return;
+        }
         // Scale icons by screen DPI
         float scalingFactor = 1.0f;
+        ViewportRequestBus::EventResult(scalingFactor, m_drawRequestViewportId, &ViewportRequestBus::Events::DeviceScalingFactor);
+
+        const auto [viewportWidth, viewportHeight] = viewportContext->GetViewportSize();
+        const auto viewportSize = AzFramework::ScreenSize(viewportWidth, viewportHeight);
+
+        for (auto &[iconId, drawIconRequests] : m_drawRequests)
         {
-            using ViewportRequestBus = AzToolsFramework::ViewportInteraction::ViewportInteractionRequestBus;
-            ViewportRequestBus::EventResult(
-                scalingFactor, drawParameters.m_viewport, &ViewportRequestBus::Events::DeviceScalingFactor);
+            // Find our icon, falling back on a gray placeholder if its image is unavailable
+            if (drawIconRequests.empty())
+            {
+                continue;
+            }
+
+            AZ::Data::Instance<AZ::RPI::Image> image = GetImageForIconId(iconId);
+            AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> drawSrg = CreateIconSRG(m_drawRequestViewportId, image);
+
+            // add all of the icons to draw buffers.
+            m_vertexCache.clear();
+            m_vertexCache.reserve(drawIconRequests.size() * 4);
+            
+            float minZ = aznumeric_cast<float>(AZStd::numeric_limits<int64_t>::max());
+            float maxZ = aznumeric_cast<float>(AZStd::numeric_limits<int64_t>::min());
+
+            for (const DrawParameters& drawParameters : drawIconRequests)
+            {
+                AZ::Vector3 screenPosition;
+                if (drawParameters.m_positionSpace == CoordinateSpace::ScreenSpace)
+                {
+                    screenPosition = drawParameters.m_position;
+                }
+                else if (drawParameters.m_positionSpace == CoordinateSpace::WorldSpace)
+                {
+                    // Calculate the ndc point (0.0-1.0 range) including depth
+                    const AZ::Vector3 ndcPoint = AzFramework::WorldToScreenNdc(
+                        drawParameters.m_position, viewportContext->GetCameraViewMatrixAsMatrix3x4(),
+                        viewportContext->GetCameraProjectionMatrix());
+
+                    // Calculate our screen space position using the viewport size
+                    // We want this instead of RenderViewportWidget::WorldToScreen which works in QWidget virtual coordinate space
+                    const AzFramework::ScreenPoint screenPoint = AzFramework::ScreenPointFromNdc(AZ::Vector3ToVector2(ndcPoint), viewportSize);
+                    screenPosition = AzFramework::Vector3FromScreenPoint(screenPoint, ndcPoint.GetZ());
+                }
+                minZ = AZStd::GetMin(minZ, screenPosition.GetZ());
+                maxZ = AZStd::GetMin(maxZ, screenPosition.GetZ());
+
+                // Create a vertex offset from the position to draw from based on the icon size
+                // Vertex positions are in screen space coordinates
+                auto createVertex = [&](float offsetX, float offsetY, float u, float v) -> IconVertexData
+                {
+                    IconVertexData vertex;
+                    screenPosition.StoreToFloat3(vertex.m_position);
+                    vertex.m_position[0] += offsetX * drawParameters.m_size.GetX() * scalingFactor;
+                    vertex.m_position[1] += offsetY * drawParameters.m_size.GetY() * scalingFactor;
+                    vertex.m_color = drawParameters.m_color.ToU32();
+                    vertex.m_uv[0] = u;
+                    vertex.m_uv[1] = v;
+                    return vertex;
+                };
+
+                m_vertexCache.emplace_back(createVertex(-0.5f, -0.5f, 0.f, 0.f));
+                m_vertexCache.emplace_back(createVertex(0.5f,  -0.5f, 1.f, 0.f));
+                m_vertexCache.emplace_back(createVertex(0.5f,  0.5f,  1.f, 1.f));
+                m_vertexCache.emplace_back(createVertex(-0.5f, 0.5f,  0.f, 1.f));
+            }
+
+            if (!m_vertexCache.empty())
+            {
+                // the indexes are always the same (0,1,2,0,2,3, 4,5,6,4,6,7, etc) and thus don't need to be updated unless more quads are added
+                using IndexCacheSize = AZStd::vector<IconIndexData>::size_type;
+
+                IndexCacheSize numQuadsInVertexBuffer = m_vertexCache.size() / 4;
+                IndexCacheSize numIndicesRequired = numQuadsInVertexBuffer * 6;
+
+                IndexCacheSize currentIndexCacheSize = m_indexCache.size();
+                if (currentIndexCacheSize < numIndicesRequired)
+                {
+                    m_indexCache.resize_no_construct(numIndicesRequired);
+                    IconIndexData baseIndex = aznumeric_cast<IconIndexData>(currentIndexCacheSize / 6);
+                    while (currentIndexCacheSize < numIndicesRequired)
+                    {
+                        m_indexCache[currentIndexCacheSize++] = (baseIndex * 4) + 0;
+                        m_indexCache[currentIndexCacheSize++] = (baseIndex * 4) + 1;
+                        m_indexCache[currentIndexCacheSize++] = (baseIndex * 4) + 2;
+                        m_indexCache[currentIndexCacheSize++] = (baseIndex * 4) + 0;
+                        m_indexCache[currentIndexCacheSize++] = (baseIndex * 4) + 2;
+                        m_indexCache[currentIndexCacheSize++] = (baseIndex * 4) + 3;
+                        ++baseIndex;
+                    }
+                }
+
+                dynamicDraw->SetSortKey((maxZ - minZ) * 0.5f  * aznumeric_cast<float>(AZStd::numeric_limits<int64_t>::max()));
+                dynamicDraw->DrawIndexed( m_vertexCache.data(), static_cast<uint32_t>(m_vertexCache.size()),
+                                         m_indexCache.data(), static_cast<uint32_t>(numIndicesRequired), RHI::IndexFormat::Uint16,
+                    drawSrg);
+            }
+            drawIconRequests.clear(); // note - we don't remove the key, we just clear the vector and keep the memory allocated.
         }
+        m_drawRequestViewportId = AzFramework::InvalidViewportId;
+    }
 
-        AZ::Vector3 screenPosition;
-        if (drawParameters.m_positionSpace == CoordinateSpace::ScreenSpace)
-        {
-            screenPosition = drawParameters.m_position;
-        }
-        else if (drawParameters.m_positionSpace == CoordinateSpace::WorldSpace)
-        {
-            // Calculate the ndc point (0.0-1.0 range) including depth
-            const AZ::Vector3 ndcPoint = AzFramework::WorldToScreenNdc(
-                drawParameters.m_position, viewportContext->GetCameraViewMatrixAsMatrix3x4(),
-                viewportContext->GetCameraProjectionMatrix());
 
-            // Calculate our screen space position using the viewport size
-            // We want this instead of RenderViewportWidget::WorldToScreen which works in QWidget virtual coordinate space
-            const AzFramework::ScreenPoint screenPoint = AzFramework::ScreenPointFromNdc(AZ::Vector3ToVector2(ndcPoint), viewportSize);
-            screenPosition = AzFramework::Vector3FromScreenPoint(screenPoint, ndcPoint.GetZ());
-        }
-
-        struct Vertex
-        {
-            float m_position[3];
-            AZ::u32 m_color;
-            float m_uv[2];
-        };
-        using Indice = AZ::u16;
-
-        // Create a vertex offset from the position to draw from based on the icon size
-        // Vertex positions are in screen space coordinates
-        auto createVertex = [&](float offsetX, float offsetY, float u, float v) -> Vertex
-        {
-            Vertex vertex;
-            screenPosition.StoreToFloat3(vertex.m_position);
-            vertex.m_position[0] += offsetX * drawParameters.m_size.GetX() * scalingFactor;
-            vertex.m_position[1] += offsetY * drawParameters.m_size.GetY() * scalingFactor;
-            vertex.m_color = drawParameters.m_color.ToU32();
-            vertex.m_uv[0] = u;
-            vertex.m_uv[1] = v;
-            return vertex;
-        };
-
-        AZStd::array<Vertex, 4> vertices = {
-            createVertex(-0.5f, -0.5f, 0.f, 0.f),
-            createVertex(0.5f,  -0.5f, 1.f, 0.f),
-            createVertex(0.5f,  0.5f,  1.f, 1.f),
-            createVertex(-0.5f, 0.5f,  0.f, 1.f)
-        };
-        AZStd::array<Indice, 6> indices = {0, 1, 2, 0, 2, 3};
-
-        dynamicDraw->SetSortKey(
-            aznumeric_cast<int64_t>(screenPosition.GetZ() * aznumeric_cast<float>(AZStd::numeric_limits<int64_t>::max())));
-        dynamicDraw->DrawIndexed(
-            &vertices, static_cast<uint32_t>(vertices.size()), &indices, static_cast<uint32_t>(indices.size()), RHI::IndexFormat::Uint16,
-            drawSrg);
+    void AtomViewportDisplayIconsSystemComponent::DrawIcon(const DrawParameters& drawParameters)
+    {
+        AddIcon(drawParameters);
+        // Be careful when using this method as it does not support batching.
+        // Prefer using AddIcon, AddIcon, AddIcon, ..., DrawIcons() to render them in a batch.
+        DrawIcons();
     }
 
     QString AtomViewportDisplayIconsSystemComponent::FindAssetPath(const QString& path) const

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ImageBasedLights/ImageBasedLightComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ImageBasedLights/ImageBasedLightComponentController.cpp
@@ -131,22 +131,43 @@ namespace AZ
 
         void ImageBasedLightComponentController::UpdateWithAsset(Data::Asset<Data::AssetData> updatedAsset)
         {
-            if (m_configuration.m_specularImageAsset.GetId() == updatedAsset.GetId())
+            // REMARK: This function is typically invoked within the context of one of the AssetBus::OnAssetXXX functions,
+            // and a deadlock may occur according to the following sequence:
+            // 1. Starting from Main thread, AssetBus locks a mutex.
+            // 2. AssetBus calls OnAssetReady and it enters in this function.
+            // 3. Start the instantiation of a new StreamingImage.
+            // 4. StreamingImage asynchronously queues work in the "Seconday Copy Queue".
+            // 5. StreamingImage waits until the work completes.
+            // 6. The thread of "Seconday Copy Queue" gets a new work item, which may hold a reference
+            //    to an old StreamingImage.
+            // 7. The old StreamingImage gets destroyed and it calls AssetBus::MultiHandler::BusDisconnect(GetAssetId());
+            // 8. When calling AssetBus::MultiHandler::BusDisconnect(GetAssetId()); it tries to lock the same mutex
+            //    from step 1. But the mutex is already locked on Main Thread in step 1.
+            // 9. The "Seconday Copy Queue" thread deadlocks and never completes the work.
+            // 10. Main thread is also deadlocked waiting for "Seconday Copy Queue" to complete.
+            // The solution is to enqueue texture update on the next tick.
+            auto postTickLambda = [=]()
             {
-                if (m_featureProcessor && HandleAssetUpdate(updatedAsset, m_configuration.m_specularImageAsset))
+                if (m_configuration.m_specularImageAsset.GetId() == updatedAsset.GetId())
                 {
-                    m_featureProcessor->SetSpecularImage(m_configuration.m_specularImageAsset);
-                    ImageBasedLightComponentNotificationBus::Event(m_entityId, &ImageBasedLightComponentNotifications::OnSpecularImageUpdated);
+                    if (m_featureProcessor && HandleAssetUpdate(updatedAsset, m_configuration.m_specularImageAsset))
+                    {
+                        m_featureProcessor->SetSpecularImage(m_configuration.m_specularImageAsset);
+                        ImageBasedLightComponentNotificationBus::Event(
+                            m_entityId, &ImageBasedLightComponentNotifications::OnSpecularImageUpdated);
+                    }
                 }
-            }
-            else if (m_configuration.m_diffuseImageAsset.GetId() == updatedAsset.GetId())
-            {
-                if (m_featureProcessor && HandleAssetUpdate(updatedAsset, m_configuration.m_diffuseImageAsset))
+                else if (m_configuration.m_diffuseImageAsset.GetId() == updatedAsset.GetId())
                 {
-                    m_featureProcessor->SetDiffuseImage(m_configuration.m_diffuseImageAsset);
-                    ImageBasedLightComponentNotificationBus::Event(m_entityId, &ImageBasedLightComponentNotifications::OnDiffuseImageUpdated);
+                    if (m_featureProcessor && HandleAssetUpdate(updatedAsset, m_configuration.m_diffuseImageAsset))
+                    {
+                        m_featureProcessor->SetDiffuseImage(m_configuration.m_diffuseImageAsset);
+                        ImageBasedLightComponentNotificationBus::Event(
+                            m_entityId, &ImageBasedLightComponentNotifications::OnDiffuseImageUpdated);
+                    }
                 }
-            }
+            };
+            AZ::TickBus::QueueFunction(AZStd::move(postTickLambda));
         }
 
         bool ImageBasedLightComponentController::HandleAssetUpdate(Data::Asset<Data::AssetData> updatedAsset, Data::Asset<RPI::StreamingImageAsset>& configAsset)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
@@ -336,7 +336,7 @@ namespace AZ
             }
         }
 
-        void MaterialComponentController::InitializeMaterialInstance(const Data::Asset<Data::AssetData>& asset)
+        void MaterialComponentController::InitializeMaterialInstancePostTick(Data::Asset<Data::AssetData> asset)
         {
             bool allReady = true;
             auto updateAsset = [&](AZ::Data::Asset<AZ::RPI::MaterialAsset>& materialAsset)
@@ -382,6 +382,30 @@ namespace AZ
                 QueueMaterialsCreatedNotification();
                 QueueMaterialsUpdatedNotification();
             }
+        }
+
+        void MaterialComponentController::InitializeMaterialInstance(Data::Asset<Data::AssetData> asset)
+        {
+            // REMARK: This function is typically invoked within the context of one of the AssetBus::OnAssetXXX functions,
+            // and a deadlock may occur according to the following sequence:
+            // 1. Starting from Main thread, AssetBus locks a mutex.
+            // 2. AssetBus calls OnAssetReady and it enters in this function.
+            // 3. Start the instantiation of a new StreamingImage.
+            // 4. StreamingImage asynchronously queues work in the "Seconday Copy Queue".
+            // 5. StreamingImage waits until the work completes.
+            // 6. The thread of "Seconday Copy Queue" gets a new work item, which may hold a reference
+            //    to an old StreamingImage.
+            // 7. The old StreamingImage gets destroyed and it calls AssetBus::MultiHandler::BusDisconnect(GetAssetId());
+            // 8. When calling AssetBus::MultiHandler::BusDisconnect(GetAssetId()); it tries to lock the same mutex
+            //    from step 1. But the mutex is already locked on Main Thread in step 1.
+            // 9. The "Seconday Copy Queue" thread deadlocks and never completes the work.
+            // 10. Main thread is also deadlocked waiting for "Seconday Copy Queue" to complete.
+            // The solution is to enqueue texture update on the next tick.
+            auto postTickLambda = [=]()
+            {
+                InitializeMaterialInstancePostTick(asset);
+            };
+            AZ::TickBus::QueueFunction(AZStd::move(postTickLambda));
         }
 
         void MaterialComponentController::ReleaseMaterials()

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
@@ -96,7 +96,10 @@ namespace AZ
             void OnSystemTick() override;
 
             void LoadMaterials();
-            void InitializeMaterialInstance(const Data::Asset<Data::AssetData>& asset);
+            // Typically called from thread context of Data::AssetBus::MultiHandler::OnAssetXXX.
+            void InitializeMaterialInstance(Data::Asset<Data::AssetData> asset);
+            // Must be called on main thread.
+            void InitializeMaterialInstancePostTick(Data::Asset<Data::AssetData> asset);
             void ReleaseMaterials();
             //! Queue applying property overrides to material instances until tick
             void QueuePropertyChanges(const MaterialAssignmentId& materialAssignmentId);

--- a/Gems/EditorPythonBindings/Editor/Scripts/level_load_unload_stress.py
+++ b/Gems/EditorPythonBindings/Editor/Scripts/level_load_unload_stress.py
@@ -1,0 +1,116 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+import os
+
+import azlmbr.legacy.general as azgeneral
+
+def RunLevelReloadTest(levels: list[str],
+                       iterationsCount: int = 3,
+                       iterationsEnterExit: int = 1,
+                       idleFramesOpen: int = 3,
+                       idleFramesEnter: int = 3,
+                       idleFramesExit: int = 3):
+    """
+    For each level name listed in @levels:
+    1- Loads the level
+    2- Waits (if requested)
+    3- Enters/Exit Game mode as many times defined in @iterationsEnterExit
+    
+    Repeats all of the above @iterationsCount times.
+    """
+    for idx in range(iterationsCount):
+        print(f"Iteration {idx}")
+        for levelName in levels:
+            azgeneral.open_level_no_prompt(levelName)
+            if idleFramesOpen > 0:
+                azgeneral.idle_wait_frames(idleFramesOpen)
+            for jdx in range(iterationsEnterExit):
+                print(f"Iteration {idx}. Enter/Exit {jdx}")
+                azgeneral.enter_game_mode()
+                if idleFramesEnter > 0:
+                    azgeneral.idle_wait_frames(idleFramesEnter)
+                azgeneral.exit_game_mode()
+                if idleFramesExit > 0:
+                    azgeneral.idle_wait_frames(idleFramesExit)
+
+
+# Quick Example on how to run this test using default levels from AutomatedTesting for 10 iterations:
+# pyRunFile C:\GIT\o3de\Gems\EditorPythonBindings\Editor\Scripts\level_load_unload_stress.py -i 10
+# pyRunFile C:\GIT\o3de\Gems\EditorPythonBindings\Editor\Scripts\level_load_unload_stress.py -i 10 --level CommsCenter,CypunkAptInterior,PoliceStation,TempleOfEnlightment
+# pyRunFile C:\GIT\o3de\Gems\EditorPythonBindings\Editor\Scripts\level_load_unload_stress.py -n 1 -x 1 --level CommsCenter,CypunkAptInterior,PoliceStation,TempleOfEnlightment
+def MainFunc():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Level loading test that validates that there are no crashes due to changing levels quickly."
+    )
+
+    parser.add_argument(
+        "-i",
+        "--iterations",
+        type=int,
+        default=3,
+        help="How many times will load all levels in the list",
+    )
+
+    parser.add_argument(
+        "-e",
+        "--enter_exit_iterations",
+        type=int,
+        default=2,
+        help="How many times will enter and exit game mode, for each level in the list.",
+    )
+
+    parser.add_argument(
+        "-o",
+        "--idle_frames_open",
+        type=int,
+        default=3,
+        help="How many frames to wait after opening a level",
+    )
+
+    parser.add_argument(
+        "-n",
+        "--idle_frames_enter",
+        type=int,
+        default=3,
+        help="How many frames to wait after entering game mode.",
+    )
+
+    parser.add_argument(
+        "-x",
+        "--idle_frames_exit",
+        type=int,
+        default=3,
+        help="How many frames to wait after exiting game mode.",
+    )
+
+    parser.add_argument(
+        "--levels",
+        default="Graphics/hermanubis,Graphics/macbeth_shaderballs",
+        help="Comma seperated list of level names.",
+    )
+
+    args = parser.parse_args()
+    iterations = args.iterations
+    iterationsEnterExit = args.enter_exit_iterations
+    idleFramesOpen = args.idle_frames_open
+    idleFramesEnter = args.idle_frames_enter
+    idleFramesExit = args.idle_frames_exit
+    levels = args.levels.split(",")
+    print(f"Original levels list:\n{levels}")
+    nonEmptyNames = []
+    for levelName in levels:
+        if levelName:
+            nonEmptyNames.append(levelName)
+    print(f"Valid levels list:\n{nonEmptyNames}")
+    RunLevelReloadTest(nonEmptyNames, iterations, iterationsEnterExit, idleFramesOpen, idleFramesEnter, idleFramesExit)
+    print(f"PASSED. Completed {iterations} iterations!")
+
+if __name__ == "__main__":
+    MainFunc()

--- a/Gems/MiniAudio/Code/Include/MiniAudio/SoundAssetRef.h
+++ b/Gems/MiniAudio/Code/Include/MiniAudio/SoundAssetRef.h
@@ -37,7 +37,9 @@ namespace MiniAudio
     private:
         class SerializationEvents : public AZ::SerializeContext::IEventHandler
         {
-            void OnReadEnd(void* classPtr) override
+            // OnWriteEnd happens after the object pointed at by classPtr
+            // has finished being deserialized and is fully loaded.
+            void OnWriteEnd(void* classPtr) override
             {
                 SoundAssetRef* SoundAssetRef = reinterpret_cast<class SoundAssetRef*>(classPtr);
                 // Call SetAsset to connect AssetBus handler as soon as m_asset field is set

--- a/Gems/ScriptCanvas/Code/Editor/Assets/ScriptCanvasFileHandling.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Assets/ScriptCanvasFileHandling.cpp
@@ -276,17 +276,19 @@ namespace ScriptCanvas
         {
             result.m_fileReadErrors = "Script Canvas Graph Deserialization Failed - " + result.m_deserializeResult.m_errors + "\n";
         }
-
-        const auto& graphDataPtr = result.m_deserializeResult.m_graphDataPtr;
-        if (graphDataPtr && graphDataPtr->GetEditorGraph())
+        else
         {
-            ScriptCanvasEditor::EditorGraphRequestBus::Event(
-                graphDataPtr->GetEditorGraph()->GetScriptCanvasId(),
-                &ScriptCanvasEditor::EditorGraphRequests::SetOriginalToNewIdsMap,
-                result.m_deserializeResult.m_originalIdsToNewIds);
-        }
+            const auto& graphDataPtr = result.m_deserializeResult.m_graphDataPtr;
+            if (graphDataPtr && graphDataPtr->GetEditorGraph())
+            {
+                ScriptCanvasEditor::EditorGraphRequestBus::Event(
+                    graphDataPtr->GetEditorGraph()->GetScriptCanvasId(),
+                    &ScriptCanvasEditor::EditorGraphRequests::SetOriginalToNewIdsMap,
+                    result.m_deserializeResult.m_originalIdsToNewIds);
+            }
 
-        result.m_handle = SourceHandle::FromRelativePath(result.m_deserializeResult.m_graphDataPtr, path);
+            result.m_handle = SourceHandle::FromRelativePath(result.m_deserializeResult.m_graphDataPtr, path);
+        }
         return result;
     }
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/ExecutionStateHandler.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/ExecutionStateHandler.cpp
@@ -134,10 +134,10 @@ namespace ScriptCanvas
             m_executionState = nullptr;
 #else
             m_executionState->StopExecution();
-            Execution::Destruct(m_executionStateStorage);
             SCRIPT_CANVAS_PERFORMANCE_FINALIZE_TIMER(m_executionState);
             ScriptCanvas::ExecutionNotificationsBus::Broadcast(
-                &ScriptCanvas::ExecutionNotifications::GraphDeactivated, GraphActivation(GraphInfo(m_executionState)));
+                &ScriptCanvas::ExecutionNotifications::GraphDeactivated, GraphDeactivation(GraphInfo(m_executionState)));
+            Execution::Destruct(m_executionStateStorage);
             m_executionState = nullptr;
 #endif
         }

--- a/Gems/Terrain/Code/Source/TerrainRenderer/Components/TerrainSurfaceMaterialsListComponent.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/Components/TerrainSurfaceMaterialsListComponent.cpp
@@ -328,6 +328,30 @@ namespace Terrain
 
     void TerrainSurfaceMaterialsListComponent::OnAssetReady(AZ::Data::Asset<AZ::Data::AssetData> asset)
     {
+        // REMARK: This function is typically invoked within the context of one of the AssetBus::OnAssetXXX functions,
+        // and a deadlock may occur according to the following sequence:
+        // 1. Starting from Main thread, AssetBus locks a mutex.
+        // 2. AssetBus calls OnAssetReady and it enters in this function.
+        // 3. Start the instantiation of a new StreamingImage.
+        // 4. StreamingImage asynchronously queues work in the "Seconday Copy Queue".
+        // 5. StreamingImage waits until the work completes.
+        // 6. The thread of "Seconday Copy Queue" gets a new work item, which may hold a reference
+        //    to an old StreamingImage.
+        // 7. The old StreamingImage gets destroyed and it calls AssetBus::MultiHandler::BusDisconnect(GetAssetId());
+        // 8. When calling AssetBus::MultiHandler::BusDisconnect(GetAssetId()); it tries to lock the same mutex
+        //    from step 1. But the mutex is already locked on Main Thread in step 1.
+        // 9. The "Seconday Copy Queue" thread deadlocks and never completes the work.
+        // 10. Main thread is also deadlocked waiting for "Seconday Copy Queue" to complete.
+        // The solution is to enqueue texture update on the next tick.
+        auto postTickLambda = [=]()
+        {
+            OnAssetReadyPostTick(asset);
+        };
+        AZ::TickBus::QueueFunction(AZStd::move(postTickLambda));
+    }
+
+    void TerrainSurfaceMaterialsListComponent::OnAssetReadyPostTick(AZ::Data::Asset<AZ::Data::AssetData> asset)
+    {
         // Find the missing material instance with the correct id.
         auto handleCreateMaterial = [&](TerrainSurfaceMaterialMapping& mapping, const AZ::Data::Asset<AZ::Data::AssetData>& asset)
         {
@@ -363,6 +387,16 @@ namespace Terrain
     }
 
     void TerrainSurfaceMaterialsListComponent::OnAssetReloaded(AZ::Data::Asset<AZ::Data::AssetData> asset)
+    {
+        // REMARK: See OnAssetReady for details on why we postpone the work on the next tick.
+        auto postTickLambda = [=]()
+        {
+            OnAssetReloadedPostTick(asset);
+        };
+        AZ::TickBus::QueueFunction(AZStd::move(postTickLambda));
+    }
+
+    void TerrainSurfaceMaterialsListComponent::OnAssetReloadedPostTick(AZ::Data::Asset<AZ::Data::AssetData> asset)
     {
         // Find the material instance with the correct id.
         auto handleUpdateMaterial = [&](TerrainSurfaceMaterialMapping& mapping, const AZ::Data::Asset<AZ::Data::AssetData>& asset)

--- a/Gems/Terrain/Code/Source/TerrainRenderer/Components/TerrainSurfaceMaterialsListComponent.h
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/Components/TerrainSurfaceMaterialsListComponent.h
@@ -106,6 +106,9 @@ namespace Terrain
         void OnAssetReady(AZ::Data::Asset<AZ::Data::AssetData> asset) override;
         void OnAssetReloaded(AZ::Data::Asset<AZ::Data::AssetData> asset) override;
 
+        void OnAssetReadyPostTick(AZ::Data::Asset<AZ::Data::AssetData> asset);
+        void OnAssetReloadedPostTick(AZ::Data::Asset<AZ::Data::AssetData> asset);
+
         TerrainSurfaceMaterialsListConfig m_configuration;
 
         AZ::Aabb m_cachedAabb{ AZ::Aabb::CreateNull() };

--- a/Registry/AssetProcessorPlatformConfig.setreg
+++ b/Registry/AssetProcessorPlatformConfig.setreg
@@ -321,7 +321,7 @@
                     "productAssetType": "{B36FEB5C-41B6-4B58-A212-21EF5AEF523C}"
                 },
                 "RC png-entityicon": {
-                    "pattern": "(.*EntityIcons\\\\/).*\\\\.png",
+                    "pattern": "(.*(EntityIcons|Editor\\\\/Icons)\\\\/).*\\\\.(png|svg)",
                     "productAssetType": "{3436C30E-E2C5-4C3B-A7B9-66C94A28701B}",
                     "params": "skip",
                     "tools": "copy"


### PR DESCRIPTION
## What does this PR do?

**18595**
The fix was to add a Mutex in Material class
that protects usage of Material::m_shaderVariantReadyEvent

**18601**
Fixes issue https://github.com/o3de/o3de/issues/18567

This batch renders icons.  Note that the old API was retained, for backward
compatibility, so all existing code in other gems will still work
(none were found in the engine), but the new API is preferred.

After this change, I can't really notice a difference between icons on and off
in terms of rendering for Startergame (A couple thousand icons).

Before this change, it would drop to about 4ps, from 60.

I'm sure there's always a way to improve this further but just this change
alone is enough for the icon rendering to no longer matter in terms of
profiler performance, so other things should probably be looked at before
we return to this.

**18609**
* Fixes race conditions and deadlocks when loading levels.

Fixes #18597

The most important change in this PR is that InstanceDatabase::EmplaceInstance
has been changed so it manages when to lock `m_databaseMutex`. In particular,
m_databaseMutex is not locked anymore during `InstanceData<Type>` creation
because creating resources like StreamingImage(s) is a multi-threaded operation
coordinated by `AsyncUploadQueue` where secondary threads (like `Secondary Copy Queue`) sometimes release
other StreamingImage(s) and that operation also locks m_databaseMutex. This is a clear
deadlock case if m_databaseMutex was already locked on the Main Thread.

The second most important change pertains to some components that instantiate StreamingImage(s)
objects in the same thread when the AssetBus calls one of the OnAssetReady() or OnAssetReloaded()
functions. The AssetBus locks its own mutex. This can also cause deadlocks,
because when  AsyncUploadQueue() is called, and an StreamingImage
is released during the `Secondary Copy Queue` thread, the StreamingImage class would call:
```cpp
Data::AssetBus::MultiHandler::BusDisconnect(GetAssetId());
```
Which will deadlock when it tries to lock the AssetBus mutex.
The fix is to defer the OnAssetXXX functions on the TickBus queue.
REMARK:
This PR fixes:
1. ImageBasedLightComponentController.cpp OnAssetXXXX
2. MaterialComponentController.cpp OnAssetXXXX
3. TerrainSurfaceMaterialsListComponent.cpp OnAssetXXXX
BUT, any other component that instantiates StreamingImage(s) exactly during OnAssetXXX functions
would need to apply a similar fix to avoid deadlocks.

The 3rd kind of bugs that have been fixed is related with race condition crashes
when some `InstanceData<Type>` classes are created during multi-threaded scenarios
like MeshDrawPacket::DoUpdate(), which runs from multiple concurrent jobs. To avoid
the crashes a new mutex was added to `InstanceDatabase<Type>` called `m_newInstanceMutex`
which is only locked when a new `InstanceData<Type>` is being created and constructed.

Finally, a major improvement was done to `CryMT::queue` class by changing its underlying container
from `std::vector` to `std::queue`. I discovered the innefficiency when I added all kinds of verbose
AZ_Printf statements when debugging all the bugs mentioned above. And I noticed that the main reason
for slow debugging was because the old implementation using `std::vector` was calling:
```cpp
v.erase(v.begin());
```
Which, for a vector, is a big no-no because erasing from the begginning of a vector causes long copy operations.
Hard to believe we've been dealing with this lingering performance threat for so long.

Added a python script:
Gems/EditorPythonBindings/Editor/Scripts/level_load_unload_stress.py
that helps automate and iterate across a list of levels.
Opens a level, enters/exits game mode, and can wait an arbitrary amount
of frames in between those operations.

**18624**
Fixed crash when opening invalid ScriptCanvas file and fixed graph deactivation error

**18620**

See https://github.com/o3de/o3de/issues/18620 for a detailed issue report.

This PR fixes the issue by doing a few specific things
* Moves a bunch of entity utility functions from inside the Property Editor (As in, the GUI Control) into
  the Entity Utility class so that it can be used from more than one location.
* Makes it so that the OnWriteEnd / OnWriteBegin functions are actually called when reading from json,
  so that classes wanting to do a post-load fixup actually get invoked
* Adds comments to the serializer to explain the OnRead* and OnWrite* functions and caveats.
* Fixes several classes that were listening to OnReadEnd thinking it meant that reading into the C++ object had finished.
  They should have been listening for OnWriteEnd instead.
* Makes it so that the Inspector component only saves the component order if it differs from default
* Adds an automated test to verify the new code.
* Makes it so that the icon component caches the icon to use only when actually asked for the icon
* Makes it so that the icon component and inspector component can deal with the case where the components are in default order.
* Makes it so that icon files (SVG as well as PNG) are tagged as such in the AP so that they can actually be used.

## How was this PR tested?

Built locally in editor.
