### PR TITLE
Level loading lock fix N2 (MAD-18029)

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArray.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArray.cpp
@@ -391,12 +391,23 @@ namespace AZ
 
         void DecalTextureArray::QueueAssetLoads()
         {
+#if defined(CARBONATED) && defined(CARBONATED_ASSET_WAIT_TIMEOUT)
+            if (m_queueAssetsInProgress)
+            {
+                AZ_Info("DecalTextureArray", "QueueAssetLoads recursion, loading %d assets", m_assetsCurrentlyLoading.size());
+                return;
+            }
+            m_queueAssetsInProgress = true;
+#endif
             int iter = m_materials.begin();
             while (iter != -1)
             {
                 QueueAssetLoad(m_materials[iter]);
                 iter = m_materials.next(iter);
             }
+#if defined(CARBONATED) && defined(CARBONATED_ASSET_WAIT_TIMEOUT)
+            m_queueAssetsInProgress = false;
+#endif
         }
 
         bool DecalTextureArray::NeedsPacking() const

--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArray.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArray.h
@@ -101,6 +101,9 @@ namespace AZ
             AZStd::array<Data::Instance<RPI::StreamingImage>, DecalMapType_Num> m_textureArrayPacked;
              
             AZStd::unordered_set<AZ::Data::AssetId> m_assetsCurrentlyLoading;
+#if defined(CARBONATED) && defined(CARBONATED_ASSET_WAIT_TIMEOUT)
+            bool m_queueAssetsInProgress = false;
+#endif
         };
 
     } // namespace Render

--- a/Gems/EMotionFX/Code/Source/Integration/Assets/MotionSetAsset.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Assets/MotionSetAsset.cpp
@@ -223,7 +223,11 @@ namespace EMotionFX
 
                     if (motionAsset)
                     {
+#if defined(CARBONATED) && defined(CARBONATED_ASSET_WAIT_TIMEOUT)
+                        motionAsset.BlockUntilLoadComplete(10000);
+#else
                         motionAsset.BlockUntilLoadComplete();
+#endif
                         assetData->BusConnect(motionAssetId);
                         assetData->m_motionAssets.push_back(motionAsset);
                     }


### PR DESCRIPTION
## What does this PR do?

Avoid decal loading recursion.
Add non-main thread lock protection for motion assets, it happens pretty rare.

## How was this PR tested?

Local tests Windows standalone and iOS clients.
