### PR TITLE
Prevent fallthrough which loads the same material again

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
@@ -616,6 +616,10 @@ namespace AZ
                     QueueLoadMaterials();
                     return;
                 }
+
+#if defined(CARBONATED)
+                return;
+#endif
             }
 
             m_configuration.m_materials[materialAssignmentId].m_materialAsset =


### PR DESCRIPTION
## What does this PR do?

Fixes a dropthrough case where it will reload a material that it has already determined its using.

## How was this PR tested?

Tested on PC, making a build now