### PR TITLE
Drop unwanted mobile shaders (mad-17666)

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
@@ -549,6 +549,17 @@ namespace AZ
 
                 for (const MaterialPropertyOutputId& connection : propertyDescriptor->GetOutputConnections())
                 {
+#if defined(CARBONATED) && defined(CARBONATED_MOBILE_PIPELINE_ON_MOBILE)
+#if defined(AZ_PLATFORM_IOS) || defined(AZ_PLATFORM_ANDROID)
+                    {
+                        const char* pipelineName = connection.m_materialPipelineName.GetCStr();
+                        if (pipelineName[0] != 0 && strcmp(pipelineName, "MobilePipeline") != 0)
+                        {
+                            continue;
+                        }
+                    }
+#endif
+#endif
                     [[maybe_unused]] bool applied =
                         TryApplyPropertyConnectionToShaderInput(value, connection, propertyDescriptor) ||
                         TryApplyPropertyConnectionToShaderOption(value, connection) ||

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
@@ -504,7 +504,17 @@ namespace AZ
                             AZ_Error("MeshDrawPacket", false, "Material has more than the limit of %d active shader items.", RHI::DrawPacketBuilder::DrawItemCountMax);
                             return false;
                         }
-
+#if defined(CARBONATED) && defined(CARBONATED_MOBILE_PIPELINE_ON_MOBILE)
+#if defined(AZ_PLATFORM_IOS) || defined(AZ_PLATFORM_ANDROID)
+                        {
+                            const char* pipelineName = materialPipelineName.GetCStr();
+                            if (pipelineName[0] != 0 && strcmp(pipelineName, "MobilePipeline") != 0)  // allow empty name and MobilePipeline
+                            {
+                                return true;
+                            }
+                        }
+#endif
+#endif
                         appendShader(shaderItem, materialPipelineName);
                     }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
@@ -504,6 +504,7 @@ namespace AZ
                             AZ_Error("MeshDrawPacket", false, "Material has more than the limit of %d active shader items.", RHI::DrawPacketBuilder::DrawItemCountMax);
                             return false;
                         }
+                        
                         appendShader(shaderItem, materialPipelineName);
                     }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
@@ -504,17 +504,6 @@ namespace AZ
                             AZ_Error("MeshDrawPacket", false, "Material has more than the limit of %d active shader items.", RHI::DrawPacketBuilder::DrawItemCountMax);
                             return false;
                         }
-#if defined(CARBONATED) && defined(CARBONATED_MOBILE_PIPELINE_ON_MOBILE)
-#if defined(AZ_PLATFORM_IOS) || defined(AZ_PLATFORM_ANDROID)
-                        {
-                            const char* pipelineName = materialPipelineName.GetCStr();
-                            if (pipelineName[0] != 0 && strcmp(pipelineName, "MobilePipeline") != 0)  // allow empty name and MobilePipeline
-                            {
-                                return true;
-                            }
-                        }
-#endif
-#endif
                         appendShader(shaderItem, materialPipelineName);
                     }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
@@ -504,7 +504,7 @@ namespace AZ
                             AZ_Error("MeshDrawPacket", false, "Material has more than the limit of %d active shader items.", RHI::DrawPacketBuilder::DrawItemCountMax);
                             return false;
                         }
-                        
+
                         appendShader(shaderItem, materialPipelineName);
                     }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialTypeAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialTypeAsset.cpp
@@ -86,6 +86,23 @@ namespace AZ
             {
                 return false;
             }
+#if defined(CARBONATED) && defined(CARBONATED_MOBILE_PIPELINE_ON_MOBILE)
+#if defined(AZ_PLATFORM_IOS) || defined(AZ_PLATFORM_ANDROID)
+            //  erase non-mobile pipeline info from the pipeline payload map
+            for (auto it = m_materialPipelinePayloads.begin(); it != m_materialPipelinePayloads.end(); )
+            {
+                const char* pipelineName = it->first.GetCStr();
+                if (pipelineName[0] != 0 && strcmp(pipelineName, "MobilePipeline") != 0)
+                {
+                    it = m_materialPipelinePayloads.erase(it);
+                }
+                else
+                {
+                    it++;
+                }
+            }
+#endif
+#endif
             for (auto& materialPipelinePair : m_materialPipelinePayloads)
             {
                 if (!materialPipelinePair.second.m_shaderCollection.InitializeShaderOptionGroups())


### PR DESCRIPTION
## What does this PR do?

Eliminate non-mobile pipelines if running on a mobile platform. This reduces memory footprint, loading speed increase is marginal.

## How was this PR tested?

Local build test. Jenkins build is in progress.
Update: Jenkins iOS build is fine, I played the first FTUE mission with no issues.
