### PR TITLE
NOTICKET. Fix Warnings treated in VS17.14.x as errors

### DIFF
--- a/Code/Editor/AssetImporter/AssetImporterManager/AssetImporterManager.cpp
+++ b/Code/Editor/AssetImporter/AssetImporterManager/AssetImporterManager.cpp
@@ -540,7 +540,11 @@ void AssetImporterManager::ProcessMoveFiles()
     }
 }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+bool AssetImporterManager::Copy([[maybe_unused]] QString relativePath, QString oldAbsolutePath, QString destinationAbsolutePath)
+#else
 bool AssetImporterManager::Copy(QString relativePath, QString oldAbsolutePath, QString destinationAbsolutePath)
+#endif // defined(CARBONATED)
 {
     QString fileName = GetFileName(destinationAbsolutePath);
     QString subPath = QFileInfo(destinationAbsolutePath).absoluteDir().absolutePath();

--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -1770,7 +1770,11 @@ bool CCryEditApp::InitInstance()
 }
 
 //////////////////////////////////////////////////////////////////////////
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+void CCryEditApp::LoadFile([[maybe_unused]] QString fileName)
+#else
 void CCryEditApp::LoadFile(QString fileName)
+#endif // defined(CARBONATED)
 {
     if (GetIEditor()->GetViewManager()->GetViewCount() == 0)
     {

--- a/Code/Framework/AzCore/AzCore/Instance/InstancePool.h
+++ b/Code/Framework/AzCore/AzCore/Instance/InstancePool.h
@@ -145,10 +145,17 @@ namespace AZ
         // same as above, but uses the class's AzTypeInfo name as the pool name. Useful when sharing pools across different editors
         // without having to manually coordinate the pool name. 
         // important note: to use this, the T type must either include the AZ_RTTI macro, or be externally exposed via AZ_TYPE_INFO_SPECIALIZE
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        template<class T>
+        AZ::Outcome<AZStd::shared_ptr<InstancePool<T>>, AZStd::string> CreatePool(
+            typename InstancePool<T>::ResetInstance resetFunc = [](T&){}, 
+            [[maybe_unused]] typename InstancePool<T>::CreateInstance createFunc = []() { return new T{}; })
+#else
         template<class T>
         AZ::Outcome<AZStd::shared_ptr<InstancePool<T>>, AZStd::string> CreatePool(
             typename InstancePool<T>::ResetInstance resetFunc = [](T&){}, 
             typename InstancePool<T>::CreateInstance createFunc = []() { return new T{}; })
+#endif // defined(CARBONATED)
         {
             return CreatePool<T>(GetDefaultName<T>(), resetFunc);
         }

--- a/Code/Framework/AzCore/Tests/Asset/AssetManagerLoadingTests.cpp
+++ b/Code/Framework/AzCore/Tests/Asset/AssetManagerLoadingTests.cpp
@@ -3350,7 +3350,11 @@ namespace UnitTest
                 BusDisconnect();
             }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+            void OnAssetReady([[maybe_unused]] Asset<AssetData> asset) override
+#else
             void OnAssetReady(Asset<AssetData> asset) override
+#endif // defined(CARBONATED)
             {
                 m_loadSignal->release();
             }
@@ -3542,7 +3546,11 @@ namespace UnitTest
                 BusDisconnect();
             }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+            void OnAssetReady([[maybe_unused]] Asset<AssetData> asset) override
+#else
             void OnAssetReady(Asset<AssetData> asset) override
+#endif // defined(CARBONATED)
             {
                 ColoredPrintf(COLOR_YELLOW, "ThreadA: OnAssetReady called \n");
                 m_onAssetReadySignal.release();

--- a/Code/Framework/AzCore/Tests/Math/Matrix3x4Tests.cpp
+++ b/Code/Framework/AzCore/Tests/Math/Matrix3x4Tests.cpp
@@ -1010,6 +1010,16 @@ namespace UnitTest
         EXPECT_NEAR(matrix2.GetTranspose3x3().GetDeterminant3x3(), expected2, 1e-3f);
     }
 
+#if defined(CARBONATED) // Fix Warning C4756 treated in VS17.14.x as error. The fix is copied from 2505.0.
+    // Use of INFINITY in newer Windows SDKs trigger a math overflow warning because it redefines INFINITY
+    // as (huge number * huge number) instead of the previous definition of just (huge number).  The multiplication
+    // operation triggers the overflow warning.
+
+    // We still want that warning globally in the code but we don't want it in this test, specifically, which uses it
+    // to validate that we can detect infinite matrices that come about from runtime operations.
+    AZ_PUSH_DISABLE_WARNING(4756, "-Wunknown-warning-option")  //warning C4756: overflow in constant arithmetic
+#endif // defined(CARBONATED)
+
     TEST(MATH_Matrix3x4, IsFinite)
     {
         AZ::Matrix3x4 matrix = AZ::Matrix3x4::CreateFromQuaternionAndTranslation(
@@ -1040,4 +1050,7 @@ namespace UnitTest
             }
         }
     }
+#if defined(CARBONATED) // Fix Warning C4756 treated in VS17.14.x as error. The fix is copied from 2505.0.
+    AZ_POP_DISABLE_WARNING
+#endif // defined(CARBONATED)
 } // namespace UnitTest

--- a/Code/Framework/AzCore/Tests/Script.cpp
+++ b/Code/Framework/AzCore/Tests/Script.cpp
@@ -326,7 +326,11 @@ namespace UnitTest
 
         virtual void OnEventConst() const {};
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        virtual BehaviorTestClass OnEventResultWithBehaviorClassParameter([[maybe_unused]] BehaviorTestClass data) { return BehaviorTestClass(); };
+#else
         virtual BehaviorTestClass OnEventResultWithBehaviorClassParameter(BehaviorTestClass data) { return BehaviorTestClass(); };
+#endif // defined(CARBONATED)
     };
 
     typedef AZ::EBus<BehaviorTestBusEvents> BehaviorTestBus;

--- a/Code/Framework/AzFramework/AzFramework/Archive/Archive.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Archive/Archive.cpp
@@ -1602,7 +1602,11 @@ namespace AZ::IO
     //////////////////////////////////////////////////////////////////////////
     // open the physical archive file - creates if it doesn't exist
     // returns nullptr if it's invalid or can't open the file
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors
+    AZStd::intrusive_ptr<INestedArchive> Archive::OpenArchive(AZStd::string_view szPath, AZStd::string_view bindRoot, uint32_t nFlags, [[maybe_unused]] AZStd::intrusive_ptr<AZ::IO::MemoryBlock> pData)
+#else
     AZStd::intrusive_ptr<INestedArchive> Archive::OpenArchive(AZStd::string_view szPath, AZStd::string_view bindRoot, uint32_t nFlags, AZStd::intrusive_ptr<AZ::IO::MemoryBlock> pData)
+#endif // defined(CARBONATED)
     {
         auto szFullPath = AZ::IO::FileIOBase::GetDirectInstance()->ResolvePath(szPath);
         if (!szFullPath)

--- a/Code/Framework/AzFramework/AzFramework/Archive/ArchiveBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Archive/ArchiveBus.h
@@ -26,7 +26,11 @@ namespace AZ::IO
         static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
         static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors
+        virtual void BundleOpened([[maybe_unused]] const char* bundleName, [[maybe_unused]] AZStd::shared_ptr<AzFramework::AssetBundleManifest> bundleManifest, [[maybe_unused]] const char* nextBundle, [[maybe_unused]] AZStd::shared_ptr<AzFramework::AssetRegistry> bundleCatalog) {}
+#else
         virtual void BundleOpened([[maybe_unused]] const char* bundleName, AZStd::shared_ptr<AzFramework::AssetBundleManifest> bundleManifest, [[maybe_unused]] const char* nextBundle, AZStd::shared_ptr<AzFramework::AssetRegistry> bundleCatalog) {}
+#endif // defined(CARBONATED)
         virtual void BundleClosed([[maybe_unused]] const char* bundleName) {}
 
         // Sent when a file is accessed through Archive

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableMonitor.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableMonitor.cpp
@@ -90,7 +90,11 @@ namespace AzFramework
         }
     }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    void SpawnableMonitor::OnAssetReady([[maybe_unused]] AZ::Data::Asset<AZ::Data::AssetData> asset)
+#else
     void SpawnableMonitor::OnAssetReady(AZ::Data::Asset<AZ::Data::AssetData> asset)
+#endif // defined(CARBONATED)
     {
         AZ_Assert(!m_isLoaded, "Trying to load spawnable %s (%s) for a second time.",
             asset.GetHint().c_str(), asset.GetId().ToString<AZStd::string>().c_str());

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ColorPicker/PaletteCardCollection.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/ColorPicker/PaletteCardCollection.cpp
@@ -206,7 +206,11 @@ namespace AzQtComponents
         }
     }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    QString PaletteCardCollection::uniquePaletteName([[maybe_unused]] QSharedPointer<PaletteCard> card, const QString& name) const
