### PR TITLE
Texture resolution limit cvar (MAD-16347)

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/StreamingImageAssetHandler.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Image/StreamingImageAssetHandler.cpp
@@ -96,7 +96,8 @@ namespace AZ
                                     numMipsToRemove++;
                                 }
                             }
-                            assetData->RemoveFrontMipchains(AZStd::min(numMipsToRemove, assetData->GetMipChainCount() - 1));
+                            const size_t finalToRemove = AZStd::min(numMipsToRemove, assetData->GetMipChainCount() - 1);
+                            assetData->RemoveFrontMipchains(finalToRemove);
                         }
                     }
 #endif


### PR DESCRIPTION
## What does this PR do?

Introduce a new CVAR to limit max texture resolution for min specs devices.

## How was this PR tested?

Local tests on iPhone XR and iPhone 11. The cvar is set for "low" tier only (there is another PR to the game repro with quality.setreg mod https://github.com/carbonated-dev/o3de-gruber/pull/1286).
