### PR TITLE
Skip removing bundle for simple archives, because they are never added

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Archive/Archive.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Archive/Archive.cpp
@@ -1249,7 +1249,9 @@ namespace AZ::IO
             m_archivesWithCatalogsToLoad.push_back(
                 ArchivesWithCatalogsToLoad(szFullPath, szBindRoot, flags, nextBundle, desc.m_strFileName));
         }
-
+#if defined(CARBONATED) && defined(CARBONATED_SIMPLE_PAK)
+        desc.m_isSimplePack = !(bundleManifest && bundleCatalog);  // there'll be no BundleOpened(...) call below
+#endif
         m_arrZips.insert(revItZip.base(), desc);
 
         if (bundleManifest && bundleCatalog)
@@ -1288,11 +1290,20 @@ namespace AZ::IO
                 //
                 // the pZip (cache) can be referenced from stream engine and pseudo-files.
                 // the archive can be referenced from outside
+#if defined(CARBONATED) && defined(CARBONATED_SIMPLE_PAK)
+                AZ::IO::ArchiveNotificationBus::Broadcast([isSimple = it->m_isSimplePack](AZ::IO::ArchiveNotifications* archiveNotifications, const AZ::IO::FixedMaxPath& bundleName)
+                {
+                    if (!isSimple)  // call BundleClosed if BundleOpened was called on the opening
+                    {
+                        archiveNotifications->BundleClosed(bundleName.c_str());
+                    }
+                }, it->GetFullPath());
+#else
                 AZ::IO::ArchiveNotificationBus::Broadcast([](AZ::IO::ArchiveNotifications* archiveNotifications, const AZ::IO::FixedMaxPath& bundleName)
                 {
                     archiveNotifications->BundleClosed(bundleName.c_str());
                 }, it->GetFullPath());
-
+#endif
                 it = m_arrZips.erase(it);
             }
             else

--- a/Code/Framework/AzFramework/AzFramework/Archive/Archive.h
+++ b/Code/Framework/AzFramework/AzFramework/Archive/Archive.h
@@ -120,7 +120,9 @@ namespace AZ::IO
 
             // [LYN-2376] Remove once legacy slice support is removed
             bool m_containsLevelPak = false; // indicates whether this archive has level.pak inside it or not  
-
+#if defined(CARBONATED) && defined(CARBONATED_SIMPLE_PAK)
+            bool m_isSimplePack = false;  // indicates there is no manifest or catalog, so it is not added to bundles container
+#endif
             AZ::IO::PathView GetFullPath() const { return pZip->GetFilePath(); }
 
             AZStd::intrusive_ptr<INestedArchive> pArchive;


### PR DESCRIPTION
## What does this PR do?

Avoid removing simple pak archives from bundle container. They are never added. This avoid a warning message.

## How was this PR tested?

Local standalone PC client build.
