### PR TITLE
Shader function leak fix (MAD-17808)

### DIFF
--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineState.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineState.cpp
@@ -368,6 +368,16 @@ namespace AZ
         {
             if (m_graphicsPipelineState)
             {
+#if defined(CARBONATED)
+                if (m_renderPipelineDesc.vertexFunction)
+                {
+                    [m_renderPipelineDesc.vertexFunction release];
+                }
+                if (m_renderPipelineDesc.fragmentFunction)
+                {
+                    [m_renderPipelineDesc.fragmentFunction release];
+                }
+#endif
                 [m_renderPipelineDesc release];
                 m_renderPipelineDesc = nil;
                 [m_graphicsPipelineState release];
@@ -376,6 +386,12 @@ namespace AZ
             
             if (m_computePipelineState)
             {
+#if defined(CARBONATED)
+                if (m_computePipelineDesc.computeFunction)
+                {
+                    [m_computePipelineDesc.computeFunction release];
+                }
+#endif
                 [m_computePipelineDesc release];
                 m_computePipelineDesc = nil;
                 [m_computePipelineState release];


### PR DESCRIPTION
## What does this PR do?

Release shader functions on pipeline state shutdown

## How was this PR tested?

Local build tests on iOS.
Here is the mission loading chart:
The first value is resident memory in main menu after startup in Gb, the second value is after mission 1, etc. I loaded 40 missions.
1.07 1.26 1.32 1.37 1.40 1.40 1.41 1.41 1.48 1.50 1.50 1.52 1.54 1.55 1.58 1.58 1.60 1.60 1.62 1.64 1.66 1.66 1.68 1.69 1.70 1.73 1.73 1.75 1.75 1.76 1.78 1.79 1.80 1.81 1.83 1.83 1.86 1.87 1.87 1.88 1.89
As you can see the memory grows, so this is not the final fix, but it grows slow. It did not crash after 40 missions, I just tired testing, I predict there will be a 100 missions until iPhone 15 outs of memory. The edge in main menu is 2.35-2.40Gb, we have just 1.89Gb after 40 missions.
The per-mission increase is about 14Mb, which matches PC standalone build increase. I likely eliminated iOS specific leak, the rest is platform agnostic. I calculate the average increase after the first 4 missions, because there is caching and buffering, the buffers are allocated at the early missions.