### PR TITLE
Minor bug fix and asset loading default timeout (MAD-17483)

### DIFF
--- a/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
@@ -274,6 +274,13 @@ namespace AZ::Data
             , m_shouldDispatchEvents(shouldDispatchEvents)
 #endif
         {
+#if defined(CARBONATED) && defined(CARBONATED_ASSET_WAIT_TIMEOUT) && (defined(AZ_PLATFORM_IOS) || defined(AZ_PLATFORM_ANDROID))
+            // exclude desktop platforms because AssetProcessor might interfere
+            if (m_timeoutMillis == 0)
+            {
+                m_timeoutMillis = 10001; // 10 sec wait time by default if loading is blocked, +1 to detect the default value by the log
+            }
+#endif
             // Track all blocking requests with the AssetManager.  This enables load jobs to potentially get routed
             // to the thread that's currently blocking waiting on the load job to complete.
             AssetManager::Instance().AddBlockingRequest(m_assetData.GetId(), this);

--- a/Gems/EMotionFX/Code/EMotionFX/Source/Importer/Importer.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Importer/Importer.cpp
@@ -361,7 +361,7 @@ namespace EMotionFX
     // try to load a motion from disk
     Motion* Importer::LoadMotion(AZStd::string filename, MotionSettings* settings)
     {
-#if !defined(CARBONATED) && defined(CARBONATED_EMOTIONFX_CONCURRENCY)
+#if !(defined(CARBONATED) && defined(CARBONATED_EMOTIONFX_CONCURRENCY))
         AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::Bus::Events::NormalizePathKeepCase, filename);
 #endif
         // check if we want to load the motion even if a motion with the given filename is already inside the motion manager


### PR DESCRIPTION
## What does this PR do?

Bug fix in preprocessor definition condition.
Set default asset loading timeout.

## How was this PR tested?

Local PC standalone build.

This is not for release. The target of this PR is to gather asset loading timeout messages from play test logs.
