### PR TITLE
Preserve texture quality tags (mad-17473)

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/TexturePropertyEditor.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/TexturePropertyEditor.cpp
@@ -170,7 +170,14 @@ namespace ImageProcessingAtomEditor
         ImageProcessingAtom::TextureSettings& baseSetting = m_textureSetting.GetMultiplatformTextureSetting();
         for (auto& it : m_textureSetting.m_settingsMap)
         {
+#if defined (CARBONATED)
+            // tags are common settings, if we do not copy them to platform specific settings here then the platform patch will erase tags
+            ImageProcessingAtom::TextureSettings platformSetting = it.second;
+            platformSetting.m_tags = baseSetting.m_tags;
+            baseSetting.ApplySettings(platformSetting, it.first);
+#else
             baseSetting.ApplySettings(it.second, it.first);
+#endif
         }
 
         ImageProcessingAtom::StringOutcome outcome = ImageProcessingAtom::TextureSettings::WriteTextureSetting(outputPath, baseSetting);


### PR DESCRIPTION
## What does this PR do?

Invert O3DE's original image quality tag logic. We do a bulk high lievel mip drop controlled by q_dropMips cvar, then check the image tags to preserve some textures quality. The original system has no bulk change cvar, just the tags to reduce texture quality.

## How was this PR tested?

Local tests on Windows standalone build. The code is platform agnostic. I'm building all  platforms build, I'll test it on a low end iOS device once ready.
