### PR TITLE
Read-Write lock for motion entries container (MAD-17844)

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/CommandSystem/Source/MotionSetCommands.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/CommandSystem/Source/MotionSetCommands.cpp
@@ -975,7 +975,9 @@ namespace CommandSystem
     void ClearMotionSetMotions(EMotionFX::MotionSet* motionSet, MCore::CommandGroup* commandGroup)
     {
         const EMotionFX::Motion* selectedMotion = GetCommandManager()->GetCurrentSelection().GetSingleMotion();
-
+#if defined(CARBONATED) && defined(CARBONATED_EMOTIONFX_CONCURRENCY_RW)
+        AZStd::shared_lock<AZStd::shared_mutex> readLock(motionSet->GetMotionEntriesMutex());
+#endif
         const EMotionFX::MotionSet::MotionEntries& motionEntries = motionSet->GetMotionEntries();
         if (motionEntries.empty())
         {

--- a/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphMotionCondition.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphMotionCondition.cpp
@@ -103,7 +103,11 @@ namespace EMotionFX
         // Early condition function check pass for the 'Is motion assigned?'. We can do this before retrieving the unique data.
         if (m_testFunction == FUNCTION_ISMOTIONASSIGNED || m_testFunction == FUNCTION_ISMOTIONNOTASSIGNED)
         {
+#if defined(CARBONATED) && defined(CARBONATED_EMOTIONFX_CONCURRENCY_RW)
+            EMotionFX::MotionSet* motionSet = animGraphInstance->GetMotionSet();
+#else
             const EMotionFX::MotionSet* motionSet = animGraphInstance->GetMotionSet();
+#endif
             if (!motionSet)
             {
                 return false;

--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionManager.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionManager.cpp
@@ -370,8 +370,14 @@ namespace EMotionFX
         }
 
         // Reset all motion entries in the motion sets of the current motion.
+#if defined(CARBONATED) && defined(CARBONATED_EMOTIONFX_CONCURRENCY_RW)
+        for (MotionSet* motionSet : m_motionSets)
+        {
+            AZStd::shared_lock<AZStd::shared_mutex> readLock(motionSet->GetMotionEntriesMutex());
+#else
         for (const MotionSet* motionSet : m_motionSets)
         {
+#endif
             const EMotionFX::MotionSet::MotionEntries& motionEntries = motionSet->GetMotionEntries();
             for (const auto& item : motionEntries)
             {

--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionSet.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionSet.cpp
@@ -895,13 +895,13 @@ namespace EMotionFX
 
     void MotionSet::Log()
     {
+#if defined(CARBONATED) && defined(CARBONATED_EMOTIONFX_CONCURRENCY_RW)
+        AZStd::shared_lock<AZStd::shared_mutex> readLock(m_motionEntriesMutex);  // here because GetNumMotionEntries() reads m_motionEntries
+#endif
         AZ_Printf("EMotionFX", " - MotionSet");
         AZ_Printf("EMotionFX", "     + Name = '%s'", m_name.c_str());
         AZ_Printf("EMotionFX", "     - Entries (%d)", GetNumMotionEntries());
 
-#if defined(CARBONATED) && defined(CARBONATED_EMOTIONFX_CONCURRENCY_RW)
-        AZStd::shared_lock<AZStd::shared_mutex> readLock(m_motionEntriesMutex);
-#endif
         int nr = 0;
         for (const auto& item : m_motionEntries)
         {

--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionSet.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionSet.cpp
@@ -262,8 +262,11 @@ namespace EMotionFX
     // Remove all motion entries from the set.
     void MotionSet::Clear()
     {
+#if defined(CARBONATED) && defined(CARBONATED_EMOTIONFX_CONCURRENCY_RW)
+        AZStd::unique_lock<AZStd::shared_mutex> writeLock(m_motionEntriesMutex);
+#else
         MCore::LockGuardRecursive lock(m_mutex);
-
+#endif
         for (const auto& item : m_motionEntries)
         {
             delete item.second;
@@ -275,7 +278,11 @@ namespace EMotionFX
 
     void MotionSet::AddMotionEntry(MotionEntry* motionEntry)
     {
+#if defined(CARBONATED) && defined(CARBONATED_EMOTIONFX_CONCURRENCY_RW)
+        AZStd::unique_lock<AZStd::shared_mutex> writeLock(m_motionEntriesMutex);
+#else
         MCore::LockGuardRecursive lock(m_mutex);
+#endif
         m_motionEntries.insert(AZStd::make_pair(motionEntry->GetId(), motionEntry));
     }
 
@@ -289,10 +296,15 @@ namespace EMotionFX
 
 
     // Build a list of unique string id values from all motion set entries.
+#if defined(CARBONATED) && defined(CARBONATED_EMOTIONFX_CONCURRENCY_RW)
+    void MotionSet::BuildIdStringList(AZStd::vector<AZStd::string>& idStrings)
+    {
+        AZStd::shared_lock<AZStd::shared_mutex> readLock(m_motionEntriesMutex);
+#else
     void MotionSet::BuildIdStringList(AZStd::vector<AZStd::string>& idStrings) const
     {
         MCore::LockGuardRecursive lock(m_mutex);
-
+#endif
         // Iterate through all entries and add their unique id strings to the given list.
         const size_t numMotionEntries = m_motionEntries.size();
         idStrings.reserve(numMotionEntries);
@@ -317,6 +329,27 @@ namespace EMotionFX
         return m_motionEntries;
     }
 
+#if defined(CARBONATED) && defined(CARBONATED_EMOTIONFX_CONCURRENCY_RW)
+    void MotionSet::RecursiveGetMotions(AZStd::unordered_set<Motion*>& childMotions)
+    {
+        if (GetIsOwnedByRuntime())
+        {
+            return;
+        }
+        {
+            AZStd::shared_lock<AZStd::shared_mutex> readLock(m_motionEntriesMutex);
+            for (const auto& item : m_motionEntries)
+            {
+                MotionEntry* motionEntry = item.second;
+                childMotions.insert(motionEntry->GetMotion());
+            }
+        }
+        for (MotionSet* childMotionSet : m_childSets)
+        {
+            childMotionSet->RecursiveGetMotions(childMotions);
+        }
+    }
+#else
     void MotionSet::RecursiveGetMotions(AZStd::unordered_set<Motion*>& childMotions) const
     {
         if (GetIsOwnedByRuntime())
@@ -333,20 +366,29 @@ namespace EMotionFX
             childMotionSet->RecursiveGetMotions(childMotions);
         }
     }
-
+#endif
+        
     void MotionSet::ReserveMotionEntries(size_t numMotionEntries)
     {
+#if defined(CARBONATED) && defined(CARBONATED_EMOTIONFX_CONCURRENCY_RW)
+        AZStd::unique_lock<AZStd::shared_mutex> writeLock(m_motionEntriesMutex);
+#else
         MCore::LockGuardRecursive lock(m_mutex);
-
+#endif
         m_motionEntries.reserve(numMotionEntries);
     }
 
 
     // Find the motion entry for a given motion.
+#if defined(CARBONATED) && defined(CARBONATED_EMOTIONFX_CONCURRENCY_RW)
+    MotionSet::MotionEntry* MotionSet::FindMotionEntry(const Motion* motion)
+    {
+        AZStd::shared_lock<AZStd::shared_mutex> lockRead(m_motionEntriesMutex);
+#else
     MotionSet::MotionEntry* MotionSet::FindMotionEntry(const Motion* motion) const
     {
         MCore::LockGuardRecursive lock(m_mutex);
-
+#endif
         for (const auto& item : m_motionEntries)
         {
             MotionEntry* motionEntry = item.second;
@@ -363,10 +405,21 @@ namespace EMotionFX
 
     void MotionSet::RemoveMotionEntry(MotionEntry* motionEntry)
     {
+#if defined(CARBONATED) && defined(CARBONATED_EMOTIONFX_CONCURRENCY_RW)
+        {
+            AZStd::unique_lock<AZStd::shared_mutex> writeLock(m_motionEntriesMutex);
+            m_motionEntries.erase(motionEntry->GetId());
+        }
+        {
+            MCore::LockGuardRecursive lock(m_mutex);
+            delete motionEntry;
+        }
+#else
         MCore::LockGuardRecursive lock(m_mutex);
 
         m_motionEntries.erase(motionEntry->GetId());
         delete motionEntry;
+#endif
     }
 
 
@@ -404,10 +457,15 @@ namespace EMotionFX
 
 
     // Find the motion entry by a given string.
+#if defined(CARBONATED) && defined(CARBONATED_EMOTIONFX_CONCURRENCY_RW)
+    MotionSet::MotionEntry* MotionSet::FindMotionEntryById(const AZStd::string& motionId)
+    {
+        AZStd::shared_lock<AZStd::shared_mutex> lockRead(m_motionEntriesMutex);
+#else
     MotionSet::MotionEntry* MotionSet::FindMotionEntryById(const AZStd::string& motionId) const
     {
         MCore::LockGuardRecursive lock(m_mutex);
-
+#endif
         const auto iterator = m_motionEntries.find(motionId);
         if (iterator == m_motionEntries.end())
         {
@@ -417,12 +475,16 @@ namespace EMotionFX
         return iterator->second;
     }
 
-
+        
     // Find the motion entry by string ID.
+#if defined(CARBONATED) && defined(CARBONATED_EMOTIONFX_CONCURRENCY_RW)
+    MotionSet::MotionEntry* MotionSet::RecursiveFindMotionEntryById(const AZStd::string& motionId)
+    {
+#else
     MotionSet::MotionEntry* MotionSet::RecursiveFindMotionEntryById(const AZStd::string& motionId) const
     {
         MCore::LockGuardRecursive lock(m_mutex);
-
+#endif
         // Is there a motion entry with the given id in the current motion set?
         MotionEntry* entry = FindMotionEntryById(motionId);
         if (entry)
@@ -443,7 +505,12 @@ namespace EMotionFX
 
 
     // Find motion by string ID.
+#if defined(CARBONATED) && defined(CARBONATED_EMOTIONFX_CONCURRENCY_RW)
+    Motion* MotionSet::RecursiveFindMotionById(const AZStd::string& motionId, bool loadOnDemand)
+    // keep the lock below because of LoadMotion()
+#else
     Motion* MotionSet::RecursiveFindMotionById(const AZStd::string& motionId, bool loadOnDemand) const
+#endif
     {
         MCore::LockGuardRecursive lock(m_mutex);
 
@@ -512,6 +579,9 @@ namespace EMotionFX
 
     void MotionSet::SetMotionEntryId(MotionEntry* motionEntry, const AZStd::string& newMotionId)
     {
+#if defined(CARBONATED)&& defined(CARBONATED_EMOTIONFX_CONCURRENCY_RW)
+        AZStd::unique_lock<AZStd::shared_mutex> writeLock(m_motionEntriesMutex);
+#endif
         const AZStd::string oldStringId = motionEntry->GetId();
 
         motionEntry->SetId(newMotionId);
@@ -576,6 +646,10 @@ namespace EMotionFX
     // Pre-load all motions.
     void MotionSet::Preload()
     {
+#if defined(CARBONATED)&& defined(CARBONATED_EMOTIONFX_CONCURRENCY_RW)
+        AZStd::shared_lock<AZStd::shared_mutex> lockRead(m_motionEntriesMutex);
+        // keep the lock below because of LoadMotion()
+#endif
         MCore::LockGuardRecursive lock(m_mutex);
 
         // Pre-load motions for all motion entries.
@@ -602,6 +676,16 @@ namespace EMotionFX
     // Reload all motions.
     void MotionSet::Reload()
     {
+#if defined(CARBONATED) && defined(CARBONATED_EMOTIONFX_CONCURRENCY_RW)
+        {
+            AZStd::unique_lock<AZStd::shared_mutex> writeLock(m_motionEntriesMutex);
+            for (const auto& item : m_motionEntries)
+            {
+                MotionEntry* motionEntry = item.second;
+                motionEntry->Reset();
+            }
+        }
+#else
         MCore::LockGuardRecursive lock(m_mutex);
 
         for (const auto& item : m_motionEntries)
@@ -609,7 +693,7 @@ namespace EMotionFX
             MotionEntry* motionEntry = item.second;
             motionEntry->Reset();
         }
-
+#endif
         // Pre-load the motions again.
         Preload();
     }
@@ -815,6 +899,9 @@ namespace EMotionFX
         AZ_Printf("EMotionFX", "     + Name = '%s'", m_name.c_str());
         AZ_Printf("EMotionFX", "     - Entries (%d)", GetNumMotionEntries());
 
+#if defined(CARBONATED) && defined(CARBONATED_EMOTIONFX_CONCURRENCY_RW)
+        AZStd::shared_lock<AZStd::shared_mutex> readLock(m_motionEntriesMutex);
+#endif
         int nr = 0;
         for (const auto& item : m_motionEntries)
         {
@@ -825,8 +912,14 @@ namespace EMotionFX
     }
 
 
+#if defined(CARBONATED) && defined(CARBONATED_EMOTIONFX_CONCURRENCY_RW)
+    size_t MotionSet::GetNumMorphMotions()
+    {
+        AZStd::shared_lock<AZStd::shared_mutex> readLock(m_motionEntriesMutex);
+#else
     size_t MotionSet::GetNumMorphMotions() const
     {
+#endif
         size_t numMorphMotions = 0;
         const MotionEntries& motionEntries = GetMotionEntries();
         for (const auto& item : motionEntries)

--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionSet.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionSet.h
@@ -218,14 +218,22 @@ namespace EMotionFX
          */
         typedef AZStd::unordered_map<AZStd::string, MotionSet::MotionEntry*> MotionEntries;
         const MotionEntries& GetMotionEntries() const;
+#if defined(CARBONATED) && defined(CARBONATED_EMOTIONFX_CONCURRENCY_RW)
+        // motion entries can be edited while the motion set is being loaded, so use lock/unlock if you call the above function
+        MCORE_INLINE AZStd::shared_mutex& GetMotionEntriesMutex() { return m_motionEntriesMutex; }
+#endif
 
         /**
          * Gets child motions recursively.
          * Every Motion* returned in childMotions will have directly or indirectly this MotionSet as a parent
          * @param[out] childMotions set where the child motions are returned.
          */
+#if defined(CARBONATED) && defined(CARBONATED_EMOTIONFX_CONCURRENCY_RW)
+        void RecursiveGetMotions(AZStd::unordered_set<Motion*>& childMotions);
+#else
         void RecursiveGetMotions(AZStd::unordered_set<Motion*>& childMotions) const;
-
+#endif
+        
         /**
          * Preallocate the array of motion entries.
          * This will NOT grow the motion entries array as reported by GetNumMotionEntries(). However, it internally pre-allocates memory to make the AddMotionEntry() calls faster.
@@ -249,12 +257,21 @@ namespace EMotionFX
          * @param[in] motion A pointer to the motion.
          * @result A pointer to the motion entry for the given motion. nullptr in case no motion entry has been found.
          */
+#if defined(CARBONATED) && defined(CARBONATED_EMOTIONFX_CONCURRENCY_RW)
+        MotionEntry* FindMotionEntry(const Motion* motion);
+#else
         MotionEntry* FindMotionEntry(const Motion* motion) const;
+#endif
 
-
+#if defined(CARBONATED) && defined(CARBONATED_EMOTIONFX_CONCURRENCY_RW)
+        MotionEntry* FindMotionEntryById(const AZStd::string& motionId);
+        MotionEntry* RecursiveFindMotionEntryById(const AZStd::string& motionId);
+        Motion* RecursiveFindMotionById(const AZStd::string& motionId, bool loadOnDemand = true);
+#else
         MotionEntry* FindMotionEntryById(const AZStd::string& motionId) const;
         MotionEntry* RecursiveFindMotionEntryById(const AZStd::string& motionId) const;
         Motion* RecursiveFindMotionById(const AZStd::string& motionId, bool loadOnDemand = true) const;
+#endif
         MotionSet* RecursiveFindMotionSetByName(const AZStd::string& motionSetName, bool isOwnedByRuntime = false) const;
 
         /**
@@ -325,8 +342,12 @@ namespace EMotionFX
          * Generate a list of motion identifications strings. This will walk over all motions and get their id strings.
          * @param[out] idStrings A list of motion identification strings from the motions inside the motion set. Make sure the array is empty before calling this function.
          */
+#if defined(CARBONATED) && defined(CARBONATED_EMOTIONFX_CONCURRENCY_RW)
+        void BuildIdStringList(AZStd::vector<AZStd::string>& idStrings);
+#else
         void BuildIdStringList(AZStd::vector<AZStd::string>& idStrings) const;
-
+#endif
+        
         /**
          * Recursively find the root motion set.
          * This will return a pointer to itself when this is a root motion set already.
@@ -390,8 +411,11 @@ namespace EMotionFX
         * Get the number of motion entries that contain morph data.
         * @result The number of motion entries that contain morph data.
         */
+#if defined(CARBONATED) && defined(CARBONATED_EMOTIONFX_CONCURRENCY_RW)
+        size_t GetNumMorphMotions();
+#else
         size_t GetNumMorphMotions() const;
-
+#endif
 
     private:
         void RecursiveRewireParentSets(MotionSet* motionSet);
@@ -408,6 +432,9 @@ namespace EMotionFX
         bool                                        m_dirtyFlag;            /**< The dirty flag which indicates whether the user has made changes to the motion set since the last file save operation. */
         bool                                        m_autoUnregister;       /**< Specifies whether we will automatically unregister this motion set from the motion manager or not, when deleting this object. */
 
+#if defined(CARBONATED) && defined(CARBONATED_EMOTIONFX_CONCURRENCY_RW)
+        AZStd::shared_mutex m_motionEntriesMutex;
+#endif
 #if defined(EMFX_DEVELOPMENT_BUILD)
         bool                                        m_isOwnedByRuntime; /**< Set if this motion set belongs to the engine runtime, as opposed to the tool suite. */
         bool                                        m_isOwnedByAsset;        /**< Set if the anim graph is used/owned by an asset. */

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionSetsWindow/MotionSetWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionSetsWindow/MotionSetWindow.cpp
@@ -2166,8 +2166,11 @@ namespace EMStudio
         {
             return nullptr;
         }
-
+#if defined(CARBONATED) && defined(CARBONATED_EMOTIONFX_CONCURRENCY_RW)
+        EMotionFX::MotionSet* motionSet = m_plugin->GetSelectedSet();
+#else
         const EMotionFX::MotionSet* motionSet = m_plugin->GetSelectedSet();
+#endif
         if (!motionSet)
         {
             return nullptr;

--- a/Gems/EMotionFX/Code/Source/Integration/Assets/MotionSetAsset.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Assets/MotionSetAsset.cpp
@@ -172,7 +172,10 @@ namespace EMotionFX
                 }
                 assetData->m_emfxMotionSet->SetFilename(assetFilename.c_str());
             }
-
+#if defined(CARBONATED) && defined(CARBONATED_EMOTIONFX_CONCURRENCY_RW)
+            {
+            AZStd::shared_lock<AZStd::shared_mutex> readLock(assetData->m_emfxMotionSet->GetMotionEntriesMutex());
+#endif
             // now load them in:
             const EMotionFX::MotionSet::MotionEntries& motionEntries = assetData->m_emfxMotionSet->GetMotionEntries();
             // Get the motions in the motion set.  Escalate them to the top of the build queue first so that they can be done in parallel.
@@ -234,7 +237,9 @@ namespace EMotionFX
                     AZ_Warning("EMotionFX", false, "Motion \"%s\" in motion set \"%s\" could not be found in the asset catalog.", motionFilename, assetFilename.c_str());
                 }
             }
-
+#if defined(CARBONATED) && defined(CARBONATED_EMOTIONFX_CONCURRENCY_RW)
+            }
+#endif
             // Set motion set's motion load callback, so if EMotion FX queries back for a motion,
             // we can pull the one managed through an AZ::Asset.
             assetData->m_emfxMotionSet->SetCallback(aznew CustomMotionSetCallback(asset));


### PR DESCRIPTION
## What does this PR do?

Use read-write lock for motion entries container because most of he time there is no protection at all.
I cannot use a simple lock because it cases to a deadlock, but RW-lock is fine, it allows shared read.

## How was this PR tested?

Local build test, about an hour of gameplay, about 20 mission. That does not prove it is gone, we need a full playtest. On the good side: there was no deadlock either. A deadlock is the major risk of this change.
