### PR TITLE
Add a call to set render resolution directly from width & height (MAD-17475)

### DIFF
--- a/Gems/Atom/Bootstrap/Code/Include/Atom/Bootstrap/BootstrapRequestBus.h
+++ b/Gems/Atom/Bootstrap/Code/Include/Atom/Bootstrap/BootstrapRequestBus.h
@@ -28,6 +28,9 @@ namespace AZ::Render::Bootstrap
         virtual void SwitchAntiAliasing(const AZStd::string& newAntiAliasing, AZ::RPI::ViewportContextPtr viewportContext) = 0;
         virtual void SwitchMultiSample(const uint16_t newSampleCount, AZ::RPI::ViewportContextPtr viewportContext) = 0;
         virtual void RefreshWindowResolution() = 0;
+#if defined(CARBONATED)
+        virtual void SetWindowResolutionDirectly(AzFramework::WindowSize resolution) = 0;
+#endif
 
     protected:
         ~Request() = default;

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -814,7 +814,8 @@ namespace AZ
             {
                 SetWindowResolution();
             }
-
+        
+#if defined(CARBONATED)
             void BootstrapSystemComponent::SetWindowResolutionDirectly(AzFramework::WindowSize resolution)
             {
                 if (m_nativeWindow)
@@ -823,7 +824,7 @@ namespace AZ
                     m_nativeWindow->SetFullScreenState(r_fullscreen);
                 }
             }
-
+#endif
 
             RPI::RenderPipelinePtr BootstrapSystemComponent::LoadPipeline( AZ::RPI::ScenePtr scene, AZ::RPI::ViewportContextPtr viewportContext,
                                                     AZStd::string_view pipelineName, AZ::RPI::ViewType viewType, AZ::RHI::MultisampleState& multisampleState)

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -22,6 +22,9 @@
 #include <AzFramework/Components/TransformComponent.h>
 #include <AzFramework/Entity/GameEntityContextBus.h>
 #include <AzFramework/Asset/AssetSystemBus.h>
+#if defined(CARBONATED)
+#include <AzFramework/IO/LocalFileIO.h>
+#endif
 
 #include <ISystem.h>
 
@@ -605,7 +608,7 @@ namespace AZ
                         resolution.m_height = static_cast<uint32_t>(windowSize.m_height * scale);
                     }
 #endif
-                    
+
                     m_nativeWindow->SetRenderResolution(resolution);
                     m_nativeWindow->SetFullScreenState(r_fullscreen);
                 }
@@ -814,6 +817,16 @@ namespace AZ
             {
                 SetWindowResolution();
             }
+
+            void BootstrapSystemComponent::SetWindowResolutionDirectly(AzFramework::WindowSize resolution)
+            {
+                if (m_nativeWindow)
+                {
+                    m_nativeWindow->SetRenderResolution(resolution);
+                    m_nativeWindow->SetFullScreenState(r_fullscreen);
+                }
+            }
+
 
             RPI::RenderPipelinePtr BootstrapSystemComponent::LoadPipeline( AZ::RPI::ScenePtr scene, AZ::RPI::ViewportContextPtr viewportContext,
                                                     AZStd::string_view pipelineName, AZ::RPI::ViewType viewType, AZ::RHI::MultisampleState& multisampleState)

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -22,9 +22,6 @@
 #include <AzFramework/Components/TransformComponent.h>
 #include <AzFramework/Entity/GameEntityContextBus.h>
 #include <AzFramework/Asset/AssetSystemBus.h>
-#if defined(CARBONATED)
-#include <AzFramework/IO/LocalFileIO.h>
-#endif
 
 #include <ISystem.h>
 

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.h
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.h
@@ -73,6 +73,9 @@ namespace AZ
                 void SwitchAntiAliasing(const AZStd::string& newAntiAliasing, AZ::RPI::ViewportContextPtr viewportContext) override;
                 void SwitchMultiSample(const uint16_t newSampleCount, AZ::RPI::ViewportContextPtr viewportContext) override;
                 void RefreshWindowResolution() override;
+#if defined(CARBONATED)
+                void SetWindowResolutionDirectly(AzFramework::WindowSize resolution) override;
+#endif
 
             protected:
                 // Component overrides ...


### PR DESCRIPTION
## What does this PR do?

Add new function to set render window resolution directly from width and height, ignoring all the auto-setup logic.

## How was this PR tested?

Locally tested on Windows and multiple iOS devices.
