### PR TITLE
Mark background-foreground callbacks, abort the app in case of a bloc…

### DIFF
--- a/Code/Framework/AzCore/AzCore/NativeUI/NativeUIRequests.h
+++ b/Code/Framework/AzCore/AzCore/NativeUI/NativeUIRequests.h
@@ -42,9 +42,13 @@ namespace AZ::NativeUI
         {
             return {};
         }
-#if defined(CARBONATED) // aefimov MAD-10299 assert modal dialog fix
-            // returns true if a blocking dialog is displayed
-            virtual bool IsDisplayingBlockingDialog() const { return false; }
+#if defined(CARBONATED)
+        // aefimov MAD-10299 assert modal dialog fix
+        // returns true if a blocking dialog is displayed
+        virtual bool IsDisplayingBlockingDialog() const { return false; }
+        // aefimov beckground & foreground callbacks fix, we cannot interrupt these calls by a blocking dialog
+        virtual void BeforeAtomicCallback() {}
+        virtual void AfterAtomicCallback() {}
 #endif
 
         //! Waits for user to select an option ('Ok' or optionally 'Cancel') before execution continues

--- a/Code/Framework/AzCore/AzCore/NativeUI/NativeUIRequests.h
+++ b/Code/Framework/AzCore/AzCore/NativeUI/NativeUIRequests.h
@@ -46,9 +46,11 @@ namespace AZ::NativeUI
         // aefimov MAD-10299 assert modal dialog fix
         // returns true if a blocking dialog is displayed
         virtual bool IsDisplayingBlockingDialog() const { return false; }
+#if defined(CARBONATED_OS_CALLBACK_ASSERT)
         // aefimov beckground & foreground callbacks fix, we cannot interrupt these calls by a blocking dialog
         virtual void BeforeAtomicCallback() {}
         virtual void AfterAtomicCallback() {}
+#endif
 #endif
 
         //! Waits for user to select an option ('Ok' or optionally 'Cancel') before execution continues

--- a/Code/Framework/AzCore/AzCore/NativeUI/NativeUISystemComponent.h
+++ b/Code/Framework/AzCore/AzCore/NativeUI/NativeUISystemComponent.h
@@ -29,8 +29,14 @@ namespace AZ::NativeUI
 #if defined(CARBONATED)
         bool IsDisplayingBlockingDialog() const override;
 #if defined(CARBONATED_OS_CALLBACK_ASSERT)
-        virtual void BeforeAtomicCallback() override;
-        virtual void AfterAtomicCallback() override;
+        virtual void BeforeAtomicCallback() override
+        {
+            m_inAtomicCallback = true;
+        }
+        virtual void AfterAtomicCallback() override
+        {
+            m_inAtomicCallback = false;
+        }
 #endif
 #endif
         AZStd::string DisplayOkDialog(const AZStd::string& title, const AZStd::string& message, bool showCancel) const override;

--- a/Code/Framework/AzCore/AzCore/NativeUI/NativeUISystemComponent.h
+++ b/Code/Framework/AzCore/AzCore/NativeUI/NativeUISystemComponent.h
@@ -26,12 +26,18 @@ namespace AZ::NativeUI
         ////////////////////////////////////////////////////////////////////////
         // NativeUIRequestBus interface implementation
         AZStd::string DisplayBlockingDialog(const AZStd::string& title, const AZStd::string& message, const AZStd::vector<AZStd::string>& options) const override;
-#if defined(CARBONATED) // aefimov MAD-10299 assert modal dialog fix
+#if defined(CARBONATED)
         bool IsDisplayingBlockingDialog() const override;
-#endif        
+        virtual void BeforeAtomicCallback() override;
+        virtual void AfterAtomicCallback() override;
+#endif
         AZStd::string DisplayOkDialog(const AZStd::string& title, const AZStd::string& message, bool showCancel) const override;
         AZStd::string DisplayYesNoDialog(const AZStd::string& title, const AZStd::string& message, bool showCancel) const override;
         AssertAction DisplayAssertDialog(const AZStd::string& message) const override;
         ////////////////////////////////////////////////////////////////////////
+        
+#if defined(CARBONATED)
+        bool m_inAtomicCallback = false;
+#endif
     };
 } // namespace AZ::NativeUI