+#else
     QString PaletteCardCollection::uniquePaletteName(QSharedPointer<PaletteCard> card, const QString& name) const
+#endif // defined(CARBONATED)
     {
         const auto paletteNameExists = [this](const QString& name)
         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManagerNotificationBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManagerNotificationBus.h
@@ -23,7 +23,11 @@ namespace AzToolsFramework
         //////////////////////////////////////////////////////////////////////////
 
         //! Triggered when an action's enabled or checked state changes.
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        virtual void OnActionStateChanged([[maybe_unused]] AZStd::string actionIdentifier) {}
+#else
         virtual void OnActionStateChanged(AZStd::string actionIdentifier) {}
+#endif // defined(CARBONATED)
 
     protected:
         ~ActionManagerNotifications() = default;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Slice/SliceUtilities.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Slice/SliceUtilities.cpp
@@ -1029,7 +1029,11 @@ namespace AzToolsFramework
         }
 
         //=========================================================================
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        SliceTransaction::Result SlicePreSaveCallbackForWorldEntities([[maybe_unused]] SliceTransaction::TransactionPtr transaction, const char* fullPath, SliceTransaction::SliceAssetPtr& asset)
+#else
         SliceTransaction::Result SlicePreSaveCallbackForWorldEntities(SliceTransaction::TransactionPtr transaction, const char* fullPath, SliceTransaction::SliceAssetPtr& asset)
+#endif // defined(CARBONATED)
         {
             AZ_PROFILE_SCOPE(AzToolsFramework, "SliceUtilities::SlicePreSaveCallbackForWorldEntities");
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabSaveLoadHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabSaveLoadHandler.cpp
@@ -1022,8 +1022,13 @@ namespace AzToolsFramework
             return AZStd::move(unsavedPrefabsContainer);
         }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        void PrefabSaveHandler::SourceFileRemoved(
+            AZStd::string relativePath, [[maybe_unused]] AZStd::string scanFolder, [[maybe_unused]] AZ::Uuid sourceUUID)
+#else
         void PrefabSaveHandler::SourceFileRemoved(
             AZStd::string relativePath, AZStd::string scanFolder, [[maybe_unused]] AZ::Uuid sourceUUID)
+#endif // defined(CARBONATED)
         {
             // This gets triggered for every source file. We only need source files that are prefabs and are loaded in the current level.
             TemplateId loadedTemplateId = s_prefabSystemComponentInterface->GetTemplateIdFromFilePath(relativePath.c_str());

--- a/Code/Framework/AzToolsFramework/Tests/SliceUpgradeTestsData.h
+++ b/Code/Framework/AzToolsFramework/Tests/SliceUpgradeTestsData.h
@@ -128,12 +128,21 @@ namespace UnitTest
             AZ::SerializeContext* serializeContext = AZ::RttiCast<AZ::SerializeContext*>(reflection);
             if (serializeContext)
             {
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+                serializeContext->Class<TestComponentA_V1, AzToolsFramework::Components::EditorComponentBase>()
+                    ->Version(1)
+                    ->Field("NewData", &TestComponentA_V1::m_data)
+                    ->TypeChange<TestDataA, NewTestDataA>("Data", 0, 1, []([[maybe_unused]] TestDataA in) -> NewTestDataA {
+                        return NewTestDataA();
+                    })
+#else
                 serializeContext->Class<TestComponentA_V1, AzToolsFramework::Components::EditorComponentBase>()
                     ->Version(1)
                     ->Field("NewData", &TestComponentA_V1::m_data)
                     ->TypeChange<TestDataA, NewTestDataA>("Data", 0, 1, [](TestDataA in) -> NewTestDataA {
                         return NewTestDataA();
                     })
+#endif // defined(CARBONATED)
                     ->NameChange(0, 1, "Data", "NewData")
                     ;
             }

--- a/Code/Legacy/CryCommon/Mocks/ICryPakMock.h
+++ b/Code/Legacy/CryCommon/Mocks/ICryPakMock.h
@@ -78,8 +78,12 @@ struct CryPakMock
     MOCK_CONST_METHOD0(GetPakPriority, AZ::IO::FileSearchPriority());
     MOCK_CONST_METHOD1(GetFileOffsetOnMedia, uint64_t(AZStd::string_view szName));
     MOCK_CONST_METHOD1(GetFileMediaType, EStreamSourceMediaType(AZStd::string_view szName));
+#if defined(CARBONATED) // Fix broken mocks for tests in MSVS starting with v.17.12.4 / VC++17; the fix exists in 2505.0
+    MOCK_METHOD0(GetLevelPackOpenEvent, LevelPackOpenEvent*());
+    MOCK_METHOD0(GetLevelPackCloseEvent, LevelPackCloseEvent*());
+#else
     MOCK_METHOD0(GetLevelPackOpenEvent, auto()->LevelPackOpenEvent*);
     MOCK_METHOD0(GetLevelPackCloseEvent, auto()->LevelPackCloseEvent*);
-
+#endif // defined(CARBONATED)
 };
 

--- a/Code/Legacy/CrySystem/XML/XMLBinaryNode.h
+++ b/Code/Legacy/CrySystem/XML/XMLBinaryNode.h
@@ -91,7 +91,11 @@ public:
     virtual bool getAttributeByIndex(int index, XmlString& key, XmlString& value);
 
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    void copyAttributes([[maybe_unused]] XmlNodeRef fromNode) override { assert(0); };
+#else
     void copyAttributes(XmlNodeRef fromNode) override { assert(0); };
+#endif // defined(CARBONATED)
 
     //! Get XML Node attribute for specified key.
     const char* getAttr(const char* key) const override;

--- a/Code/Tools/AssetProcessor/native/AssetManager/AssetRequestHandler.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/AssetRequestHandler.cpp
@@ -290,7 +290,11 @@ namespace
         return response;
     }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    GetScanFoldersResponse HandleGetScanFoldersRequest([[maybe_unused]] MessageData<GetScanFoldersRequest> messageData)
+#else
     GetScanFoldersResponse HandleGetScanFoldersRequest(MessageData<GetScanFoldersRequest> messageData)
+#endif // defined(CARBONATED)
     {
         bool success = true;
         AZStd::vector<AZStd::string> scanFolders;
@@ -305,7 +309,11 @@ namespace
         return GetScanFoldersResponse(move(scanFolders));
     }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    GetAssetSafeFoldersResponse HandleGetAssetSafeFoldersRequest([[maybe_unused]] MessageData<GetAssetSafeFoldersRequest> messageData)
+#else
     GetAssetSafeFoldersResponse HandleGetAssetSafeFoldersRequest(MessageData<GetAssetSafeFoldersRequest> messageData)
+#endif // defined(CARBONATED)
     {
         bool success = true;
         AZStd::vector<AZStd::string> assetSafeFolders;

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -350,7 +350,11 @@ namespace AssetProcessor
     }
 
     //! A network request came in, Given a Job Run Key (from the above Job Request), asking for the actual log for that job.
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    GetAbsoluteAssetDatabaseLocationResponse AssetProcessorManager::ProcessGetAbsoluteAssetDatabaseLocationRequest([[maybe_unused]] MessageData<GetAbsoluteAssetDatabaseLocationRequest> messageData)
+#else
     GetAbsoluteAssetDatabaseLocationResponse AssetProcessorManager::ProcessGetAbsoluteAssetDatabaseLocationRequest(MessageData<GetAbsoluteAssetDatabaseLocationRequest> messageData)
+#endif // defined(CARBONATED)
     {
         GetAbsoluteAssetDatabaseLocationResponse response;
 

--- a/Code/Tools/AssetProcessor/native/tests/AssetProcessorMessagesTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/AssetProcessorMessagesTests.cpp
@@ -164,10 +164,17 @@ namespace AssetProcessorMessagesTests
             m_batchApplicationManager->InitAssetRequestHandler(m_assetRequestHandler);
             m_batchApplicationManager->ConnectAssetCatalog();
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+            QObject::connect(m_batchApplicationManager->m_connectionManager, &ConnectionManager::ConnectionError, []([[maybe_unused]] unsigned connId, [[maybe_unused]] QString error)
+                {
+                    AZ_Error("ConnectionManager", false, "%s", error.toUtf8().constData());
+                });
+#else
             QObject::connect(m_batchApplicationManager->m_connectionManager, &ConnectionManager::ConnectionError, [](unsigned /*connId*/, QString error)
                 {
                     AZ_Error("ConnectionManager", false, "%s", error.toUtf8().constData());
                 });
+#endif // defined(CARBONATED)
 
             ASSERT_TRUE(m_batchApplicationManager->m_applicationServer->startListening(AssetProcessorPort));
 

--- a/Code/Tools/AssetProcessor/native/tests/UnitTestUtilities.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/UnitTestUtilities.cpp
@@ -165,10 +165,17 @@ namespace UnitTests
         }
     }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    void MockMultiBuilderInfoHandler::ProcessJob(
+        [[maybe_unused]] AssetBuilderExtraInfo extraInfo,
+        [[maybe_unused]] const AssetBuilderSDK::ProcessJobRequest& request,
+        [[maybe_unused]] AssetBuilderSDK::ProcessJobResponse& response)
+#else
     void MockMultiBuilderInfoHandler::ProcessJob(
         AssetBuilderExtraInfo extraInfo,
         [[maybe_unused]] const AssetBuilderSDK::ProcessJobRequest& request,
         AssetBuilderSDK::ProcessJobResponse& response)
