### PR TITLE
Removing unnecessary trim change

### DIFF
--- a/Code/Legacy/CrySystem/XConsole.cpp
+++ b/Code/Legacy/CrySystem/XConsole.cpp
@@ -1557,11 +1557,7 @@ void CXConsole::ExecuteStringInternal(const char* command, const bool bFromConso
                 if (nPos != AZStd::string::npos)
                 {
                     sTemp = sTemp.substr(nPos + 1);     // remove the command from sTemp
-#ifdef CARBONATED
-                    AZ::StringFunc::Strip(sTemp, " \t\r\n\"\'");    // Gruber patch. In LY it was "sTemp.Trim(" \t\r\n\"\'");" i.e. the trim from both sides not only at the end
-#else
                     AZ::StringFunc::StripEnds(sTemp, " \t\r\n\"\'");
-#endif
                     if (sTemp == "?")
                     {
                         ICVar* v = itrVar->second;


### PR DESCRIPTION
This xconsole (which afaik is only the console for the editor itself) change fixes a bad strip that completely condenses input.

Ex:

my_cvar_vector 0.2 0.3 0.4
should set my_cvar_vector to (0.2, 0.3, 0.4)
but with this gruber patch the string to vector function gets a single string value (0.20.30.4), which is impossible to parse.

I cannot find a single case where this patch is necessary, but I might be missing something.