### PR TITLE
Add astc4x4 UI texture atlas preset (noticket)

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/UserInterfaceWithAlpha_HQ_Compressed.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/UserInterfaceWithAlpha_HQ_Compressed.preset
@@ -1,0 +1,49 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "MultiplatformPresetSettings",
+    "ClassData": {
+        "DefaultPreset": {
+            "UUID": "{2828FBFE-BDF9-45A7-9370-F93822719CCF}",
+            "Name": "UserInterface_Compressed",
+            "SuppressEngineReduce": true,
+            "PixelFormat": "BC3",
+            "SourceColor": "sRGB",
+            "DestColor": "sRGB"
+        },
+        "PlatformsPresets": {
+            "android": {
+                "UUID": "{2828FBFE-BDF9-45A7-9370-F93822719CCF}",
+                "Name": "UserInterface_Compressed",
+                "SuppressEngineReduce": true,
+                "PixelFormat": "ASTC_4x4",
+                "SourceColor": "sRGB",
+                "DestColor": "sRGB"
+            },
+            "ios": {
+                "UUID": "{2828FBFE-BDF9-45A7-9370-F93822719CCF}",
+                "Name": "UserInterface_Compressed",
+                "SuppressEngineReduce": true,
+                "PixelFormat": "ASTC_4x4",
+                "SourceColor": "sRGB",
+                "DestColor": "sRGB"
+            },
+            "mac": {
+                "UUID": "{2828FBFE-BDF9-45A7-9370-F93822719CCF}",
+                "Name": "UserInterface_Compressed",
+                "SuppressEngineReduce": true,
+                "PixelFormat": "BC3",
+                "SourceColor": "sRGB",
+                "DestColor": "sRGB"
+            },
+            "provo": {
+                "UUID": "{2828FBFE-BDF9-45A7-9370-F93822719CCF}",
+                "Name": "UserInterface_Compressed",
+                "SuppressEngineReduce": true,
+                "PixelFormat": "BC3",
+                "SourceColor": "sRGB",
+                "DestColor": "sRGB"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Add a preset with ASTC 4x4 compression level to improve UI texture atlas quality.

## How was this PR tested?

iOS Jenkins build test.