+#endif // defined(CARBONATED)
     {
         response.m_resultCode = AssetBuilderSDK::ProcessJobResultCode::ProcessJobResult_Success;
     }

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetManagerTestingBase.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetManagerTestingBase.cpp
@@ -158,6 +158,15 @@ namespace UnitTests
         m_rc = AZStd::make_unique<TestingRCController>(1, 1);
         m_rc->SetDispatchPaused(false);
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        QObject::connect(
+            m_rc.get(),
+            &AssetProcessor::RCController::FileFailed,
+            [this]([[maybe_unused]] auto entryIn)
+            {
+                m_fileFailed = true;
+            });
+#else
         QObject::connect(
             m_rc.get(),
             &AssetProcessor::RCController::FileFailed,
@@ -165,6 +174,7 @@ namespace UnitTests
             {
                 m_fileFailed = true;
             });
+#endif // defined(CARBONATED)
 
         QObject::connect(
             m_rc.get(),
@@ -225,6 +235,15 @@ namespace UnitTests
 
         AZStd::atomic_bool delayed = false;
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        QObject::connect(
+            m_assetProcessorManager.get(),
+            &AssetProcessor::AssetProcessorManager::ProcessingDelayed,
+            [&delayed]([[maybe_unused]] QString filePath)
+            {
+                delayed = true;
+            });
+#else
         QObject::connect(
             m_assetProcessorManager.get(),
             &AssetProcessor::AssetProcessorManager::ProcessingDelayed,
@@ -232,7 +251,17 @@ namespace UnitTests
             {
                 delayed = true;
             });
+#endif // defined(CARBONATED)
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        QObject::connect(
+            m_assetProcessorManager.get(),
+            &AssetProcessor::AssetProcessorManager::ProcessingResumed,
+            [&delayed]([[maybe_unused]] QString filePath)
+            {
+                delayed = false;
+            });
+#else
         QObject::connect(
             m_assetProcessorManager.get(),
             &AssetProcessor::AssetProcessorManager::ProcessingResumed,
@@ -240,6 +269,7 @@ namespace UnitTests
             {
                 delayed = false;
             });
+#endif // defined(CARBONATED)
 
         QCoreApplication::processEvents(); // execute CheckSource
 
@@ -417,6 +447,15 @@ namespace UnitTests
     void AssetManagerTestingBase::SetCatalogToUpdateOnJobCompletion()
     {
         using namespace AssetBuilderSDK;
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        QObject::connect(
+            m_rc.get(),
+            &AssetProcessor::RCController::FileCompiled,
+            [this](AssetProcessor::JobEntry entry, [[maybe_unused]] AssetBuilderSDK::ProcessJobResponse response)
+            {
+                QMetaObject::invokeMethod(m_rc.get(), "OnAddedToCatalog", Qt::QueuedConnection, Q_ARG(AssetProcessor::JobEntry, entry));
+            });
+#else
         QObject::connect(
             m_rc.get(),
             &AssetProcessor::RCController::FileCompiled,
@@ -424,6 +463,7 @@ namespace UnitTests
             {
                 QMetaObject::invokeMethod(m_rc.get(), "OnAddedToCatalog", Qt::QueuedConnection, Q_ARG(AssetProcessor::JobEntry, entry));
             });
+#endif // defined(CARBONATED)
     }
 
     AZStd::string AssetManagerTestingBase::MakePath(const char* filename, bool intermediate)

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
@@ -5621,7 +5621,11 @@ TEST_F(ChainJobDependencyTest, TestChainDependency_Multi)
 
     // Wait for the file compiled event and trigger OnAddedToCatalog with a delay, this is what causes rccontroller to process out of order
     AZStd::vector<JobEntry> finishedJobs;
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    QObject::connect(m_data->m_rcController.get(), &RCController::FileCompiled, [this, &finishedJobs](JobEntry entry, [[maybe_unused]] AssetBuilderSDK::ProcessJobResponse response)
+#else
     QObject::connect(m_data->m_rcController.get(), &RCController::FileCompiled, [this, &finishedJobs](JobEntry entry, AssetBuilderSDK::ProcessJobResponse response)
+#endif // defined(CARBONATED)
         {
             finishedJobs.push_back(entry);
 

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/MockAssetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/MockAssetProcessorManager.cpp
@@ -10,17 +10,29 @@
 
 namespace UnitTests
 {
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    void MockAssetProcessorManager::AssessAddedFile([[maybe_unused]] QString filePath)
+#else
     void MockAssetProcessorManager::AssessAddedFile(QString filePath)
+#endif // defined(CARBONATED)
     {
         m_events[TestEvents::Added].Signal();
     }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    void MockAssetProcessorManager::AssessModifiedFile([[maybe_unused]] QString filePath)
+#else
     void MockAssetProcessorManager::AssessModifiedFile(QString filePath)
+#endif // defined(CARBONATED)
     {
         m_events[TestEvents::Modified].Signal();
     }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    void MockAssetProcessorManager::AssessDeletedFile([[maybe_unused]] QString filePath)
+#else
     void MockAssetProcessorManager::AssessDeletedFile(QString filePath)
+#endif // defined(CARBONATED)
     {
         m_events[TestEvents::Deleted].Signal();
     }

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/MockFileProcessor.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/MockFileProcessor.cpp
@@ -10,12 +10,20 @@
 
 namespace UnitTests
 {
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    void MockFileProcessor::AssessAddedFile([[maybe_unused]] QString fileName)
+#else
      void MockFileProcessor::AssessAddedFile(QString fileName)
+#endif // defined(CARBONATED)
     {
         m_events[TestEvents::Added].Signal();
     }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    void MockFileProcessor::AssessDeletedFile([[maybe_unused]] QString fileName)
+#else
      void MockFileProcessor::AssessDeletedFile(QString fileName)
+#endif // defined(CARBONATED)
     {
         m_events[TestEvents::Deleted].Signal();
     }

--- a/Code/Tools/AssetProcessor/native/tests/resourcecompiler/RCControllerTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/resourcecompiler/RCControllerTest.cpp
@@ -222,7 +222,11 @@ TEST_F(RCcontrollerTest_Simple, DISABLED_SameJobIsCompletedMultipleTimes_Complet
     using namespace AssetProcessor;
 
     AZStd::vector<JobEntry> jobEntries;
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    QObject::connect(m_rcController.get(), &RCController::FileCompiled, [&jobEntries](JobEntry entry, [[maybe_unused]] AssetBuilderSDK::ProcessJobResponse response)
+#else
     QObject::connect(m_rcController.get(), &RCController::FileCompiled, [&jobEntries](JobEntry entry, AssetBuilderSDK::ProcessJobResponse response)
+#endif // defined(CARBONATED)
     {
         jobEntries.push_back(entry);
     });

--- a/Code/Tools/AssetProcessor/native/ui/ProductAssetDetailsPanel.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/ProductAssetDetailsPanel.cpp
@@ -260,10 +260,17 @@ namespace AssetProcessor
         m_ui->outgoingUnmetPathProductDependenciesList->adjustSize();
     }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    void ProductAssetDetailsPanel::BuildIncomingProductDependencies(
+        [[maybe_unused]] const AZStd::shared_ptr<const ProductAssetTreeItemData> productItemData,
+        const AZ::Data::AssetId& assetId,
+        const AZStd::string& platform)
+#else
     void ProductAssetDetailsPanel::BuildIncomingProductDependencies(
         const AZStd::shared_ptr<const ProductAssetTreeItemData> productItemData,
         const AZ::Data::AssetId& assetId,
         const AZStd::string& platform)
+#endif // defined(CARBONATED)
     {
 
         int incomingProductDependencyCount = 0;

--- a/Code/Tools/AssetProcessor/native/unittests/AssetRequestHandlerUnitTests.cpp
+++ b/Code/Tools/AssetProcessor/native/unittests/AssetRequestHandlerUnitTests.cpp
@@ -66,7 +66,11 @@ namespace AssetProcessor
             m_fenceId = fenceId;
             return m_fenceFileName;
         }
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        bool DeleteFenceFile([[maybe_unused]] QString fenceFileName) override
+#else
         bool DeleteFenceFile(QString fenceFileName) override
+#endif // defined(CARBONATED)
         {
             m_numTimesDeleteFenceFileCalled++;
             return m_deleteFenceFileResult;

--- a/Code/Tools/AssetProcessor/native/unittests/RCcontrollerUnitTests.cpp
+++ b/Code/Tools/AssetProcessor/native/unittests/RCcontrollerUnitTests.cpp
@@ -202,7 +202,11 @@ void RCcontrollerUnitTests::ConnectCompileGroupSignalsAndSlots(bool& gotCreated,
 
 void RCcontrollerUnitTests::ConnectJobSignalsAndSlots(bool& allJobsCompleted, JobEntry& completedJob)
 {
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    QObject::connect(m_rcController.get(), &RCController::FileCompiled, this, [&](JobEntry entry, [[maybe_unused]] AssetBuilderSDK::ProcessJobResponse response)
+#else
     QObject::connect(m_rcController.get(), &RCController::FileCompiled, this, [&](JobEntry entry, AssetBuilderSDK::ProcessJobResponse response)
+#endif // defined(CARBONATED)
         {
             completedJob = entry;
         });

--- a/Code/Tools/AssetProcessor/native/utilities/AssetUtilEBusHelper.h
+++ b/Code/Tools/AssetProcessor/native/utilities/AssetUtilEBusHelper.h
@@ -39,9 +39,17 @@ public:
 
     virtual ~AssetProcessorPlaformBusTraits() {}
     //Informs that the AP got a connection for this platform.
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    virtual void AssetProcessorPlatformConnected([[maybe_unused]] const AZStd::string platform) {}
+#else
     virtual void AssetProcessorPlatformConnected(const AZStd::string platform) {}
-    //Informs that a connection got disconnected for this platform.
+#endif // defined(CARBONATED)
+    // Informs that a connection got disconnected for this platform.
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    virtual void AssetProcessorPlatformDisconnected([[maybe_unused]] const AZStd::string platform) {}
+#else
     virtual void AssetProcessorPlatformDisconnected(const AZStd::string platform) {}
+#endif // defined(CARBONATED)
 };
 
 using AssetProcessorPlatformBus = AZ::EBus<AssetProcessorPlaformBusTraits>;

--- a/Code/Tools/AssetProcessor/native/utilities/BatchApplicationManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/BatchApplicationManager.cpp
@@ -98,7 +98,11 @@ const char* BatchApplicationManager::GetLogBaseName()
     return "AP_Batch";
 }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+ApplicationManager::RegistryCheckInstructions BatchApplicationManager::PopupRegistryProblemsMessage([[maybe_unused]] QString warningText)
+#else
 ApplicationManager::RegistryCheckInstructions BatchApplicationManager::PopupRegistryProblemsMessage(QString warningText)
+#endif // defined(CARBONATED)
 {
     return RegistryCheckInstructions::Exit;
 }

--- a/Code/Tools/AssetProcessor/native/utilities/BuilderManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/BuilderManager.cpp
@@ -66,7 +66,11 @@ namespace AssetProcessor
         }
     }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    void BuilderManager::IncomingBuilderPing(AZ::u32 connId, AZ::u32 /*type*/, AZ::u32 serial, QByteArray payload, [[maybe_unused]] QString platform)
+#else
     void BuilderManager::IncomingBuilderPing(AZ::u32 connId, AZ::u32 /*type*/, AZ::u32 serial, QByteArray payload, QString platform)
+#endif // defined(CARBONATED)
     {
         AssetBuilder::BuilderHelloRequest requestPing;
         AssetBuilder::BuilderHelloResponse responsePing;

--- a/Gems/AWSMetrics/Code/Tests/MetricsManagerTest.cpp
+++ b/Gems/AWSMetrics/Code/Tests/MetricsManagerTest.cpp
@@ -79,7 +79,11 @@ namespace AWSMetrics
         : public MetricsManager
     {
     private:
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        AZ::Outcome<void, AZStd::string> SendMetricsToFile([[maybe_unused]] AZStd::shared_ptr<MetricsQueue> metricsQueue) override
+#else
         AZ::Outcome<void, AZStd::string> SendMetricsToFile(AZStd::shared_ptr<MetricsQueue> metricsQueue) override
+#endif // defined(CARBONATED)
         {
             if (AZ::IO::FileIOBase::GetInstance())
             {

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Compressors/ISPCTextureCompressor.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Compressors/ISPCTextureCompressor.cpp
@@ -248,7 +248,11 @@ namespace ImageProcessingAtom
         return destinationImage;
     }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    IImageObjectPtr ISPCCompressor::DecompressImage([[maybe_unused]] IImageObjectPtr sourceImage, [[maybe_unused]] EPixelFormat destinationFormat) const
+#else
     IImageObjectPtr ISPCCompressor::DecompressImage(IImageObjectPtr sourceImage, [[maybe_unused]] EPixelFormat destinationFormat) const
+#endif // defined(CARBONATED)
     {
         return nullptr;
     }

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -1789,7 +1789,11 @@ namespace AZ
             OnAssetReady(asset);
         }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        void ModelDataInstance::MeshLoader::OnAssetError([[maybe_unused]] Data::Asset<Data::AssetData> asset)
+#else
         void ModelDataInstance::MeshLoader::OnAssetError(Data::Asset<Data::AssetData> asset)
+#endif // defined(CARBONATED)
         {
             // Note: m_modelAsset and asset represents same asset, but only m_modelAsset contains the file path in its hint from serialization
             AZ_Error(

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbe.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbe.cpp
@@ -39,7 +39,11 @@ namespace AZ
             }
         }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        void ReflectionProbe::OnAssetError([[maybe_unused]] Data::Asset<Data::AssetData> asset)
+#else
         void ReflectionProbe::OnAssetError(Data::Asset<Data::AssetData> asset)
+#endif // defined(CARBONATED)
         {
             AZ_Error("ReflectionProbe", false, "Failed to load ReflectionProbe dependency asset %s", asset.ToString<AZStd::string>().c_str());
             Data::AssetBus::Handler::BusDisconnect();

--- a/Gems/Atom/RHI/Code/Tests/Device.h
+++ b/Gems/Atom/RHI/Code/Tests/Device.h
@@ -69,7 +69,11 @@ namespace UnitTest
 
         AZ::RHI::ResourceMemoryRequirements GetResourceMemoryRequirements([[maybe_unused]] const AZ::RHI::BufferDescriptor& descriptor) { return AZ::RHI::ResourceMemoryRequirements{}; };
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        void ObjectCollectionNotify([[maybe_unused]] AZ::RHI::ObjectCollectorNotifyFunction notifyFunction) override {}
+#else
         void ObjectCollectionNotify(AZ::RHI::ObjectCollectorNotifyFunction notifyFunction) override {}
+#endif // defined(CARBONATED)
 
         AZ::RHI::ShadingRateImageValue ConvertShadingRate([[maybe_unused]] AZ::RHI::ShadingRate rate) const override
         {

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/RayTracingShaderTable.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/RayTracingShaderTable.cpp
@@ -47,12 +47,21 @@ namespace AZ
             return largestRecordSize;
         }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        RHI::Ptr<Buffer> RayTracingShaderTable::BuildTable([[maybe_unused]] RHI::Device& deviceBase,
+                                                           const RHI::RayTracingBufferPools& bufferPools,
+                                                           const RHI::RayTracingShaderTableRecordList& recordList,
+                                                           uint32_t shaderRecordSize,
+                                                           [[maybe_unused]] AZStd::wstring shaderTableName,
+                                                           Microsoft::WRL::ComPtr<ID3D12StateObjectProperties>& stateObjectProperties)
+#else
         RHI::Ptr<Buffer> RayTracingShaderTable::BuildTable([[maybe_unused]] RHI::Device& deviceBase,
                                                            const RHI::RayTracingBufferPools& bufferPools,
                                                            const RHI::RayTracingShaderTableRecordList& recordList,
                                                            uint32_t shaderRecordSize,
                                                            AZStd::wstring shaderTableName,
                                                            Microsoft::WRL::ComPtr<ID3D12StateObjectProperties>& stateObjectProperties)
+#endif // defined(CARBONATED)
         {
 
             uint32_t shaderTableSize = shaderRecordSize * static_cast<uint32_t>(recordList.size());

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/SceneBus.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/SceneBus.h
@@ -51,7 +51,11 @@ namespace AZ
             //! @deprecated use OnRenderPipelineChanged(RenderPipeline*, RenderPipelineChangeType::Added)
             //! Notifies when a render pipeline is added to this scene. 
             //! @param pipeline The render pipeline which was added
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors
+            virtual void OnRenderPipelineAdded([[maybe_unused]] RenderPipelinePtr pipeline) {};
+#else
             virtual void OnRenderPipelineAdded(RenderPipelinePtr pipeline) {};
+#endif // defined(CARBONATED)
                         
             //! O3DE_DEPRECATION_NOTICE(GHI-12687)
             //! @deprecated use OnRenderPipelineChanged(RenderPipeline*, RenderPipelineChangeType::PassChanged)
@@ -76,7 +80,11 @@ namespace AZ
             //! @param viewTag The viewTag in this render pipeline which the new view was set to
             //! @param newView The view which was set to the render pipeline's view tag
             //! @param previousView The previous view associates to render pipeline's view tag before the new view was set
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors
+            virtual void OnRenderPipelinePersistentViewChanged([[maybe_unused]] RenderPipeline* renderPipeline, [[maybe_unused]] PipelineViewTag viewTag, [[maybe_unused]] ViewPtr newView, [[maybe_unused]] ViewPtr previousView) {}
+#else
             virtual void OnRenderPipelinePersistentViewChanged([[maybe_unused]] RenderPipeline* renderPipeline, PipelineViewTag viewTag, ViewPtr newView, ViewPtr previousView) {}
+#endif // defined(CARBONATED)
 
             //! Notifies when the PrepareRender phase is beginning
             //! This phase is when data is read from the FeatureProcessors and written to the draw lists.

--- a/Gems/Atom/RPI/Code/Tests/Common/RHI/Stubs.h
+++ b/Gems/Atom/RPI/Code/Tests/Common/RHI/Stubs.h
@@ -72,7 +72,11 @@ namespace UnitTest
             void PreShutdown() override {}
             AZ::RHI::ResourceMemoryRequirements GetResourceMemoryRequirements([[maybe_unused]] const AZ::RHI::ImageDescriptor& descriptor) override { return AZ::RHI::ResourceMemoryRequirements{}; };
             AZ::RHI::ResourceMemoryRequirements GetResourceMemoryRequirements([[maybe_unused]] const AZ::RHI::BufferDescriptor& descriptor) override { return AZ::RHI::ResourceMemoryRequirements{}; };
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+            void ObjectCollectionNotify([[maybe_unused]] AZ::RHI::ObjectCollectorNotifyFunction notifyFunction) override {}
+#else
             void ObjectCollectionNotify(AZ::RHI::ObjectCollectorNotifyFunction notifyFunction) override {}
+#endif // defined(CARBONATED)
             AZ::RHI::ShadingRateImageValue ConvertShadingRate([[maybe_unused]] AZ::RHI::ShadingRate rate) const override
             {
                 return AZ::RHI::ShadingRateImageValue{};

--- a/Gems/Atom/RPI/Code/Tests/Common/TestFeatureProcessors.h
+++ b/Gems/Atom/RPI/Code/Tests/Common/TestFeatureProcessors.h
@@ -48,7 +48,11 @@ namespace UnitTest
         void Render(const RenderPacket&)  override {};
 
         // Overrides for scene notification bus handler
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        void OnRenderPipelinePersistentViewChanged(AZ::RPI::RenderPipeline* renderPipeline, [[maybe_unused]] AZ::RPI::PipelineViewTag viewTag, [[maybe_unused]] AZ::RPI::ViewPtr newView, [[maybe_unused]] AZ::RPI::ViewPtr previousView) override
+#else
         void OnRenderPipelinePersistentViewChanged(AZ::RPI::RenderPipeline* renderPipeline, AZ::RPI::PipelineViewTag viewTag, AZ::RPI::ViewPtr newView, AZ::RPI::ViewPtr previousView) override
+#endif // defined(CARBONATED)
         {
             m_viewSetCount++;
             m_lastPipeline = renderPipeline;

--- a/Gems/AtomLyIntegration/AtomBridge/Code/Source/AtomDebugDisplayViewportInterface.cpp
+++ b/Gems/AtomLyIntegration/AtomBridge/Code/Source/AtomDebugDisplayViewportInterface.cpp
@@ -151,7 +151,11 @@ namespace AZ::AtomBridge
     }
 
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    void AtomDebugDisplayViewportInterface::OnViewportDefaultViewChanged([[maybe_unused]] AZ::RPI::ViewPtr view)
+#else
     void AtomDebugDisplayViewportInterface::OnViewportDefaultViewChanged(AZ::RPI::ViewPtr view)
+#endif // defined(CARBONATED)
     {
         ResetRenderState();
         if (!m_defaultInstance)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Decals/DecalBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Decals/DecalBus.h
@@ -113,7 +113,11 @@ namespace AZ
 
             //! Signals that the material has changed
             //! @param materialAsset The material asset of the decal
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+            virtual void OnMaterialChanged([[maybe_unused]] Data::Asset<RPI::MaterialAsset> materialAsset){ }
+#else
             virtual void OnMaterialChanged(Data::Asset<RPI::MaterialAsset> materialAsset){ }
+#endif // defined(CARBONATED)
         };
 
         /// The EBus for decal notification events.

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.cpp
@@ -464,7 +464,11 @@ namespace AZ
             }
         }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        void EditorMaterialComponentSlot::OnAssetReloaded([[maybe_unused]] Data::Asset<Data::AssetData> asset)
+#else
         void EditorMaterialComponentSlot::OnAssetReloaded(Data::Asset<Data::AssetData> asset)
+#endif // defined(CARBONATED)
         {
             UpdatePreview();
         }

--- a/Gems/DiffuseProbeGrid/Code/Source/Components/DiffuseProbeGridComponentController.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Components/DiffuseProbeGridComponentController.cpp
@@ -204,7 +204,11 @@ namespace AZ
             m_boxChangedByGridEvent.Signal(true);
         }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        void DiffuseProbeGridComponentController::OnAssetReady([[maybe_unused]] Data::Asset<Data::AssetData> asset)
+#else
         void DiffuseProbeGridComponentController::OnAssetReady(Data::Asset<Data::AssetData> asset)
+#endif // defined(CARBONATED)
         {
             // if all assets are ready we can set the baked texture images
             if (m_configuration.m_bakedIrradianceTextureAsset.IsReady() &&

--- a/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
+++ b/Gems/DiffuseProbeGrid/Code/Source/Render/DiffuseProbeGridFeatureProcessor.cpp
@@ -860,8 +860,13 @@ namespace AZ
             m_needUpdatePipelineStates = true;
         }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        void DiffuseProbeGridFeatureProcessor::OnRenderPipelinePersistentViewChanged(
+            RPI::RenderPipeline* renderPipeline, RPI::PipelineViewTag viewTag, RPI::ViewPtr newView, [[maybe_unused]] RPI::ViewPtr previousView)
+#else
         void DiffuseProbeGridFeatureProcessor::OnRenderPipelinePersistentViewChanged(
             RPI::RenderPipeline* renderPipeline, RPI::PipelineViewTag viewTag, RPI::ViewPtr newView, RPI::ViewPtr previousView)
+#endif // defined(CARBONATED)
         {
             if (m_sceneAndViewShader)
             {

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/FileManager.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/FileManager.cpp
@@ -237,7 +237,11 @@ namespace EMStudio
         return false;
     }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    void FileManager::SourceFileChanged(AZStd::string relativePath, [[maybe_unused]] AZStd::string scanFolder, [[maybe_unused]] AZ::TypeId sourceTypeId)
+#else
     void FileManager::SourceFileChanged(AZStd::string relativePath, AZStd::string scanFolder, [[maybe_unused]] AZ::TypeId sourceTypeId)
+#endif // defined(CARBONATED)
     {
         AZStd::string filename;
         AZStd::string assetSourcePath = AZ::IO::FileIOBase::GetInstance()->GetAlias("@projectroot@");

--- a/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
@@ -611,11 +611,19 @@ namespace EMotionFX
 
                 if (dependencyAsset && dependencyAsset.GetType() == azrtti_typeid<AZ::RPI::ModelAsset>())
                 {
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+                    m_modelReloadedEventHandler = AZ::Render::ModelReloadedEvent::Handler(
+                        [this]([[maybe_unused]] AZ::Data::Asset<AZ::RPI::ModelAsset> modelAsset)
+                        {
+                            m_actorAsset.QueueLoad();
+                        });
+#else
                      m_modelReloadedEventHandler = AZ::Render::ModelReloadedEvent::Handler(
                         [this](AZ::Data::Asset<AZ::RPI::ModelAsset> modelAsset)
                         {
                             m_actorAsset.QueueLoad();
                         });
+#endif // defined(CARBONATED)
 
                     // Now that the ModelAsset has been found, request a reload.
                     // When this finishes, the callback will trigger a QueueLoad on m_actorAsset.

--- a/Gems/EditorPythonBindings/Code/Source/PythonMarshalComponent.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/PythonMarshalComponent.cpp
@@ -263,7 +263,11 @@ namespace EditorPythonBindings
             return aznew AZStd::any(address, valueInfo);
         }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        AZStd::optional<PythonMarshalTypeRequests::BehaviorValueResult> PythonToParameterWithProxy(EditorPythonBindings::PythonProxyObject* proxyObj, [[maybe_unused]] pybind11::object pyObj, AZ::BehaviorArgument& outValue)
+#else
         AZStd::optional<PythonMarshalTypeRequests::BehaviorValueResult> PythonToParameterWithProxy(EditorPythonBindings::PythonProxyObject* proxyObj, pybind11::object pyObj, AZ::BehaviorArgument& outValue)
+#endif // defined(CARBONATED)
         {
             auto behaviorObject = proxyObj->GetBehaviorObject();
             if (!behaviorObject)

--- a/Gems/EditorPythonBindings/Code/Tests/PythonGlobalsTests.cpp
+++ b/Gems/EditorPythonBindings/Code/Tests/PythonGlobalsTests.cpp
@@ -20,7 +20,11 @@
 
 namespace UnitTest
 {
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    void AcceptTwoStrings([[maybe_unused]] AZStd::string stringValue1, [[maybe_unused]] AZStd::string stringValue2)
+#else
     void AcceptTwoStrings(AZStd::string stringValue1, AZStd::string stringValue2)
+#endif // defined(CARBONATED)
     {
         AZ_TracePrintf("python", stringValue1.empty() ? "stringValue1_is_empty" : "stringValue1_has_data");
         AZ_TracePrintf("python", stringValue2.empty() ? "stringValue2_is_empty" : "stringValue2_has_data");

--- a/Gems/GameState/Code/Include/GameState/GameStateNotificationBus.h
+++ b/Gems/GameState/Code/Include/GameState/GameStateNotificationBus.h
@@ -31,8 +31,13 @@ namespace GameState
         //! Called when a game state transition occurs
         //! \param[in] oldGameState The old game state we are transitioning from (can be null)
         //! \param[in] newGameState The new game state we are transitioning into (can be null)
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        virtual void OnActiveGameStateChanged([[maybe_unused]] AZStd::shared_ptr<IGameState> oldGameState,
+                                              [[maybe_unused]] AZStd::shared_ptr<IGameState> newGameState) {}
+#else
         virtual void OnActiveGameStateChanged(AZStd::shared_ptr<IGameState> oldGameState,
                                               AZStd::shared_ptr<IGameState> newGameState) {}
+#endif // defined(CARBONATED)
     };
     using GameStateNotificationBus = AZ::EBus<GameStateNotifications>;
 } // namespace GameState

--- a/Gems/GameStateSamples/Code/Include/GameStateSamples/GameStatePrimaryUserMonitor.inl
+++ b/Gems/GameStateSamples/Code/Include/GameStateSamples/GameStatePrimaryUserMonitor.inl
@@ -41,8 +41,13 @@ namespace GameStateSamples
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    inline void GameStatePrimaryUserMonitor::OnActiveGameStateChanged(AZStd::shared_ptr<IGameState> oldGameState,
+                                                                      [[maybe_unused]] AZStd::shared_ptr<IGameState> newGameState)
+#else
     inline void GameStatePrimaryUserMonitor::OnActiveGameStateChanged(AZStd::shared_ptr<IGameState> oldGameState,
                                                                       AZStd::shared_ptr<IGameState> newGameState)
+#endif // defined(CARBONATED)
     {
         if (m_primaryUserSignedOutWhileLevelLoading &&
             azrtti_istypeof<GameStateLevelLoading>(oldGameState.get()))

--- a/Gems/GraphModel/Code/Include/GraphModel/GraphModelBus.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/GraphModelBus.h
@@ -233,11 +233,19 @@ namespace GraphModelIntegration
 
         //! Sent whenever a graph model slot value changes
         //! \param slot The slot that was modified in the graph.
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        virtual void OnGraphModelSlotModified([[maybe_unused]] GraphModel::SlotPtr slot) {};
+#else
         virtual void OnGraphModelSlotModified(GraphModel::SlotPtr slot){};
+#endif // defined(CARBONATED)
 
         //! Something in the graph has been modified
         //! \param node The node that was modified in the graph.  If this is nullptr, some metadata on the graph itself was modified
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        virtual void OnGraphModelGraphModified([[maybe_unused]] GraphModel::NodePtr node) {};
+#else
         virtual void OnGraphModelGraphModified(GraphModel::NodePtr node){};
+#endif // defined(CARBONATED)
 
         //! A request has been made to record data for an undoable operation 
         virtual void OnGraphModelRequestUndoPoint(){};

--- a/Gems/GraphModel/Code/Include/GraphModel/Integration/EditorMainWindow.h
+++ b/Gems/GraphModel/Code/Include/GraphModel/Integration/EditorMainWindow.h
@@ -50,7 +50,11 @@ namespace GraphModelIntegration
 
         /// Client can override this to handle click events on a wrapper node's action widget
         /// using a GraphModel::NodePtr instead of the lower-level GraphCanvas::NodeId
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        virtual void HandleWrapperNodeActionWidgetClicked([[maybe_unused]] GraphModel::NodePtr wrapperNode, [[maybe_unused]] const QRect& actionWidgetBoundingRect, [[maybe_unused]] const QPointF& scenePoint, [[maybe_unused]] const QPoint& screenPoint) {}
+#else
         virtual void HandleWrapperNodeActionWidgetClicked(GraphModel::NodePtr wrapperNode, [[maybe_unused]] const QRect& actionWidgetBoundingRect, [[maybe_unused]] const QPointF& scenePoint, [[maybe_unused]] const QPoint& screenPoint) {}
+#endif // defined(CARBONATED)
 
         /// Keep track of the graphs we create on behalf of the client when
         /// new editor dock widgets are created.

--- a/Gems/GraphModel/Code/Source/Model/Module/ModuleGraphManager.cpp
+++ b/Gems/GraphModel/Code/Source/Model/Module/ModuleGraphManager.cpp
@@ -44,7 +44,11 @@ namespace GraphModel
         AzToolsFramework::AssetSystemBus::Handler::BusDisconnect();
     }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    void ModuleGraphManager::SourceFileChanged(AZStd::string relativePath, [[maybe_unused]] AZStd::string scanFolder, AZ::Uuid sourceUUID)
+#else
     void ModuleGraphManager::SourceFileChanged(AZStd::string relativePath, AZStd::string scanFolder, AZ::Uuid sourceUUID)
+#endif // defined(CARBONATED)
     {
         AZStd::string extension;
         if (AzFramework::StringFunc::Path::GetExtension(relativePath.data(), extension) && extension == m_moduleFileExtension)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
@@ -674,7 +674,11 @@ namespace LandscapeCanvasEditor
         UpdateConnectionData(connection, false /* added */);
     }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    void MainWindow::PreOnGraphModelNodeWrapped([[maybe_unused]] GraphModel::NodePtr wrapperNode, GraphModel::NodePtr node)
+#else
     void MainWindow::PreOnGraphModelNodeWrapped(GraphModel::NodePtr wrapperNode, GraphModel::NodePtr node)
+#endif // defined(CARBONATED)
     {
         if (m_ignoreGraphUpdates)
         {

--- a/Gems/LyShine/Code/Include/LyShine/Animation/IUiAnimation.h
+++ b/Gems/LyShine/Code/Include/LyShine/Animation/IUiAnimation.h
@@ -1060,7 +1060,11 @@ struct IUiAnimationListener
     virtual ~IUiAnimationListener(){}
     //! callback on UI animation events
     virtual void OnUiAnimationEvent(EUiAnimationEvent uiAnimationEvent, IUiAnimSequence* pAnimSequence) = 0;
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    virtual void OnUiTrackEvent([[maybe_unused]] AZStd::string eventName, [[maybe_unused]] AZStd::string valueName, [[maybe_unused]] IUiAnimSequence* pAnimSequence) {}
+#else
     virtual void OnUiTrackEvent(AZStd::string eventName, AZStd::string valueName, [[maybe_unused]] IUiAnimSequence* pAnimSequence) {}
+#endif // defined(CARBONATED)
     // </interfuscator:shuffle>
 };
 

--- a/Gems/LyShine/Code/Include/LyShine/Bus/UiAnimationBus.h
+++ b/Gems/LyShine/Code/Include/LyShine/Bus/UiAnimationBus.h
@@ -116,7 +116,11 @@ public: // member functions
     virtual void OnUiAnimationEvent(IUiAnimationListener::EUiAnimationEvent uiAnimationEvent, AZStd::string animSequenceName) = 0;
 
     //! Called on animation track event triggered
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    virtual void OnUiTrackEvent([[maybe_unused]] AZStd::string eventName, [[maybe_unused]] AZStd::string valueName, [[maybe_unused]] AZStd::string animSequenceName) {}
+#else
     virtual void OnUiTrackEvent(AZStd::string eventName, AZStd::string valueName, AZStd::string animSequenceName) {}
+#endif // defined(CARBONATED)
 };
 
 typedef AZ::EBus<UiAnimationNotifications> UiAnimationNotificationBus;

--- a/Gems/LyShine/Code/Include/LyShine/Bus/UiVisualBus.h
+++ b/Gems/LyShine/Code/Include/LyShine/Bus/UiVisualBus.h
@@ -39,7 +39,11 @@ public: // member functions
 
     //! Set the override font, if this visual component uses a font this will override it
     //! \param font   If null the font on the visual component will not be overridden
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    virtual void SetOverrideFont([[maybe_unused]] FontFamilyPtr fontFamily) {};
+#else
     virtual void SetOverrideFont(FontFamilyPtr fontFamily) {};
+#endif // defined(CARBONATED)
 
     //! Set the override font effect, if this visual component uses a font this will override it
     virtual void SetOverrideFontEffect([[maybe_unused]] unsigned int fontEffectIndex) {};

--- a/Gems/LyShine/Code/Tests/AnimationTest.cpp
+++ b/Gems/LyShine/Code/Tests/AnimationTest.cpp
@@ -55,7 +55,11 @@ namespace UnitTest
             UiAnimationNotificationBus::Handler::BusDisconnect(m_busId);
         }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        void OnUiAnimationEvent([[maybe_unused]] IUiAnimationListener::EUiAnimationEvent uiAnimationEvent, [[maybe_unused]] AZStd::string animSequenceName) {};
+#else
         void OnUiAnimationEvent([[maybe_unused]] IUiAnimationListener::EUiAnimationEvent uiAnimationEvent, AZStd::string animSequenceName) {};
+#endif // defined(CARBONATED)
         void OnUiTrackEvent(AZStd::string eventName, AZStd::string valueName, AZStd::string animSequenceName)
         {
             m_recievedEvents.push_back(EventInfo{ eventName, valueName, animSequenceName });

--- a/Gems/MessagePopup/Code/Source/LyShineMessagePopup.cpp
+++ b/Gems/MessagePopup/Code/Source/LyShineMessagePopup.cpp
@@ -117,7 +117,11 @@ namespace MessagePopup
     }
 
     //-----------------------------------------------------------------------------
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    void LyShineMessagePopup::OnShowPopup(AZ::u32 _popupID, const AZStd::string& _message, EPopupButtons _buttons, EPopupKind _kind, [[maybe_unused]] AZStd::function<void(int _button)> _callback, void** _popupClientID)
+#else
     void LyShineMessagePopup::OnShowPopup(AZ::u32 _popupID, const AZStd::string& _message, EPopupButtons _buttons, EPopupKind _kind, AZStd::function<void(int _button)> _callback, void** _popupClientID)
+#endif // defined(CARBONATED)
     {
         AZ::EntityId canvasEntityId;
         bool isNavigationSupported = false;

--- a/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkEntityManager.cpp
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkEntityManager.cpp
@@ -643,8 +643,13 @@ namespace Multiplayer
         return ticket;
     }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    void NetworkEntityManager::OnRootSpawnableAssigned([[maybe_unused]] AZ::Data::Asset<AzFramework::Spawnable> rootSpawnable,
+        [[maybe_unused]] uint32_t generation)
+#else
     void NetworkEntityManager::OnRootSpawnableAssigned(AZ::Data::Asset<AzFramework::Spawnable> rootSpawnable,
         [[maybe_unused]] uint32_t generation)
+#endif // defined(CARBONATED)
     {
         auto* multiplayer = GetMultiplayer();
         const auto agentType = multiplayer->GetAgentType();

--- a/Gems/PhysX/Core/Code/Source/HeightfieldColliderComponent.cpp
+++ b/Gems/PhysX/Core/Code/Source/HeightfieldColliderComponent.cpp
@@ -110,7 +110,11 @@ namespace PhysX
         }
     }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    void HeightfieldColliderComponent::OnAssetError([[maybe_unused]] AZ::Data::Asset<AZ::Data::AssetData> asset)
+#else
     void HeightfieldColliderComponent::OnAssetError(AZ::Data::Asset<AZ::Data::AssetData> asset)
+#endif // defined(CARBONATED)
     {
         InitHeightfieldCollider(HeightfieldCollider::DataSource::GenerateNewHeightfield);
     }

--- a/Gems/ScriptCanvas/Code/Editor/GraphCanvas/Components/NodeDescriptors/FunctionNodeDescriptorComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/GraphCanvas/Components/NodeDescriptors/FunctionNodeDescriptorComponent.cpp
@@ -68,17 +68,29 @@ namespace ScriptCanvasEditor
         AZ::Data::AssetBus::Handler::BusDisconnect();
     }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    void FunctionNodeDescriptorComponent::OnAssetReloaded([[maybe_unused]] AZ::Data::Asset<AZ::Data::AssetData> asset)
+#else
     void FunctionNodeDescriptorComponent::OnAssetReloaded(AZ::Data::Asset<AZ::Data::AssetData> asset)
+#endif // defined(CARBONATED)
     {
         TriggerUpdate();
     }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    void FunctionNodeDescriptorComponent::OnAssetReloadError([[maybe_unused]] AZ::Data::Asset<AZ::Data::AssetData> asset)
+#else
     void FunctionNodeDescriptorComponent::OnAssetReloadError(AZ::Data::Asset<AZ::Data::AssetData> asset)
+#endif // defined(CARBONATED)
     {
         TriggerUpdate();
     }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    void FunctionNodeDescriptorComponent::OnAssetError([[maybe_unused]] AZ::Data::Asset<AZ::Data::AssetData> asset)
+#else
     void FunctionNodeDescriptorComponent::OnAssetError(AZ::Data::Asset<AZ::Data::AssetData> asset)
+#endif // defined(CARBONATED)
     {
         TriggerUpdate();
     }

--- a/Gems/ScriptCanvas/Code/Editor/GraphCanvas/Components/NodeDescriptors/ScriptEventReceiverNodeDescriptorComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/GraphCanvas/Components/NodeDescriptors/ScriptEventReceiverNodeDescriptorComponent.cpp
@@ -466,7 +466,11 @@ namespace ScriptCanvasEditor
         return this;
     }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    void ScriptEventReceiverNodeDescriptorComponent::OnAssetReloaded([[maybe_unused]] AZ::Data::Asset<AZ::Data::AssetData> asset)
+#else
     void ScriptEventReceiverNodeDescriptorComponent::OnAssetReloaded(AZ::Data::Asset<AZ::Data::AssetData> asset)
+#endif // defined(CARBONATED)
     {
         AZ::EntityId graphCanvasGraphId;
         GraphCanvas::SceneMemberRequestBus::EventResult(graphCanvasGraphId, GetEntityId(), &GraphCanvas::SceneMemberRequests::GetScene);

--- a/Gems/ScriptCanvas/Code/Editor/GraphCanvas/Components/NodeDescriptors/ScriptEventSenderNodeDescriptorComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/GraphCanvas/Components/NodeDescriptors/ScriptEventSenderNodeDescriptorComponent.cpp
@@ -74,7 +74,11 @@ namespace ScriptCanvasEditor
         SignalNeedsVersionConversion();
     }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    void ScriptEventSenderNodeDescriptorComponent::OnAssetReloaded([[maybe_unused]] AZ::Data::Asset<AZ::Data::AssetData> asset)
+#else
     void ScriptEventSenderNodeDescriptorComponent::OnAssetReloaded(AZ::Data::Asset<AZ::Data::AssetData> asset)
+#endif // defined(CARBONATED)
     {
         SignalNeedsVersionConversion();
     }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/AbstractCodeModel.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/AbstractCodeModel.cpp
@@ -606,7 +606,11 @@ namespace ScriptCanvas
             return AZStd::const_pointer_cast<Scope>(m_graphScope)->AddVariableName(name);
         }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        void AbstractCodeModel::AddUserOutToLeaf(ExecutionTreePtr parent, [[maybe_unused]] ExecutionTreeConstPtr root, AZStd::string_view name)
+#else
         void AbstractCodeModel::AddUserOutToLeaf(ExecutionTreePtr parent, ExecutionTreeConstPtr root, AZStd::string_view name)
+#endif // defined(CARBONATED)
         {
             ExecutionTreePtr out;
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/ParsingUtilities.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/ParsingUtilities.cpp
@@ -145,7 +145,11 @@ namespace ParsingUtilitiesCpp
             m_result += "\n";
         }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        void EvaluateRoot([[maybe_unused]] ExecutionTreeConstPtr node, const Slot*) override
+#else
         void EvaluateRoot(ExecutionTreeConstPtr node, const Slot*)
+#endif // defined(CARBONATED)
         {
             m_result += "\nRoot:\n";
         }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/ReceiveScriptEvent.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/ReceiveScriptEvent.cpp
@@ -140,7 +140,11 @@ namespace ScriptCanvas
                 }
             }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+            void ReceiveScriptEvent::InitializeEvent([[maybe_unused]] AZ::Data::Asset<ScriptEvents::ScriptEventsAsset> asset, int eventIndex, SlotIdMapping& populationMapping)
+#else
             void ReceiveScriptEvent::InitializeEvent(AZ::Data::Asset<ScriptEvents::ScriptEventsAsset> asset, int eventIndex, SlotIdMapping& populationMapping)
+#endif // defined(CARBONATED)
             {
                 if (!m_handler)
                 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/SendScriptEvent.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/SendScriptEvent.cpp
@@ -369,7 +369,11 @@ namespace ScriptCanvas
                 }
             }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+            bool SendScriptEvent::RegisterScriptEvent([[maybe_unused]] AZ::Data::Asset<ScriptEvents::ScriptEventsAsset> asset)
+#else
             bool SendScriptEvent::RegisterScriptEvent(AZ::Data::Asset<ScriptEvents::ScriptEventsAsset> asset)
+#endif // defined(CARBONATED)
             {
                 if (!m_scriptEvent)
                 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Translation/GraphToLua.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Translation/GraphToLua.cpp
@@ -1501,7 +1501,11 @@ namespace ScriptCanvas
             }
         }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        void GraphToLua::WriteDebugInfoVariableChange([[maybe_unused]] Grammar::ExecutionTreeConstPtr execution, Grammar::OutputAssignmentConstPtr output)
+#else
         void GraphToLua::WriteDebugInfoVariableChange(Grammar::ExecutionTreeConstPtr execution, Grammar::OutputAssignmentConstPtr output)
+#endif // defined(CARBONATED)
         {
             if (IsDebugInfoWritten())
             {
@@ -1663,7 +1667,11 @@ namespace ScriptCanvas
             }
         }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        void GraphToLua::WriteFunctionCallNullCheckPost([[maybe_unused]] Grammar::ExecutionTreeConstPtr execution)
+#else
         void GraphToLua::WriteFunctionCallNullCheckPost(Grammar::ExecutionTreeConstPtr execution)
+#endif // defined(CARBONATED)
         {
             m_dotLua.Outdent();
             m_dotLua.WriteLineIndented("end");

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Translation/GraphToLuaUtility.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Translation/GraphToLuaUtility.cpp
@@ -29,7 +29,11 @@ namespace ScriptCanvas
     namespace Translation
     {
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        void CheckConversionStringPost(Writer& writer, [[maybe_unused]] Grammar::VariableConstPtr source, const Grammar::ConversionByIndex& conversions, size_t index)
+#else
         void CheckConversionStringPost(Writer& writer, Grammar::VariableConstPtr source, const Grammar::ConversionByIndex& conversions, size_t index)
+#endif // defined(CARBONATED)
         {
             auto iter = conversions.find(index);
             if (iter == conversions.end())

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Translation/GraphToLuaUtility.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Translation/GraphToLuaUtility.cpp
@@ -77,7 +77,11 @@ namespace ScriptCanvas
             }
         }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        void CheckConversionStringPre(Writer& writer, [[maybe_unused]] Grammar::VariableConstPtr source, const Grammar::ConversionByIndex& conversions, size_t index)
+#else
         void CheckConversionStringPre(Writer& writer, Grammar::VariableConstPtr source, const Grammar::ConversionByIndex& conversions, size_t index)
+#endif // defined(CARBONATED)
         {
             auto iter = conversions.find(index);
             if (iter == conversions.end())

--- a/Gems/ScriptEvents/Code/Include/ScriptEvents/ScriptEventsAssetRef.h
+++ b/Gems/ScriptEvents/Code/Include/ScriptEvents/ScriptEventsAssetRef.h
@@ -82,7 +82,11 @@ namespace ScriptEvents
         void OnAssetReloaded(AZ::Data::Asset<AZ::Data::AssetData> asset) override;
         void OnAssetUnloaded(const AZ::Data::AssetId assetId, const AZ::Data::AssetType assetType) override;
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        void OnAssetSaved([[maybe_unused]] AZ::Data::Asset<AZ::Data::AssetData> asset, [[maybe_unused]] bool isSuccessful) override
+#else
         void OnAssetSaved(AZ::Data::Asset<AZ::Data::AssetData> asset, [[maybe_unused]] bool isSuccessful) override
+#endif // defined(CARBONATED)
         {
             SetAsset(m_asset);
         }

--- a/Gems/ScriptEvents/Code/Source/Editor/ScriptEventsSystemEditorComponent.cpp
+++ b/Gems/ScriptEvents/Code/Source/Editor/ScriptEventsSystemEditorComponent.cpp
@@ -166,7 +166,11 @@ namespace ScriptEventsEditor
         scriptEventAsset->m_definition.IncreaseVersion();
     }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    void ScriptEventAssetHandler::BeforePropertyEdit(AzToolsFramework::InstanceDataNode* node, [[maybe_unused]] AZ::Data::Asset<AZ::Data::AssetData> asset)
+#else
     void ScriptEventAssetHandler::BeforePropertyEdit(AzToolsFramework::InstanceDataNode* node, AZ::Data::Asset<AZ::Data::AssetData> asset)
+#endif // defined(CARBONATED)
     {
         ScriptEventData::VersionedProperty* property = nullptr;
         AzToolsFramework::InstanceDataNode* parent = node;

--- a/Gems/ScriptEvents/Code/Source/ScriptEventsAssetRef.cpp
+++ b/Gems/ScriptEvents/Code/Source/ScriptEventsAssetRef.cpp
@@ -99,7 +99,11 @@ namespace ScriptEvents
         return AZ::Edit::PropertyRefreshLevels::None;
     }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+    void ScriptEventsAssetRef::OnAssetReady([[maybe_unused]] AZ::Data::Asset<AZ::Data::AssetData> asset)
+#else
     void ScriptEventsAssetRef::OnAssetReady(AZ::Data::Asset<AZ::Data::AssetData> asset)
+#endif // defined(CARBONATED)
     {
         if (ScriptEventsAsset* scriptEventAsset = m_asset.GetAs<ScriptEventsAsset>())
         {

--- a/Gems/ScriptEvents/Code/Tests/Tests/ScriptEventsTest_Core.cpp
+++ b/Gems/ScriptEvents/Code/Tests/Tests/ScriptEventsTest_Core.cpp
@@ -231,7 +231,11 @@ namespace ScriptEventsTests
             AZ::Data::AssetBus::Handler::BusDisconnect();
         }
         
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        void OnAssetError([[maybe_unused]] AZ::Data::Asset<AZ::Data::AssetData> assetData) override
+#else
         void OnAssetError(AZ::Data::Asset<AZ::Data::AssetData> assetData) override
+#endif // defined(CARBONATED)
         {
             EXPECT_TRUE(false);
             AZ::Data::AssetBus::Handler::BusDisconnect();
@@ -247,7 +251,11 @@ namespace ScriptEventsTests
             m_onReadyCallback();
         }
 
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        void OnAssetSaved([[maybe_unused]] AZ::Data::Asset<AZ::Data::AssetData> asset, [[maybe_unused]] bool isSuccessful) override
+#else
         void OnAssetSaved(AZ::Data::Asset<AZ::Data::AssetData> asset, [[maybe_unused]] bool isSuccessful) override
+#endif // defined(CARBONATED)
         {
             AZ::Data::AssetBus::Handler::BusDisconnect();
             AZ::Data::AssetManager::Instance().DispatchEvents();

--- a/Gems/Vegetation/Code/Tests/PrefabInstanceSpawnerTests.cpp
+++ b/Gems/Vegetation/Code/Tests/PrefabInstanceSpawnerTests.cpp
@@ -127,10 +127,17 @@ namespace UnitTest
         {
             assetTypes.push_back(AZ::AzTypeInfo<AzFramework::Spawnable>::Uuid());
         }
+#if defined(CARBONATED) // Fix Warnings C4100 treated in VS17.14.x as errors.
+        AZ::Data::AssetHandler::LoadResult LoadAssetData(
+            const AZ::Data::Asset<AZ::Data::AssetData>& asset,
+            [[maybe_unused]] AZStd::shared_ptr<AZ::Data::AssetDataStream> stream,
+            [[maybe_unused]] const AZ::Data::AssetFilterCB& assetLoadFilterCB) override
+#else
         AZ::Data::AssetHandler::LoadResult LoadAssetData(
             const AZ::Data::Asset<AZ::Data::AssetData>& asset,
             AZStd::shared_ptr<AZ::Data::AssetDataStream> stream,
             [[maybe_unused]] const AZ::Data::AssetFilterCB& assetLoadFilterCB) override
+#endif // defined(CARBONATED)
         {
             MockAssetData* temp = reinterpret_cast<MockAssetData*>(asset.GetData());
             temp->SetStatus(AZ::Data::AssetData::AssetStatus::Ready);


### PR DESCRIPTION
## What does this PR do?

With newer Windows SDK and newer MS VS compilers (v.17.12.x-17.14.x) some legacy code started generating compilation errors on certain warnings.
In this PR:
* Warnings C4100 treated in VS17.14.x as errors, are fixed adding `[[maybe_unused]]` where needed in argument lists.
* Some Warnings C4100 appeared in `Release` build only, where arguments were used only in `AZ_Assert()` / `AZ_Error()` / `AZ_Info()`, etc. becoming `noop`.
* Also 2 fixes for warnings treated as errors are copied from 2505.0 release codebase;
* All patches are under  `#if defined(CARBONATED)` .. `#endif // defined(CARBONATED)` fences, legacy code preseved in `#else` part.

Pair PR to Gruber:  https://github.com/carbonated-dev/o3de-gruber/pull/1529

## How was this PR tested?

`ALL_BUILD` built in `Profile` and `Release` with Microsoft Visual Studio Community 2022 (64-bit) Version 17.14.7 (latest as of now).
Editor and game runs.

Jenkins multi-platform builds succeded:
1.  http://10.0.1.100:8080/blue/organizations/jenkins/MadWorld%2FClient-O3DE/detail/build%2FNOTICKET-fix-warnings-C4100/2/pipeline/ - with 1st commits to both branches;
2. http://10.0.1.100:8080/job/MadWorld/job/Client-O3DE/job/build%252FNOTICKET-fix-warnings-C4100/3/  - with 2nd commits to both branches.

BTW, default VULKAN exceeds 3Gb capacity of my GF 1060.

