### PR TITLE
Drop offscreen primitives (mad-17847)

### DIFF
--- a/Gems/LyShine/Code/Source/RenderGraph.h
+++ b/Gems/LyShine/Code/Source/RenderGraph.h
@@ -322,6 +322,9 @@ namespace LyShine
         bool IsEmpty();
 
         void GetRenderTargetsAndDependencies(LyShine::AttachmentImagesAndDependencies& attachmentImagesAndDependencies);
+#if defined(CARBONATED) && defined(CARBONATED_DROP_LYSHINE_OFFSCREEN_PRIMITIVES)
+        void SetViewportSize(AZ::Vector2 viewportSize);
+#endif
 
 #ifndef _RELEASE
         // A debug-only function useful for debugging, not called but calls can be added during debugging
@@ -371,6 +374,10 @@ namespace LyShine
 
         AZStd::vector<RenderTargetRenderNode*>  m_renderTargetRenderNodes;
         int                         m_renderTargetNestLevel = 0;
+
+#if defined(CARBONATED) && defined(CARBONATED_DROP_LYSHINE_OFFSCREEN_PRIMITIVES)
+        AZ::Vector2                  m_viewportSize;
+#endif
 
 #ifndef _RELEASE
         // A debug-only variable used to track whether the rendergraph was rebuilt this frame

--- a/Gems/LyShine/Code/Source/RenderGraph.h
+++ b/Gems/LyShine/Code/Source/RenderGraph.h
@@ -376,7 +376,7 @@ namespace LyShine
         int                         m_renderTargetNestLevel = 0;
 
 #if defined(CARBONATED) && defined(CARBONATED_DROP_LYSHINE_OFFSCREEN_PRIMITIVES)
-        AZ::Vector2                  m_viewportSize;
+        AZ::Vector2                  m_viewportSize = AZ::Vector2(0.0f, 0.0f);
 #endif
 
 #ifndef _RELEASE

--- a/Gems/LyShine/Code/Source/UiCanvasComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiCanvasComponent.cpp
@@ -2095,7 +2095,13 @@ void UiCanvasComponent::RenderCanvas(bool isInGame, AZ::Vector2 viewportSize, Ui
             }
         }
 
+#if defined(CARBONATED) && defined(CARBONATED_DROP_LYSHINE_OFFSCREEN_PRIMITIVES)
+        m_renderGraph.SetViewportSize(viewportSize);
+#endif
         UiElementBus::Event(m_rootElement, &UiElementBus::Events::RenderElement, &m_renderGraph, isInGame);
+#if defined(CARBONATED) && defined(CARBONATED_DROP_LYSHINE_OFFSCREEN_PRIMITIVES)
+        m_renderGraph.SetViewportSize(AZ::Vector2(0.0f, 0.0f));
+#endif
 
         if (renderToTexture)
         {


### PR DESCRIPTION
## What does this PR do?

Store viewport size before rendering starts.
Drop out of the viewport primitives.
This helped with worldmap before I applied city visibility lua fix. So if we make a similar mess then this mod saves the day.

## How was this PR tested?

PC standalone build test. The code is platform agnostic, it should work everywhere.