--- a/Code/Framework/AzCore/AzCore/NativeUI/NativeUISystemComponent.h
+++ b/Code/Framework/AzCore/AzCore/NativeUI/NativeUISystemComponent.h
@@ -28,8 +28,10 @@ namespace AZ::NativeUI
         AZStd::string DisplayBlockingDialog(const AZStd::string& title, const AZStd::string& message, const AZStd::vector<AZStd::string>& options) const override;
 #if defined(CARBONATED)
         bool IsDisplayingBlockingDialog() const override;
+#if defined(CARBONATED_OS_CALLBACK_ASSERT)
         virtual void BeforeAtomicCallback() override;
         virtual void AfterAtomicCallback() override;
+#endif
 #endif
         AZStd::string DisplayOkDialog(const AZStd::string& title, const AZStd::string& message, bool showCancel) const override;
         AZStd::string DisplayYesNoDialog(const AZStd::string& title, const AZStd::string& message, bool showCancel) const override;

--- a/Code/Framework/AzCore/AzCore/NativeUI/NativeUISystemComponent.h
+++ b/Code/Framework/AzCore/AzCore/NativeUI/NativeUISystemComponent.h
@@ -38,7 +38,7 @@ namespace AZ::NativeUI
         AssertAction DisplayAssertDialog(const AZStd::string& message) const override;
         ////////////////////////////////////////////////////////////////////////
         
-#if defined(CARBONATED)
+#if defined(CARBONATED) && defined(CARBONATED_OS_CALLBACK_ASSERT)
         bool m_inAtomicCallback = false;
 #endif
     };

--- a/Code/Framework/AzCore/Platform/iOS/AzCore/NativeUI/NativeUISystemComponent_iOS.mm
+++ b/Code/Framework/AzCore/Platform/iOS/AzCore/NativeUI/NativeUISystemComponent_iOS.mm
@@ -76,7 +76,7 @@ namespace AZ
             NSLog(@"Dialog title: %@", nsTitle);
             NSLog(@"Dialog message: %@\n", nsMessage);
         }
-
+#if defined(CARBONATED_OS_CALLBACK_ASSERT)
     // There is no perfect solution for callbacks like AppWillEnterForeground because we cannot interrupt such callback with a cycle
     static void OnAtomicCallbackInterrupt(NSString* nsTitle, NSString* nsMessage)
     {
@@ -107,6 +107,7 @@ namespace AZ
         NSLog(@"Dialog message: %@\n", nsMessage);
     }
 #endif
