### PR TITLE
Niko/noticket inverted click handling

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Script/ScriptComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Script/ScriptComponent.cpp
@@ -373,8 +373,10 @@ namespace AzFramework
         {
             LSV_BEGIN(lua, 1);
 
+            #if !defined(CARBONATED) //This log is so incredibly spammy if you add a property to a very common script
             AZ::ScriptContext::FromNativeContext(lua)->Error(AZ::ScriptContext::ErrorType::Warning, true,
-                "Property %s not found in entity table. Please push this property to your slice to avoid decrease in performance.", lua_tostring(lua, -1));
+                "Property %s not found in entity table. Please push this property to your slice to avoid decrease in performance.", lua_tostring(lua, -1)); 
+            #endif
             int lookupKey = lua_gettop(lua);
 
             int lookupTable = lookupKey - 1;

--- a/Code/Framework/AzFramework/AzFramework/Script/ScriptComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Script/ScriptComponent.cpp
@@ -373,10 +373,10 @@ namespace AzFramework
         {
             LSV_BEGIN(lua, 1);
 
-            #if !defined(CARBONATED) //This log is so incredibly spammy if you add a property to a very common script
+#if !defined(CARBONATED) //This log is so incredibly spammy if you add a property to a very common script
             AZ::ScriptContext::FromNativeContext(lua)->Error(AZ::ScriptContext::ErrorType::Warning, true,
                 "Property %s not found in entity table. Please push this property to your slice to avoid decrease in performance.", lua_tostring(lua, -1)); 
-            #endif
+#endif
             int lookupKey = lua_gettop(lua);
 
             int lookupTable = lookupKey - 1;

--- a/Gems/LyShine/Code/Include/LyShine/Bus/UiElementBus.h
+++ b/Gems/LyShine/Code/Include/LyShine/Bus/UiElementBus.h
@@ -151,6 +151,10 @@ public: // member functions
     virtual bool IsRenderEnabled() = 0;
     virtual void SetIsRenderEnabled(bool isRenderEnabled) = 0;
 
+    #if defined(CARBONATED)
+    virtual bool IsHandlingAreaInverted() = 0;
+    virtual void SetHandlingAreaInverted(bool isInverted) = 0;
+    #endif
 public: // static member data
 
     //! Only one component on a entity can implement the events

--- a/Gems/LyShine/Code/Include/LyShine/Bus/UiElementBus.h
+++ b/Gems/LyShine/Code/Include/LyShine/Bus/UiElementBus.h
@@ -151,10 +151,10 @@ public: // member functions
     virtual bool IsRenderEnabled() = 0;
     virtual void SetIsRenderEnabled(bool isRenderEnabled) = 0;
 
-    #if defined(CARBONATED)
+#if defined(CARBONATED)
     virtual bool IsHandlingAreaInverted() = 0;
     virtual void SetHandlingAreaInverted(bool isInverted) = 0;
-    #endif
+#endif
 public: // static member data
 
     //! Only one component on a entity can implement the events

--- a/Gems/LyShine/Code/Include/LyShine/Bus/UiElementBus.h
+++ b/Gems/LyShine/Code/Include/LyShine/Bus/UiElementBus.h
@@ -151,7 +151,7 @@ public: // member functions
     virtual bool IsRenderEnabled() = 0;
     virtual void SetIsRenderEnabled(bool isRenderEnabled) = 0;
 
-#if defined(CARBONATED)
+#if defined(CARBONATED) && defined(CARBONATED_UIELEMENT_INVERT_INPUT)
     virtual bool IsHandlingAreaInverted() = 0;
     virtual void SetHandlingAreaInverted(bool isInverted) = 0;
 #endif

--- a/Gems/LyShine/Code/Source/UiElementComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiElementComponent.cpp
@@ -621,7 +621,7 @@ AZ::EntityId UiElementComponent::FindInteractableToHandleEvent(AZ::Vector2 point
         if (UiInteractableBus::FindFirstHandler(GetEntityId()))
         {
             bool isInRect = GetTransform2dComponent()->IsPointInRect(point);
-#if defined(CARBONATED)
+#if defined(CARBONATED) && defined(CARBONATED_UIELEMENT_INVERT_INPUT)
             if (isInRect != m_isHandlingAreaInverted)
 #else
             if(isInRect)
@@ -1417,7 +1417,7 @@ void UiElementComponent::Reflect(AZ::ReflectContext* context)
             ->Event("IsAncestor", &UiElementBus::Events::IsAncestor)
             ->Event("IsEnabled", &UiElementBus::Events::IsEnabled)
             ->Event("SetIsEnabled", &UiElementBus::Events::SetIsEnabled)
-#if defined(CARBONATED)
+#if defined(CARBONATED) && defined(CARBONATED_UIELEMENT_INVERT_INPUT)
             ->Event("SetIsHandlingAreaInverted", &UiElementBus::Events::SetHandlingAreaInverted)
 #endif
             ;

--- a/Gems/LyShine/Code/Source/UiElementComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiElementComponent.cpp
@@ -621,7 +621,11 @@ AZ::EntityId UiElementComponent::FindInteractableToHandleEvent(AZ::Vector2 point
         if (UiInteractableBus::FindFirstHandler(GetEntityId()))
         {
             bool isInRect = GetTransform2dComponent()->IsPointInRect(point);
-            if (isInRect)
+#if defined(CARBONATED)
+            if (isInRect != m_isHandlingAreaInverted)
+#else
+            if(isInRect)
+#endif
             {
                 // check if this interactable component is in a state where it can handle an event at the given point
                 bool canHandle = false;
@@ -1412,7 +1416,11 @@ void UiElementComponent::Reflect(AZ::ReflectContext* context)
             ->Event("FindDescendantByName", &UiElementBus::Events::FindDescendantEntityIdByName)
             ->Event("IsAncestor", &UiElementBus::Events::IsAncestor)
             ->Event("IsEnabled", &UiElementBus::Events::IsEnabled)
-            ->Event("SetIsEnabled", &UiElementBus::Events::SetIsEnabled);
+            ->Event("SetIsEnabled", &UiElementBus::Events::SetIsEnabled)
+            #if defined(CARBONATED)
+            ->Event("SetIsHandlingAreaInverted", &UiElementBus::Events::SetHandlingAreaInverted)
+            #endif
+            ;
     }
 }
 

--- a/Gems/LyShine/Code/Source/UiElementComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiElementComponent.cpp
@@ -1417,9 +1417,9 @@ void UiElementComponent::Reflect(AZ::ReflectContext* context)
             ->Event("IsAncestor", &UiElementBus::Events::IsAncestor)
             ->Event("IsEnabled", &UiElementBus::Events::IsEnabled)
             ->Event("SetIsEnabled", &UiElementBus::Events::SetIsEnabled)
-            #if defined(CARBONATED)
+#if defined(CARBONATED)
             ->Event("SetIsHandlingAreaInverted", &UiElementBus::Events::SetHandlingAreaInverted)
-            #endif
+#endif
             ;
     }
 }

--- a/Gems/LyShine/Code/Source/UiElementComponent.h
+++ b/Gems/LyShine/Code/Source/UiElementComponent.h
@@ -104,6 +104,11 @@ public: // member functions
     bool IsRenderEnabled() override;
     void SetIsRenderEnabled(bool isRenderEnabled) override;
 
+    #if defined(CARBONATED)
+    bool IsHandlingAreaInverted() override { return m_isHandlingAreaInverted; }
+    void SetHandlingAreaInverted(bool isInverted) override { m_isHandlingAreaInverted = isInverted; }
+    #endif
+
     // ~UiElementInterface
 
     // UiEditorInterface
@@ -292,6 +297,10 @@ private: // data
 
     bool m_isEnabled = true;
     bool m_isRenderEnabled = true;
+
+    #if defined(CARBONATED)
+    bool m_isHandlingAreaInverted = false;
+    #endif
 
     // this data is only relevant when running in the editor, it is accessed through UiEditorBus
     bool m_isVisibleInEditor = true;

--- a/Gems/LyShine/Code/Source/UiElementComponent.h
+++ b/Gems/LyShine/Code/Source/UiElementComponent.h
@@ -104,10 +104,10 @@ public: // member functions
     bool IsRenderEnabled() override;
     void SetIsRenderEnabled(bool isRenderEnabled) override;
 
-    #if defined(CARBONATED)
+#if defined(CARBONATED)
     bool IsHandlingAreaInverted() override { return m_isHandlingAreaInverted; }
     void SetHandlingAreaInverted(bool isInverted) override { m_isHandlingAreaInverted = isInverted; }
-    #endif
+#endif
 
     // ~UiElementInterface
 
@@ -298,9 +298,9 @@ private: // data
     bool m_isEnabled = true;
     bool m_isRenderEnabled = true;
 
-    #if defined(CARBONATED)
+#if defined(CARBONATED)
     bool m_isHandlingAreaInverted = false;
-    #endif
+#endif
 
     // this data is only relevant when running in the editor, it is accessed through UiEditorBus
     bool m_isVisibleInEditor = true;

--- a/Gems/LyShine/Code/Source/UiElementComponent.h
+++ b/Gems/LyShine/Code/Source/UiElementComponent.h
@@ -104,7 +104,7 @@ public: // member functions
     bool IsRenderEnabled() override;
     void SetIsRenderEnabled(bool isRenderEnabled) override;
 
-#if defined(CARBONATED)
+#if defined(CARBONATED) && defined(CARBONATED_UIELEMENT_INVERT_INPUT)
     bool IsHandlingAreaInverted() override { return m_isHandlingAreaInverted; }
     void SetHandlingAreaInverted(bool isInverted) override { m_isHandlingAreaInverted = isInverted; }
 #endif
@@ -298,7 +298,7 @@ private: // data
     bool m_isEnabled = true;
     bool m_isRenderEnabled = true;
 
-#if defined(CARBONATED)
+#if defined(CARBONATED) && defined(CARBONATED_UIELEMENT_INVERT_INPUT)
     bool m_isHandlingAreaInverted = false;
 #endif
 


### PR DESCRIPTION
## What does this PR do?

Needed a way to have buttons handle areas opposite their bounds (i.e. a click hint where they can only tap inside the square)

## How was this PR tested?

On device, with the click hint
