### PR TITLE
Use a specific define for tag memory tracing system, off by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,10 +23,15 @@ if(CARBONATED)
 endif(CARBONATED)
 
 # memory and performance tracking options
+OPTION(MEMORY_TAG_TRACING "Enable asset and mmeory tags" OFF)
 OPTION(START_MEMORY_TRACING "Start memory tracing from app start" OFF)
 OPTION(ADVANCED_ASSET_TRACING "Take more CPU time to find asset names for precise asset size tracing" OFF)
 OPTION(LOD_REMOVAL "Enable conditional LOD removal at runtime to save RAM" ON)
 OPTION(MIP_REMOVAL "Enable conditional mipmap level removal at runtime to save RAM" ON)
+
+if(MEMORY_TAG_TRACING)
+    add_compile_definitions(AZ_MEMORY_TAG_TRACING)
+endif(MEMORY_TAG_TRACING)
 
 if(START_MEMORY_TRACING)
     add_compile_definitions(AZ_START_MEMORY_TRACING)  # enables memory tracing at startup, sys_LogMemoryMap command can dump allocations at any moment

--- a/Code/Framework/AzCore/AzCore/Memory/MemoryMarker.cpp
+++ b/Code/Framework/AzCore/AzCore/Memory/MemoryMarker.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#if defined(AZ_ENABLE_TRACING) && !defined(_RELEASE) && defined(CARBONATED)  // without tracing definition engine's memory tracking is off
+#if defined(AZ_ENABLE_TRACING) && defined(AZ_MEMORY_TAG_TRACING) && !defined(_RELEASE) && defined(CARBONATED)
 
 #include <AzCore/Memory/AllocatorManager.h>
 #include <AzCore/Memory/MemoryMarker.h>
@@ -60,4 +60,4 @@ namespace AZ
 
 } // namespace AZ
 
-#endif  // AZ_ENABLE_TRACING  && !_RELEASE && CARBONATED
+#endif  // AZ_ENABLE_TRACING && AZ_MEMORY_TAG_TRACING && !_RELEASE CARBONATED

--- a/Code/Framework/AzCore/AzCore/Memory/MemoryMarker.h
+++ b/Code/Framework/AzCore/AzCore/Memory/MemoryMarker.h
@@ -7,7 +7,7 @@
  */
 #pragma once
 
-#if defined(AZ_ENABLE_TRACING) && !defined(_RELEASE) && defined(CARBONATED)
+#if defined(AZ_ENABLE_TRACING) && defined(AZ_MEMORY_TAG_TRACING) && !defined(_RELEASE) && defined(CARBONATED)
 
 namespace AZ
 {


### PR DESCRIPTION
## What does this PR do?

Turn memory tag tracing system off by default via specific define.

## How was this PR tested?

Tested on local PC standalone build. Multi-platform Jenkins build is being built.
I did not test it with the define ON yet, maybe the definition will be off for the game code because it is defined in the engine cmake file. However, the main goal for now is to disable the system for playtests.