### PR TITLE
NOTICKET. AssetProcessorBatch file mask feature

### DIFF
--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -558,7 +558,7 @@ namespace AssetProcessor
             if (iter.value().m_sourceAssetReference)
             {
 #if defined(CARBONATED) && defined(CARBONATED_APB_FILE_MASK)				
-				// Support "only_process" command line argument
+				// Support "process-project-assets" and "process-engine-assets" command line arguments
                 if (!m_processOnlyFiles.isEmpty())
                 {
                     // If we have the list "to process only" then we check for the deletion of unneeded assets/products in this list
@@ -3614,13 +3614,15 @@ namespace AssetProcessor
 
     void AssetProcessorManager::RecordFilesFromScanner(QSet<AssetFileInfo> filePaths)
     {
-#if defined(CARBONATED) && defined(CARBONATED_APB_FILE_MASK)		
-        // Support "only_process" command line argument
-        QStringList onlyProcessedFilesArguments = AssetUtilities::ReadOnlyProcessedFilesFromCommandLine();
-        if (!onlyProcessedFilesArguments.isEmpty())
+#if defined(CARBONATED) && defined(CARBONATED_APB_FILE_MASK)
+        // Support "process-project-assets" and "process-engine-assets" command line arguments
+        QStringList processedProjectFilesArguments = AssetUtilities::ReadProcessedAssetsFilesFromCommandLine(true);
+        QStringList processedEngineFilesArguments = AssetUtilities::ReadProcessedAssetsFilesFromCommandLine(false);
+        if (!processedProjectFilesArguments.isEmpty() || !processedEngineFilesArguments.isEmpty())
         {
-            QString projectPath = AssetUtilities::ComputeProjectPath();
-            QStringList filesToProcess = AssetUtilities::ResolveAbsolutePathsWithExistingFiles(projectPath, onlyProcessedFilesArguments);
+            QStringList filesToProcess = AssetUtilities::ResolveAbsolutePathsWithExistingFiles(AssetUtilities::ComputeProjectPath(), processedProjectFilesArguments);
+			QStringList filesToProcessInEngine = AssetUtilities::ResolveAbsolutePathsWithExistingFiles(QString(AZ::Utils::GetEnginePath().c_str()), processedEngineFilesArguments);
+            filesToProcess << filesToProcessInEngine;
             if (!filesToProcess.isEmpty())
             {
                 QSet<AssetFileInfo> filteredFiles;

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -3621,7 +3621,7 @@ namespace AssetProcessor
         if (!processedProjectFilesArguments.isEmpty() || !processedEngineFilesArguments.isEmpty())
         {
             QStringList filesToProcess = AssetUtilities::ResolveAbsolutePathsWithExistingFiles(AssetUtilities::ComputeProjectPath(), processedProjectFilesArguments);
-			QStringList filesToProcessInEngine = AssetUtilities::ResolveAbsolutePathsWithExistingFiles(QString(AZ::Utils::GetEnginePath().c_str()), processedEngineFilesArguments);
+            QStringList filesToProcessInEngine = AssetUtilities::ResolveAbsolutePathsWithExistingFiles(QString(AZ::Utils::GetEnginePath().c_str()), processedEngineFilesArguments);
             filesToProcess << filesToProcessInEngine;
             if (!filesToProcess.isEmpty())
             {

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -557,7 +557,7 @@ namespace AssetProcessor
         {
             if (iter.value().m_sourceAssetReference)
             {
-#if defined(CARBONATED) && defined(CARBONATED_APB_FILE_MASK)				
+#if defined(CARBONATED) && defined(CARBONATED_APB_FILE_MASK)
                 // Support "process-project-assets" and "process-engine-assets" command line arguments
                 if (!m_processOnlyFiles.isEmpty())
                 {
@@ -600,10 +600,10 @@ namespace AssetProcessor
 
         m_scanFoldersInDatabase.clear();
         m_sourceFilesInDatabase.clear();
-#if defined(CARBONATED) && defined(CARBONATED_APB_FILE_MASK)										  
+#if defined(CARBONATED) && defined(CARBONATED_APB_FILE_MASK)
         m_processOnlyFiles.clear();
 #endif
-		
+
         QueueIdleCheck();
     }
 

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -559,11 +559,11 @@ namespace AssetProcessor
             {
 #if defined(CARBONATED) && defined(CARBONATED_APB_FILE_MASK)
                 // Support "process-project-assets" and "process-engine-assets" command line arguments
-                if (!m_processOnlyFiles.isEmpty())
+                if (!m_filesToProcess.isEmpty())
                 {
                     // If we have the list "to process only" then we should check for the deletion of unneeded assets/products in this list
                     bool inProcessOnlyList = false;
-                    for (const auto& file : m_processOnlyFiles)
+                    for (const auto& file : m_filesToProcess)
                     {
                         if (AssetUtilities::ArePathsEqual(file.m_filePath, QString(iter.value().m_sourceAssetReference.AbsolutePath().c_str())))
                         {
@@ -601,7 +601,7 @@ namespace AssetProcessor
         m_scanFoldersInDatabase.clear();
         m_sourceFilesInDatabase.clear();
 #if defined(CARBONATED) && defined(CARBONATED_APB_FILE_MASK)
-        m_processOnlyFiles.clear();
+        m_filesToProcess.clear();
 #endif
 
         QueueIdleCheck();
@@ -3636,7 +3636,7 @@ namespace AssetProcessor
                             if (AssetUtilities::ArePathsEqual(file, fileInProject.m_filePath))
                             {
                                 filteredFiles.insert(fileInProject);
-                                m_processOnlyFiles.insert(fileInProject);
+                                m_filesToProcess.insert(fileInProject);
                             }
                         }
                     }

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -558,7 +558,7 @@ namespace AssetProcessor
             if (iter.value().m_sourceAssetReference)
             {
 #if defined(CARBONATED) && defined(CARBONATED_APB_FILE_MASK)				
-				// Support "process-project-assets" and "process-engine-assets" command line arguments
+                // Support "process-project-assets" and "process-engine-assets" command line arguments
                 if (!m_processOnlyFiles.isEmpty())
                 {
                     // If we have the list "to process only" then we should check for the deletion of unneeded assets/products in this list

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -561,19 +561,19 @@ namespace AssetProcessor
 				// Support "process-project-assets" and "process-engine-assets" command line arguments
                 if (!m_processOnlyFiles.isEmpty())
                 {
-                    // If we have the list "to process only" then we check for the deletion of unneeded assets/products in this list
-                    bool inProcessOnly = false;
+                    // If we have the list "to process only" then we should check for the deletion of unneeded assets/products in this list
+                    bool inProcessOnlyList = false;
                     for (const auto& file : m_processOnlyFiles)
                     {
                         if (AssetUtilities::ArePathsEqual(file.m_filePath, QString(iter.value().m_sourceAssetReference.AbsolutePath().c_str())))
                         {
-                            inProcessOnly = true;
+                            inProcessOnlyList = true;
                             break;
                         }
                     }
-                    if (!inProcessOnly)
+                    if (!inProcessOnlyList)
                     {
-                        // Other files in database we will ignore
+                        // Ignoring all other files in database
                         continue;
                     }
                 }

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -557,6 +557,27 @@ namespace AssetProcessor
         {
             if (iter.value().m_sourceAssetReference)
             {
+#if defined(CARBONATED) && defined(CARBONATED_APB_FILE_MASK)				
+				// Support "only_process" command line argument
+                if (!m_processOnlyFiles.isEmpty())
+                {
+                    // If we have the list "to process only" then we check for the deletion of unneeded assets/products in this list
+                    bool inProcessOnly = false;
+                    for (const auto& file : m_processOnlyFiles)
+                    {
+                        if (AssetUtilities::ArePathsEqual(file.m_filePath, QString(iter.value().m_sourceAssetReference.AbsolutePath().c_str())))
+                        {
+                            inProcessOnly = true;
+                            break;
+                        }
+                    }
+                    if (!inProcessOnly)
+                    {
+                        // Other files in database we will ignore
+                        continue;
+                    }
+                }
+#endif
                 // CheckDeletedSourceFile actually expects the database name as the second value
                 // iter.key is the full path normalized.  iter.value is the database path.
                 // we need the relative path too:
@@ -579,7 +600,10 @@ namespace AssetProcessor
 
         m_scanFoldersInDatabase.clear();
         m_sourceFilesInDatabase.clear();
-
+#if defined(CARBONATED) && defined(CARBONATED_APB_FILE_MASK)										  
+        m_processOnlyFiles.clear();
+#endif
+		
         QueueIdleCheck();
     }
 
@@ -3590,6 +3614,48 @@ namespace AssetProcessor
 
     void AssetProcessorManager::RecordFilesFromScanner(QSet<AssetFileInfo> filePaths)
     {
+#if defined(CARBONATED) && defined(CARBONATED_APB_FILE_MASK)		
+        // Support "only_process" command line argument
+        QStringList onlyProcessedFilesArguments = AssetUtilities::ReadOnlyProcessedFilesFromCommandLine();
+        if (!onlyProcessedFilesArguments.isEmpty())
+        {
+            QString projectPath = AssetUtilities::ComputeProjectPath();
+            QStringList filesToProcess = AssetUtilities::ResolveAbsolutePathsWithExistingFiles(projectPath, onlyProcessedFilesArguments);
+            if (!filesToProcess.isEmpty())
+            {
+                QSet<AssetFileInfo> filteredFiles;
+
+                for (const auto& file : filesToProcess)
+                {
+                    for (const auto& fileInProject : filePaths)
+                    {
+                        if (!fileInProject.m_isDirectory)
+                        {
+                            if (AssetUtilities::ArePathsEqual(file, fileInProject.m_filePath))
+                            {
+                                filteredFiles.insert(fileInProject);
+                                m_processOnlyFiles.insert(fileInProject);
+                            }
+                        }
+                    }
+                }
+
+                if (!filteredFiles.isEmpty())
+                {
+                    AssetProcessor::StatsCapture::BeginCaptureStat("WarmingFileCache");
+                    WarmUpFileCache(filePaths);
+                    AssetProcessor::StatsCapture::EndCaptureStat("WarmingFileCache");
+
+                    filePaths.clear();
+                    m_scannerFiles = filteredFiles;
+
+                    Q_EMIT FileCacheIsReady();
+                    CheckReadyToAssessScanFiles();
+                    return;
+                }
+            }
+        }
+#endif
         m_scannerFiles = filePaths;
 
         AssetProcessor::StatsCapture::BeginCaptureStat("WarmingFileCache");

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
@@ -620,7 +620,7 @@ namespace AssetProcessor
         QSet<AssetFileInfo> m_scannerFiles;
 
 #if defined(CARBONATED) && defined(CARBONATED_APB_FILE_MASK)
-        // Files from the scanner, waiting for initial analysis
+        // Files from the scanner that should be processed according to the "process-project-assets" and/or "process-engine-assets" command line arguments
         QSet<AssetFileInfo> m_processOnlyFiles;
 #endif
 		

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
@@ -621,7 +621,7 @@ namespace AssetProcessor
 
 #if defined(CARBONATED) && defined(CARBONATED_APB_FILE_MASK)
         // Files from the scanner that should be processed according to the "process-project-assets" and/or "process-engine-assets" command line arguments.
-        // If there no new command line keys then the container is empty, so APB checks all the assets.
+        // If there are no new command line keys then the container is empty, so APB checks all the assets.
         QSet<AssetFileInfo> m_filesToProcess;
 #endif
 

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
@@ -623,7 +623,7 @@ namespace AssetProcessor
         // Files from the scanner that should be processed according to the "process-project-assets" and/or "process-engine-assets" command line arguments
         QSet<AssetFileInfo> m_processOnlyFiles;
 #endif
-		
+
         //////////////////// Analysis Early-Out feature ///////////////////
         // ComputeBuilderDirty builds the maps of which builders are dirty and how they have changed.
         // note that until ComputeBuilderDirty is called, it is assumed that *all* are dirty, to be conservative.

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
@@ -620,8 +620,9 @@ namespace AssetProcessor
         QSet<AssetFileInfo> m_scannerFiles;
 
 #if defined(CARBONATED) && defined(CARBONATED_APB_FILE_MASK)
-        // Files from the scanner that should be processed according to the "process-project-assets" and/or "process-engine-assets" command line arguments
-        QSet<AssetFileInfo> m_processOnlyFiles;
+        // Files from the scanner that should be processed according to the "process-project-assets" and/or "process-engine-assets" command line arguments.
+        // If there no new command line keys then the container is empty, so APB checks all the assets.
+        QSet<AssetFileInfo> m_filesToProcess;
 #endif
 
         //////////////////// Analysis Early-Out feature ///////////////////

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
@@ -619,6 +619,11 @@ namespace AssetProcessor
         // Files from the scanner, waiting for initial analysis
         QSet<AssetFileInfo> m_scannerFiles;
 
+#if defined(CARBONATED) && defined(CARBONATED_APB_FILE_MASK)
+        // Files from the scanner, waiting for initial analysis
+        QSet<AssetFileInfo> m_processOnlyFiles;
+#endif
+		
         //////////////////// Analysis Early-Out feature ///////////////////
         // ComputeBuilderDirty builds the maps of which builders are dirty and how they have changed.
         // note that until ComputeBuilderDirty is called, it is assumed that *all* are dirty, to be conservative.

--- a/Code/Tools/AssetProcessor/native/utilities/assetUtils.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/assetUtils.cpp
@@ -60,6 +60,10 @@
 
 #include <sstream>
 
+#if defined(CARBONATED) && defined(CARBONATED_APB_FILE_MASK)
+#include <QDirIterator>
+#endif
+
 namespace AssetUtilsInternal
 {
     static const unsigned int g_RetryWaitInterval = 250; // The amount of time that we are waiting for retry.
@@ -694,12 +698,14 @@ namespace AssetUtilities
     }
 
 #if defined(CARBONATED) && defined(CARBONATED_APB_FILE_MASK)
-    QStringList ReadOnlyProcessedFilesFromCommandLine()
+    QStringList ReadProcessedAssetsFilesFromCommandLine(bool projectOrEnginePath)
     {
         QStringList args = QCoreApplication::arguments();
         for (QString arg : args)
         {
-            if (arg.contains("--only_process=", Qt::CaseInsensitive) || arg.contains("/only_process=", Qt::CaseInsensitive))
+            if (projectOrEnginePath && (arg.contains("--process-project-assets=", Qt::CaseInsensitive) || arg.contains("/process-project-assets=", Qt::CaseInsensitive)) ||
+			   !projectOrEnginePath && (arg.contains("--process-engine-assets=", Qt::CaseInsensitive) || arg.contains("/process-engine-assets=", Qt::CaseInsensitive))
+				)
             {
                 QString rawPlatformString = arg.split("=")[1];
                 return rawPlatformString.split(",");
@@ -709,7 +715,7 @@ namespace AssetUtilities
         return QStringList();
     }
 
-    QStringList ResolveAbsolutePathsWithExistingFiles(const QString& projectPath, const QStringList& inputPaths)
+    QStringList ResolveAbsolutePathsWithExistingFiles(const QString& rootPath, const QStringList& inputPaths)
     {
         QStringList result;
 
@@ -728,7 +734,7 @@ namespace AssetUtilities
             }
 
             // Case 2: Handle relative paths/masks
-            QDir baseDir(projectPath);
+            QDir baseDir(rootPath);
             QString combinedPath = baseDir.absoluteFilePath(path);
             QFileInfo combinedInfo(combinedPath);
 

--- a/Code/Tools/AssetProcessor/native/utilities/assetUtils.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/assetUtils.cpp
@@ -704,8 +704,8 @@ namespace AssetUtilities
         for (QString arg : args)
         {
             if (projectOrEnginePath && (arg.contains("--process-project-assets=", Qt::CaseInsensitive) || arg.contains("/process-project-assets=", Qt::CaseInsensitive)) ||
-			   !projectOrEnginePath && (arg.contains("--process-engine-assets=", Qt::CaseInsensitive) || arg.contains("/process-engine-assets=", Qt::CaseInsensitive))
-				)
+            !projectOrEnginePath && (arg.contains("--process-engine-assets=", Qt::CaseInsensitive) || arg.contains("/process-engine-assets=", Qt::CaseInsensitive))
+            )
             {
                 QString rawPlatformString = arg.split("=")[1];
                 return rawPlatformString.split(",");
@@ -759,7 +759,7 @@ namespace AssetUtilities
             }
             else
             {
-                // Path doesn't exist directly — treat as a mask
+                // Path doesn't exist directly - treat as a mask
                 // Extract directory part and pattern from the input path
                 QString dirPart = QFileInfo(path).path();
                 QString filePattern = QFileInfo(path).fileName();

--- a/Code/Tools/AssetProcessor/native/utilities/assetUtils.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/assetUtils.cpp
@@ -693,6 +693,103 @@ namespace AssetUtilities
         return QStringList();
     }
 
+#if defined(CARBONATED) && defined(CARBONATED_APB_FILE_MASK)
+    QStringList ReadOnlyProcessedFilesFromCommandLine()
+    {
+        QStringList args = QCoreApplication::arguments();
+        for (QString arg : args)
+        {
+            if (arg.contains("--only_process=", Qt::CaseInsensitive) || arg.contains("/only_process=", Qt::CaseInsensitive))
+            {
+                QString rawPlatformString = arg.split("=")[1];
+                return rawPlatformString.split(",");
+            }
+        }
+
+        return QStringList();
+    }
+
+    QStringList ResolveAbsolutePathsWithExistingFiles(const QString& projectPath, const QStringList& inputPaths)
+    {
+        QStringList result;
+
+        for (const QString& path : inputPaths)
+        {
+            QFileInfo fileInfo(path);
+
+            // Case 1: If it's an absolute path and exists
+            if (fileInfo.isAbsolute())
+            {
+                if (fileInfo.exists())
+                {
+                    result.append(QDir::toNativeSeparators(fileInfo.absoluteFilePath()));
+                }
+                continue;
+            }
+
+            // Case 2: Handle relative paths/masks
+            QDir baseDir(projectPath);
+            QString combinedPath = baseDir.absoluteFilePath(path);
+            QFileInfo combinedInfo(combinedPath);
+
+            // Check if combined path is a valid existing file or folder
+            if (combinedInfo.exists())
+            {
+                if (combinedInfo.isFile())
+                {
+                    // Just add the file directly
+                    result.append(QDir::toNativeSeparators(combinedInfo.absoluteFilePath()));
+                }
+                else if (combinedInfo.isDir())
+                {
+                    // Search recursively in this directory
+                    QDirIterator dirIt(combinedInfo.absoluteFilePath(), QDir::NoDotAndDotDot | QDir::Files, QDirIterator::Subdirectories);
+                    while (dirIt.hasNext())
+                    {
+                        QString fullPath = QDir::toNativeSeparators(dirIt.next());
+                        result.append(fullPath);
+                    }
+                }
+            }
+            else
+            {
+                // Path doesn't exist directly — treat as a mask
+                // Extract directory part and pattern from the input path
+                QString dirPart = QFileInfo(path).path();
+                QString filePattern = QFileInfo(path).fileName();
+
+                // Combine directory with project path
+                QString searchDirPath = baseDir.absoluteFilePath(dirPart);
+                QDir searchDir(searchDirPath);
+
+                if (!searchDir.exists())
+                {
+                    continue;
+                }
+
+                // Use QDirIterator to find all matching files recursively
+                QDirIterator dirIt(
+                    searchDirPath, QStringList() << filePattern, QDir::NoDotAndDotDot | QDir::Files, QDirIterator::Subdirectories);
+
+                while (dirIt.hasNext())
+                {
+                    QString fullPath = QDir::toNativeSeparators(dirIt.next());
+                    result.append(fullPath);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    bool ArePathsEqual(const QString& path1, const QString& path2)
+    {
+        QString normalized1 = QDir::fromNativeSeparators(path1).toLower();
+        QString normalized2 = QDir::fromNativeSeparators(path2).toLower();
+
+        return normalized1 == normalized2;
+    }
+#endif
     bool CopyFileWithTimeout(QString sourceFile, QString outputFile, unsigned int waitTimeInSeconds)
     {
         return AssetUtilsInternal::FileCopyMoveWithTimeout(sourceFile, outputFile, true, waitTimeInSeconds);

--- a/Code/Tools/AssetProcessor/native/utilities/assetUtils.h
+++ b/Code/Tools/AssetProcessor/native/utilities/assetUtils.h
@@ -115,8 +115,8 @@ namespace AssetUtilities
 
 #if defined(CARBONATED) && defined(CARBONATED_APB_FILE_MASK)
 	/**
-     * @brief ReadOnlyProcessedFilesFromCommandLine.
-     * Reads only processed files from command line.
+     * @brief ReadProcessedAssetsFilesFromCommandLine.
+     * Reads file masks that should be processed from command line.
      *
      * @param projectOrEnginePath: true - project path, --process-project-assets=XXXX, false - engine path, --process-engine-assets=YYYY
      * @return QStringList with masks to the files/subdirectories

--- a/Code/Tools/AssetProcessor/native/utilities/assetUtils.h
+++ b/Code/Tools/AssetProcessor/native/utilities/assetUtils.h
@@ -113,6 +113,23 @@ namespace AssetUtilities
     //! Reads platforms from command line
     QStringList ReadPlatformsFromCommandLine();
 
+#if defined(CARBONATED) && defined(CARBONATED_APB_FILE_MASK)
+    //! Reads only processed files from command line.
+    QStringList ReadOnlyProcessedFilesFromCommandLine();
+
+/**
+     * @brief ResolveAbsolutePathsWithExistingFiles.
+     * Recursively finds all files matching the given masks or paths relative to the project root.
+     *
+     * @param projectPath Absolute path to the project root directory.
+     * @param inputPaths  List of file masks or paths (can be relative or absolute).
+     * @return            QStringList with full native paths to existing files.
+     */
+    QStringList ResolveAbsolutePathsWithExistingFiles(const QString& projectPath, const QStringList& inputPaths);
+
+    //! Compares paths to the files ignoring case and native separators
+    bool ArePathsEqual(const QString& path1, const QString& path2);
+#endif
     //! Copies the sourceFile to the outputFile,returns true if the copy operation succeeds otherwise return false
     //! This function will try deleting the outputFile first,if it exists, before doing the copy operation
     bool CopyFileWithTimeout(QString sourceFile, QString outputFile, unsigned int waitTimeinSeconds = 0);

--- a/Code/Tools/AssetProcessor/native/utilities/assetUtils.h
+++ b/Code/Tools/AssetProcessor/native/utilities/assetUtils.h
@@ -114,7 +114,7 @@ namespace AssetUtilities
     QStringList ReadPlatformsFromCommandLine();
 
 #if defined(CARBONATED) && defined(CARBONATED_APB_FILE_MASK)
-	/**
+     /**
      * @brief ReadProcessedAssetsFilesFromCommandLine.
      * Reads file masks that should be processed from command line.
      *
@@ -123,7 +123,7 @@ namespace AssetUtilities
      */
     QStringList ReadProcessedAssetsFilesFromCommandLine(bool projectOrEnginePath);
 
-	/**
+     /**
      * @brief ResolveAbsolutePathsWithExistingFiles.
      * Recursively finds all files matching the given masks or paths relative to the root.
      *

--- a/Code/Tools/AssetProcessor/native/utilities/assetUtils.h
+++ b/Code/Tools/AssetProcessor/native/utilities/assetUtils.h
@@ -114,18 +114,24 @@ namespace AssetUtilities
     QStringList ReadPlatformsFromCommandLine();
 
 #if defined(CARBONATED) && defined(CARBONATED_APB_FILE_MASK)
-    //! Reads only processed files from command line.
-    QStringList ReadOnlyProcessedFilesFromCommandLine();
-
-/**
-     * @brief ResolveAbsolutePathsWithExistingFiles.
-     * Recursively finds all files matching the given masks or paths relative to the project root.
+	/**
+     * @brief ReadOnlyProcessedFilesFromCommandLine.
+     * Reads only processed files from command line.
      *
-     * @param projectPath Absolute path to the project root directory.
+     * @param projectOrEnginePath: true - project path, --process-project-assets=XXXX, false - engine path, --process-engine-assets=YYYY
+     * @return QStringList with masks to the files/subdirectories
+     */
+    QStringList ReadProcessedAssetsFilesFromCommandLine(bool projectOrEnginePath);
+
+	/**
+     * @brief ResolveAbsolutePathsWithExistingFiles.
+     * Recursively finds all files matching the given masks or paths relative to the root.
+     *
+     * @param rootPath    Absolute path to the root project or engine directory
      * @param inputPaths  List of file masks or paths (can be relative or absolute).
      * @return            QStringList with full native paths to existing files.
      */
-    QStringList ResolveAbsolutePathsWithExistingFiles(const QString& projectPath, const QStringList& inputPaths);
+    QStringList ResolveAbsolutePathsWithExistingFiles(const QString& rootPath, const QStringList& inputPaths);
 
     //! Compares paths to the files ignoring case and native separators
     bool ArePathsEqual(const QString& path1, const QString& path2);


### PR DESCRIPTION
## What does this PR do?

2 new command line arguments are implemented for the AssetProcessorBatch.exe:
--process-project-assets=<file_masks1>,<file_mask2>
--process-engine-assets=<file_maskN1>,<file_maskN2>
file_mask maybe as file as subdiectory relative to the root of the project or of the engine.
This feature skips almost all checks of all other files in the engine and in the project that allows to reprocess the assets only in the required subdirectory much faster.

## How was this PR tested?

Create an empty default project.
Run AssetProcessorBatch.exe with the default arguments for the first time.
Run AssetProcessorBatch.exe with the default arguments again and measure the time that AssetProcessorBatch just checks the assets in the engine and in the project and does nothing because assets are not changed. It will take about 5 minutes for about 4500 files (by default).
Run AssetProcessorBatch.exe with new argument that lists some subdirectory in the project. It will take about 10 seconds because it  checks only a few files in the listed subdirectory.

