### PR TITLE
Zero lods to remove in constructor

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/ModelAsset.h
@@ -127,7 +127,7 @@ namespace AZ
             AZ::Aabb m_aabb = AZ::Aabb::CreateNull();
             AZStd::fixed_vector<Data::Asset<ModelLodAsset>, ModelLodAsset::LodCountMax> m_lodAssets;
 #if defined(CARBONATED) && defined(AZ_LOD_REMOVAL)
-            int m_numLodsToRemove;
+            int m_numLodsToRemove = 0;
 #endif
 
             // mutable method


### PR DESCRIPTION
## What does this PR do?

Zeroes var in constructor, otherwise it breaks automation tests

## How was this PR tested?

Another TechRound engineer worked on enabling all the automation tests for original o3de version and collaterally on Carbonated o3de version. This fix is from him. It is pretty safe.
