### PR TITLE
Add UI atlas with alpha preset (mad-17767)

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/UserInterfaceWithAlpha_Compressed.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/UserInterfaceWithAlpha_Compressed.preset
@@ -1,0 +1,49 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "MultiplatformPresetSettings",
+    "ClassData": {
+        "DefaultPreset": {
+            "UUID": "{2828FBFE-BDF9-45A7-9370-F93822719CCF}",
+            "Name": "UserInterface_Compressed",
+            "SuppressEngineReduce": true,
+            "PixelFormat": "BC3",
+            "SourceColor": "sRGB",
+            "DestColor": "sRGB"
+        },
+        "PlatformsPresets": {
+            "android": {
+                "UUID": "{2828FBFE-BDF9-45A7-9370-F93822719CCF}",
+                "Name": "UserInterface_Compressed",
+                "SuppressEngineReduce": true,
+                "PixelFormat": "ASTC_6x6",
+                "SourceColor": "sRGB",
+                "DestColor": "sRGB"
+            },
+            "ios": {
+                "UUID": "{2828FBFE-BDF9-45A7-9370-F93822719CCF}",
+                "Name": "UserInterface_Compressed",
+                "SuppressEngineReduce": true,
+                "PixelFormat": "ASTC_6x6",
+                "SourceColor": "sRGB",
+                "DestColor": "sRGB"
+            },
+            "mac": {
+                "UUID": "{2828FBFE-BDF9-45A7-9370-F93822719CCF}",
+                "Name": "UserInterface_Compressed",
+                "SuppressEngineReduce": true,
+                "PixelFormat": "BC3",
+                "SourceColor": "sRGB",
+                "DestColor": "sRGB"
+            },
+            "provo": {
+                "UUID": "{2828FBFE-BDF9-45A7-9370-F93822719CCF}",
+                "Name": "UserInterface_Compressed",
+                "SuppressEngineReduce": true,
+                "PixelFormat": "BC3",
+                "SourceColor": "sRGB",
+                "DestColor": "sRGB"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Add UserInterfaceWithAlpha_Compressed texture preset that uses BC3 compression instead of BC1 compression comparing to UserInterface_Compressed preset. This enables 8-bit alpha instead of 1-bit alpha for BC1.

## How was this PR tested?

Local test on PC. Mobile devices are not affected, the same ASTC compression level.