+#endif
     
         AZStd::string NativeUISystem::DisplayBlockingDialog(const AZStd::string& title, const AZStd::string& message, const AZStd::vector<AZStd::string>& options) const
         {
@@ -124,12 +125,13 @@ namespace AZ
             NSString* nsMessage = [NSString stringWithUTF8String:message.c_str()];
             
 #if defined(CARBONATED)
+#if defined(CARBONATED_OS_CALLBACK_ASSERT)
             if (NSThread.isMainThread && m_inAtomicCallback)  // we cannot interrupt the main thread only, the others are OK
             {
                 OnAtomicCallbackInterrupt(nsTitle, nsMessage);
                 abort();
             }
-            
+#endif
             // these 3 can be used later after this call is over
             [nsTitle retain];
             [nsMessage retain];

--- a/Code/Framework/AzCore/Platform/iOS/AzCore/NativeUI/NativeUISystemComponent_iOS.mm
+++ b/Code/Framework/AzCore/Platform/iOS/AzCore/NativeUI/NativeUISystemComponent_iOS.mm
@@ -23,16 +23,7 @@ namespace AZ
         {
             return false;
         }
-#if defined(CARBONATED_OS_CALLBACK_ASSERT)
-        void NativeUISystem::BeforeAtomicCallback()
-        {
-            m_inAtomicCallback = true;
-        }
-        void NativeUISystem::AfterAtomicCallback()
-        {
-            m_inAtomicCallback = false;
-        }
-#endif
+    
         template <
             class result_t   = std::chrono::milliseconds,
             class clock_t    = std::chrono::steady_clock,

--- a/Code/Framework/AzCore/Platform/iOS/AzCore/NativeUI/NativeUISystemComponent_iOS.mm
+++ b/Code/Framework/AzCore/Platform/iOS/AzCore/NativeUI/NativeUISystemComponent_iOS.mm
@@ -23,7 +23,7 @@ namespace AZ
         {
             return false;
         }
-    
+#if defined(CARBONATED_OS_CALLBACK_ASSERT)
         void NativeUISystem::BeforeAtomicCallback()
         {
             m_inAtomicCallback = true;
@@ -32,7 +32,7 @@ namespace AZ
         {
             m_inAtomicCallback = false;
         }
-    
+#endif
         template <
             class result_t   = std::chrono::milliseconds,
             class clock_t    = std::chrono::steady_clock,

--- a/Code/Framework/AzCore/Platform/iOS/AzCore/NativeUI/NativeUISystemComponent_iOS.mm
+++ b/Code/Framework/AzCore/Platform/iOS/AzCore/NativeUI/NativeUISystemComponent_iOS.mm
@@ -124,7 +124,7 @@ namespace AZ
             NSString* nsMessage = [NSString stringWithUTF8String:message.c_str()];
             
 #if defined(CARBONATED)
-            if (m_inAtomicCallback)
+            if (NSThread.isMainThread && m_inAtomicCallback)  // we cannot interrupt the main thread only, the others are OK
             {
                 OnAtomicCallbackInterrupt(nsTitle, nsMessage);
                 abort();

--- a/Code/LauncherUnified/Platform/iOS/O3DEApplicationDelegate_iOS.mm
+++ b/Code/LauncherUnified/Platform/iOS/O3DEApplicationDelegate_iOS.mm
@@ -98,48 +98,48 @@ namespace
 
 - (void)applicationWillResignActive:(UIApplication*)application
 {
-#if defined(CARBONATED)
+#if defined(CARBONATED)  && defined(CARBONATED_OS_CALLBACK_ASSERT)
     AZ::NativeUI::NativeUIRequestBus::Broadcast(&AZ::NativeUI::NativeUIRequestBus::Events::BeforeAtomicCallback);
 #endif
     AzFramework::IosLifecycleEvents::Bus::Broadcast(
         &AzFramework::IosLifecycleEvents::Bus::Events::OnWillResignActive);
-#if defined(CARBONATED)
+#if defined(CARBONATED)  && defined(CARBONATED_OS_CALLBACK_ASSERT)
     AZ::NativeUI::NativeUIRequestBus::Broadcast(&AZ::NativeUI::NativeUIRequestBus::Events::AfterAtomicCallback);
 #endif
 }
 
 - (void)applicationDidEnterBackground:(UIApplication*)application
 {
-#if defined(CARBONATED)
+#if defined(CARBONATED)  && defined(CARBONATED_OS_CALLBACK_ASSERT)
     AZ::NativeUI::NativeUIRequestBus::Broadcast(&AZ::NativeUI::NativeUIRequestBus::Events::BeforeAtomicCallback);
 #endif
     AzFramework::IosLifecycleEvents::Bus::Broadcast(
         &AzFramework::IosLifecycleEvents::Bus::Events::OnDidEnterBackground);
-#if defined(CARBONATED)
+#if defined(CARBONATED)  && defined(CARBONATED_OS_CALLBACK_ASSERT)
     AZ::NativeUI::NativeUIRequestBus::Broadcast(&AZ::NativeUI::NativeUIRequestBus::Events::AfterAtomicCallback);
 #endif
 }
 
 - (void)applicationWillEnterForeground:(UIApplication*)application
 {
-#if defined(CARBONATED)
+#if defined(CARBONATED)  && defined(CARBONATED_OS_CALLBACK_ASSERT)
     AZ::NativeUI::NativeUIRequestBus::Broadcast(&AZ::NativeUI::NativeUIRequestBus::Events::BeforeAtomicCallback);
 #endif
     AzFramework::IosLifecycleEvents::Bus::Broadcast(
         &AzFramework::IosLifecycleEvents::Bus::Events::OnWillEnterForeground);
-#if defined(CARBONATED)
+#if defined(CARBONATED)  && defined(CARBONATED_OS_CALLBACK_ASSERT)
     AZ::NativeUI::NativeUIRequestBus::Broadcast(&AZ::NativeUI::NativeUIRequestBus::Events::AfterAtomicCallback);
 #endif
 }
 
 - (void)applicationDidBecomeActive:(UIApplication*)application
 {
-#if defined(CARBONATED)
+#if defined(CARBONATED)  && defined(CARBONATED_OS_CALLBACK_ASSERT)
     AZ::NativeUI::NativeUIRequestBus::Broadcast(&AZ::NativeUI::NativeUIRequestBus::Events::BeforeAtomicCallback);
 #endif
     AzFramework::IosLifecycleEvents::Bus::Broadcast(
         &AzFramework::IosLifecycleEvents::Bus::Events::OnDidBecomeActive);
-#if defined(CARBONATED)
+#if defined(CARBONATED)  && defined(CARBONATED_OS_CALLBACK_ASSERT)
     AZ::NativeUI::NativeUIRequestBus::Broadcast(&AZ::NativeUI::NativeUIRequestBus::Events::AfterAtomicCallback);
 #endif
 }

--- a/Code/LauncherUnified/Platform/iOS/O3DEApplicationDelegate_iOS.mm
+++ b/Code/LauncherUnified/Platform/iOS/O3DEApplicationDelegate_iOS.mm
@@ -17,6 +17,10 @@
 
 #include <AzCore/Utils/SystemUtilsApple_Platform.h>
 
+#if defined(CARBONATED)
+#include <AzCore/NativeUI/NativeUIRequests.h>
+#endif
+
 #import <UIKit/UIKit.h>
 
 
@@ -94,26 +98,50 @@ namespace
 
 - (void)applicationWillResignActive:(UIApplication*)application
 {
+#if defined(CARBONATED)
+    AZ::NativeUI::NativeUIRequestBus::Broadcast(&AZ::NativeUI::NativeUIRequestBus::Events::BeforeAtomicCallback);
+#endif
     AzFramework::IosLifecycleEvents::Bus::Broadcast(
         &AzFramework::IosLifecycleEvents::Bus::Events::OnWillResignActive);
+#if defined(CARBONATED)
+    AZ::NativeUI::NativeUIRequestBus::Broadcast(&AZ::NativeUI::NativeUIRequestBus::Events::AfterAtomicCallback);
+#endif
 }
 
 - (void)applicationDidEnterBackground:(UIApplication*)application
 {
+#if defined(CARBONATED)
+    AZ::NativeUI::NativeUIRequestBus::Broadcast(&AZ::NativeUI::NativeUIRequestBus::Events::BeforeAtomicCallback);
+#endif
     AzFramework::IosLifecycleEvents::Bus::Broadcast(
         &AzFramework::IosLifecycleEvents::Bus::Events::OnDidEnterBackground);
+#if defined(CARBONATED)
+    AZ::NativeUI::NativeUIRequestBus::Broadcast(&AZ::NativeUI::NativeUIRequestBus::Events::AfterAtomicCallback);
+#endif
 }
 
 - (void)applicationWillEnterForeground:(UIApplication*)application
 {
+#if defined(CARBONATED)
+    AZ::NativeUI::NativeUIRequestBus::Broadcast(&AZ::NativeUI::NativeUIRequestBus::Events::BeforeAtomicCallback);
+#endif
     AzFramework::IosLifecycleEvents::Bus::Broadcast(
         &AzFramework::IosLifecycleEvents::Bus::Events::OnWillEnterForeground);
+#if defined(CARBONATED)
+    AZ::NativeUI::NativeUIRequestBus::Broadcast(&AZ::NativeUI::NativeUIRequestBus::Events::AfterAtomicCallback);
+#endif
 }
 
 - (void)applicationDidBecomeActive:(UIApplication*)application
 {
+#if defined(CARBONATED)
+    AZ::NativeUI::NativeUIRequestBus::Broadcast(&AZ::NativeUI::NativeUIRequestBus::Events::BeforeAtomicCallback);
+#endif
     AzFramework::IosLifecycleEvents::Bus::Broadcast(
         &AzFramework::IosLifecycleEvents::Bus::Events::OnDidBecomeActive);
+#if defined(CARBONATED)
+    AZ::NativeUI::NativeUIRequestBus::Broadcast(&AZ::NativeUI::NativeUIRequestBus::Events::AfterAtomicCallback);
+#endif
 }
 
 - (void)applicationWillTerminate:(UIApplication *)application

--- a/Code/LauncherUnified/Platform/iOS/O3DEApplicationDelegate_iOS.mm
+++ b/Code/LauncherUnified/Platform/iOS/O3DEApplicationDelegate_iOS.mm
@@ -17,7 +17,7 @@
 
 #include <AzCore/Utils/SystemUtilsApple_Platform.h>
 
-#if defined(CARBONATED)
+#if defined(CARBONATED)  && defined(CARBONATED_OS_CALLBACK_ASSERT)
 #include <AzCore/NativeUI/NativeUIRequests.h>
 #endif
 

--- a/Code/LauncherUnified/Platform/iOS/O3DEApplicationDelegate_iOS.mm
+++ b/Code/LauncherUnified/Platform/iOS/O3DEApplicationDelegate_iOS.mm
@@ -98,48 +98,48 @@ namespace
 
 - (void)applicationWillResignActive:(UIApplication*)application
 {
-#if defined(CARBONATED)  && defined(CARBONATED_OS_CALLBACK_ASSERT)
+#if defined(CARBONATED) && defined(CARBONATED_OS_CALLBACK_ASSERT)
     AZ::NativeUI::NativeUIRequestBus::Broadcast(&AZ::NativeUI::NativeUIRequestBus::Events::BeforeAtomicCallback);
 #endif
     AzFramework::IosLifecycleEvents::Bus::Broadcast(
         &AzFramework::IosLifecycleEvents::Bus::Events::OnWillResignActive);
-#if defined(CARBONATED)  && defined(CARBONATED_OS_CALLBACK_ASSERT)
+#if defined(CARBONATED) && defined(CARBONATED_OS_CALLBACK_ASSERT)
     AZ::NativeUI::NativeUIRequestBus::Broadcast(&AZ::NativeUI::NativeUIRequestBus::Events::AfterAtomicCallback);
 #endif
 }
 
 - (void)applicationDidEnterBackground:(UIApplication*)application
 {
-#if defined(CARBONATED)  && defined(CARBONATED_OS_CALLBACK_ASSERT)
+#if defined(CARBONATED) && defined(CARBONATED_OS_CALLBACK_ASSERT)
     AZ::NativeUI::NativeUIRequestBus::Broadcast(&AZ::NativeUI::NativeUIRequestBus::Events::BeforeAtomicCallback);
 #endif
     AzFramework::IosLifecycleEvents::Bus::Broadcast(
         &AzFramework::IosLifecycleEvents::Bus::Events::OnDidEnterBackground);
-#if defined(CARBONATED)  && defined(CARBONATED_OS_CALLBACK_ASSERT)
+#if defined(CARBONATED) && defined(CARBONATED_OS_CALLBACK_ASSERT)
     AZ::NativeUI::NativeUIRequestBus::Broadcast(&AZ::NativeUI::NativeUIRequestBus::Events::AfterAtomicCallback);
 #endif
 }
 
 - (void)applicationWillEnterForeground:(UIApplication*)application
 {
-#if defined(CARBONATED)  && defined(CARBONATED_OS_CALLBACK_ASSERT)
+#if defined(CARBONATED) && defined(CARBONATED_OS_CALLBACK_ASSERT)
     AZ::NativeUI::NativeUIRequestBus::Broadcast(&AZ::NativeUI::NativeUIRequestBus::Events::BeforeAtomicCallback);
 #endif
     AzFramework::IosLifecycleEvents::Bus::Broadcast(
         &AzFramework::IosLifecycleEvents::Bus::Events::OnWillEnterForeground);
-#if defined(CARBONATED)  && defined(CARBONATED_OS_CALLBACK_ASSERT)
+#if defined(CARBONATED) && defined(CARBONATED_OS_CALLBACK_ASSERT)
     AZ::NativeUI::NativeUIRequestBus::Broadcast(&AZ::NativeUI::NativeUIRequestBus::Events::AfterAtomicCallback);
 #endif
 }
 
 - (void)applicationDidBecomeActive:(UIApplication*)application
 {
-#if defined(CARBONATED)  && defined(CARBONATED_OS_CALLBACK_ASSERT)
+#if defined(CARBONATED) && defined(CARBONATED_OS_CALLBACK_ASSERT)
     AZ::NativeUI::NativeUIRequestBus::Broadcast(&AZ::NativeUI::NativeUIRequestBus::Events::BeforeAtomicCallback);
 #endif
     AzFramework::IosLifecycleEvents::Bus::Broadcast(
         &AzFramework::IosLifecycleEvents::Bus::Events::OnDidBecomeActive);
-#if defined(CARBONATED)  && defined(CARBONATED_OS_CALLBACK_ASSERT)
+#if defined(CARBONATED) && defined(CARBONATED_OS_CALLBACK_ASSERT)
     AZ::NativeUI::NativeUIRequestBus::Broadcast(&AZ::NativeUI::NativeUIRequestBus::Events::AfterAtomicCallback);
 #endif
 }


### PR DESCRIPTION
## What does this PR do?

Fix ANR in case of an assertion in app background/foreground callback. Mark the callbacks, do abort instead of app freeze. There is no other option because we cannot block such a callback, but we cannot return control back either.

## How was this PR tested?

Local iOS build.
An assert before background interrupt shows the dialog, an assert after background interrupt shows the dialog, an assert while going foreground aborts the app leaving a post-mortem file.

