### PR TITLE
Prevent invis decals from rendering

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
@@ -659,6 +659,15 @@ namespace AZ
             {
                 uint32_t dataIndex = sortedDecals[i];
                 const auto& decalData = dataVector[dataIndex];
+
+#if defined(CARBONATED)
+                // In lieu of a visibility toggle, prevent sending decals to the GPU that are not visible
+                if (decalData.m_opacity <= 0.0f)
+                {
+                    continue;
+                }
+#endif
+
                 AZ::Obb obb = AZ::Obb::CreateFromPositionRotationAndHalfLengths(
                     AZ::Vector3::CreateFromFloat3(decalData.m_position.data()),
                     AZ::Quaternion::CreateFromFloat4(decalData.m_quaternion.data()),

--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
@@ -660,7 +660,7 @@ namespace AZ
                 uint32_t dataIndex = sortedDecals[i];
                 const auto& decalData = dataVector[dataIndex];
 
-#if defined(CARBONATED)
+#if defined(CARBONATED) && defined(CARBONATED_DECAL_VISTOGGLE)
                 // In lieu of a visibility toggle, prevent sending decals to the GPU that are not visible
                 if (decalData.m_opacity <= 0.0f)
                 {

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Decals/DecalBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Decals/DecalBus.h
@@ -37,7 +37,7 @@ namespace AZ
             //! Sets the decal opacity
             virtual void SetOpacity(float opacity) = 0;
 
-#if defined(CARBONATED)
+#if defined(CARBONATED) && defined(CARBONATED_DECAL_VISTOGGLE)
             //! Gets the decals visibility
             virtual bool GetVisibility() const = 0;
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Decals/DecalComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Decals/DecalComponentController.cpp
@@ -97,7 +97,7 @@ namespace AZ
         DecalComponentController::DecalComponentController(const DecalComponentConfig& config)
             : m_configuration(config)
 #if defined(CARBONATED) && defined(CARBONATED_DECAL_VISTOGGLE)
-            , mIsHidden(false)
+            , m_isHidden(false)
 #endif
         {
         }
@@ -294,7 +294,7 @@ namespace AZ
             if (m_featureProcessor)
             {
 #if defined(CARBONATED) && defined(CARBONATED_DECAL_VISTOGGLE)
-                m_featureProcessor->SetDecalOpacity(m_handle, mIsHidden ? 0.0f : m_configuration.m_opacity);
+                m_featureProcessor->SetDecalOpacity(m_handle, m_isHidden ? 0.0f : m_configuration.m_opacity);
 #else
                 m_featureProcessor->SetDecalOpacity(m_handle, m_configuration.m_opacity);
 #endif

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Decals/DecalComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Decals/DecalComponentController.cpp
@@ -59,7 +59,7 @@ namespace AZ
                     ->Event("GetSortKey", &DecalRequestBus::Events::GetSortKey)
                     ->Event("GetDecalColor", &DecalRequestBus::Events::GetDecalColor)
                     ->Event("SetDecalColor", &DecalRequestBus::Events::SetDecalColor)
-#if defined(CARBONATED)
+#if defined(CARBONATED) && defined(CARBONATED_DECAL_VISTOGGLE)
                     ->Event("GetVisibility", &DecalRequestBus::Events::GetVisibility)
                     ->Event("SetVisibility", &DecalRequestBus::Events::SetVisibility)
 #endif
@@ -96,7 +96,7 @@ namespace AZ
 
         DecalComponentController::DecalComponentController(const DecalComponentConfig& config)
             : m_configuration(config)
-#if defined(CARBONATED)
+#if defined(CARBONATED) && defined(CARBONATED_DECAL_VISTOGGLE)
             , mIsHidden(false)
 #endif
         {
@@ -223,7 +223,7 @@ namespace AZ
             OpacityChanged();
         }
 
-#if defined(CARBONATED)
+#if defined(CARBONATED) && defined(CARBONATED_DECAL_VISTOGGLE)
         bool DecalComponentController::GetVisibility() const
         {
             return !mIsHidden;
@@ -290,7 +290,7 @@ namespace AZ
             DecalNotificationBus::Event(m_entityId, &DecalNotifications::OnOpacityChanged, m_configuration.m_opacity);
             if (m_featureProcessor)
             {
-#if defined(CARBONATED)
+#if defined(CARBONATED) && defined(CARBONATED_DECAL_VISTOGGLE)
                 m_featureProcessor->SetDecalOpacity(m_handle, mIsHidden ? 0.0f : m_configuration.m_opacity);
 #else
                 m_featureProcessor->SetDecalOpacity(m_handle, m_configuration.m_opacity);

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Decals/DecalComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Decals/DecalComponentController.cpp
@@ -226,12 +226,15 @@ namespace AZ
 #if defined(CARBONATED) && defined(CARBONATED_DECAL_VISTOGGLE)
         bool DecalComponentController::GetVisibility() const
         {
-            return !mIsHidden;
+            return !m_isHidden;
         }
 
         void DecalComponentController::SetVisibility(bool show)
         {
-            mIsHidden = !show;
+            //Show is inverted
+            if (m_isHidden != show)
+                return; 
+            m_isHidden = !show;
             OpacityChanged();
         }
 #endif

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Decals/DecalComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Decals/DecalComponentController.h
@@ -63,7 +63,7 @@ namespace AZ
             void SetMaterialAssetId(Data::AssetId) override;
             Data::AssetId GetMaterialAssetId() const override;
 
-#if defined(CARBONATED)
+#if defined(CARBONATED) && defined(CARBONATED_DECAL_VISTOGGLE)
             bool mIsHidden = false;
             bool GetVisibility() const override;
             void SetVisibility(bool show) override;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Decals/DecalComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Decals/DecalComponentController.h
@@ -64,7 +64,7 @@ namespace AZ
             Data::AssetId GetMaterialAssetId() const override;
 
 #if defined(CARBONATED) && defined(CARBONATED_DECAL_VISTOGGLE)
-            bool mIsHidden = false;
+            bool m_isHidden;
             bool GetVisibility() const override;
             void SetVisibility(bool show) override;
 #endif


### PR DESCRIPTION
## What does this PR do?

We dont have the ability to toggle visibility on decals, awhile ago we added a toggle that just forces an opacity of 0. Unfortunately, some shaders still interact with it, like water.

## How was this PR tested?

Tested on pc, a client is being built