### PR TITLE
Add hpha allocator stats, fix some issues preventing hpha disabling (MAD-17808)

### DIFF
--- a/Code/Framework/AzCore/AzCore/Memory/ChildAllocatorSchema.h
+++ b/Code/Framework/AzCore/AzCore/Memory/ChildAllocatorSchema.h
@@ -129,9 +129,14 @@ namespace AZ
         {
 #if defined(CARBONATED)
             AZ_MEMORY_PROFILE(ProfileReallocationBegin(ptr));
-#endif
-
+            if (newAlignment == 0)  // Windows produces an error if the alignment is zero
+            {
+                newAlignment = 1;
+            }
+            const size_type oldAllocatedSize = (ptr != nullptr) ? get_allocated_size(ptr, 1) : 0;
+#else
             const size_type oldAllocatedSize = get_allocated_size(ptr, 1);
+#endif
             AllocateAddress newAddress = AZ::AllocatorInstance<Parent>::Get().reallocate(ptr, newSize, newAlignment);
             // The reallocation might have clamped the newSize to be at least the minimum allocation size
             // used by the parent schema. For example the HphaSchemaBase has a minimum allocation size of 8 bytes

--- a/Code/Framework/AzCore/AzCore/Memory/HphaAllocator.cpp
+++ b/Code/Framework/AzCore/AzCore/Memory/HphaAllocator.cpp
@@ -945,6 +945,12 @@ namespace AZ
         {
             return mTotalAllocatedSizeBuckets + mTotalAllocatedSizeTree;
         }
+#if defined(CARBONATED)
+        inline size_t used() const
+        {
+            return mTotalCapacitySizeBuckets + mTotalCapacitySizeTree;
+        }
+#endif
 
         /// returns allocation size for the pointer if it belongs to the allocator. result is undefined if the pointer doesn't belong to the allocator.
         size_t  AllocationSize(void* ptr);
@@ -2594,6 +2600,17 @@ namespace AZ
         return m_allocator->allocated();
     }
 
+#if defined(CARBONATED)
+    //=========================================================================
+    // NumUsedBytes
+    // [5/12/2025]
+    //=========================================================================
+    template<bool DebugAllocator>
+    auto HphaSchemaBase<DebugAllocator>::NumUsedBytes() const -> size_type
+    {
+        return m_allocator->used();
+    }
+#endif
     //=========================================================================
     // GarbageCollect
     // [2/22/2011]

--- a/Code/Framework/AzCore/AzCore/Memory/HphaAllocator.h
+++ b/Code/Framework/AzCore/AzCore/Memory/HphaAllocator.h
@@ -36,6 +36,9 @@ namespace AZ
         size_type get_allocated_size(pointer ptr, align_type alignment = 1) const override;
 
         size_type       NumAllocatedBytes() const override;
+#if defined(CARBONATED)
+        size_type       NumUsedBytes() const override;
+#endif
 
         /// Return unused memory to the OS. Don't call this unless you really need free memory, it is slow.
         void            GarbageCollect() override;

--- a/Code/Framework/AzCore/AzCore/Memory/IAllocator.h
+++ b/Code/Framework/AzCore/AzCore/Memory/IAllocator.h
@@ -275,6 +275,14 @@ namespace AZ
         /// Returns true if profiling calls will be made.
         virtual bool IsProfilingActive() const { return false; }
 
+#if defined(CARBONATED)
+        /// Returns memory used by the allocator including overhead (if possible)
+        /// the traget is to calculate efficiency factor as NumAllocatedBytes() / NumUsedBytes()
+        virtual size_type NumUsedBytes() const
+        {
+            return 0;
+        }
+#endif
     protected:
         /// All conforming allocators must call PostCreate() after their custom Create() method in order to be properly registered.
         virtual void PostCreate() {}

--- a/Code/Framework/AzCore/AzCore/Memory/SystemAllocator.h
+++ b/Code/Framework/AzCore/AzCore/Memory/SystemAllocator.h
@@ -50,7 +50,9 @@ namespace AZ
         void            GarbageCollect() override                 { m_subAllocator->GarbageCollect(); }
 
         size_type       NumAllocatedBytes() const override;
-
+#if defined(CARBONATED)
+        size_type       NumUsedBytes() const override;
+#endif
         //////////////////////////////////////////////////////////////////////////
 
     protected:


### PR DESCRIPTION
## What does this PR do?

Add hpha used bytes stats to check its effectiveness factor.
Fix some issues preventing hpha off.

## How was this PR tested?

Local tests on Windows standalone build.
