### PR TITLE
MAD-18368 The code to check that InAppPurchases are supported on the current platform.

### DIFF
--- a/Gems/InAppPurchases/Code/Include/InAppPurchases/InAppPurchasesBus.h
+++ b/Gems/InAppPurchases/Code/Include/InAppPurchases/InAppPurchasesBus.h
@@ -47,6 +47,9 @@ namespace InAppPurchases
 #if defined(CARBONATED)  // PR375
         virtual AZStd::string GetTransactionReceipt() const { return ""; }
 #endif
+#if defined(CARBONATED) && defined(CARBONATED_CHECK_PURCHASE_SUPPORT)
+        virtual bool IsInAppPurchaseSupported() const { return false; }
+#endif
         
         // This should be called when a user buys any consumable product(like virtual currency). Otherwise, the user will not be able to buy this product again.
         virtual void ConsumePurchase(const AZStd::string& purchaseToken) const = 0;

--- a/Gems/InAppPurchases/Code/Include/InAppPurchases/InAppPurchasesInterface.h
+++ b/Gems/InAppPurchases/Code/Include/InAppPurchases/InAppPurchasesInterface.h
@@ -165,7 +165,10 @@ namespace InAppPurchases
 #if defined(CARBONATED) // PR375
         virtual AZStd::string GetTransactionReceipt() const { return ""; }
 #endif
-        
+#if defined(CARBONATED) && defined(CARBONATED_CHECK_PURCHASE_SUPPORT)
+        virtual bool IsInAppPurchaseSupported() const { return false; }
+#endif
+
         virtual void ConsumePurchase(const AZStd::string& purchaseToken) const = 0;
         
         virtual void FinishTransaction(const AZStd::string& transactionId, bool downloadHostedContent) const = 0;

--- a/Gems/InAppPurchases/Code/Source/InAppPurchasesSystemComponent.cpp
+++ b/Gems/InAppPurchases/Code/Source/InAppPurchasesSystemComponent.cpp
@@ -281,6 +281,14 @@ namespace InAppPurchases
     }
 #endif
 
+#if defined(CARBONATED) && defined(CARBONATED_CHECK_PURCHASE_SUPPORT)
+    bool SystemComponent::IsInAppPurchaseSupported() const
+    {
+        return InAppPurchasesInterface::GetInstance() != nullptr;
+    }
+#endif
+
+
     void SystemComponent::ConsumePurchase(const AZStd::string& purchaseToken) const
     {
         if (InAppPurchasesInterface::GetInstance() != nullptr)

--- a/Gems/InAppPurchases/Code/Source/InAppPurchasesSystemComponent.cpp
+++ b/Gems/InAppPurchases/Code/Source/InAppPurchasesSystemComponent.cpp
@@ -72,6 +72,9 @@ namespace InAppPurchases
                 ->Event("QueryPurchasedProducts", &InAppPurchasesRequestBus::Events::QueryPurchasedProducts)
                 ->Event("ConsumePurchase", &InAppPurchasesRequestBus::Events::ConsumePurchase)
                 ->Event("FinishTransaction", &InAppPurchasesRequestBus::Events::FinishTransaction)
+#if defined(CARBONATED) && defined(CARBONATED_CHECK_PURCHASE_SUPPORT)
+                ->Event("IsInAppPurchaseSupported", &InAppPurchasesRequestBus::Events::IsInAppPurchaseSupported)
+#endif
                 ;
 
             behaviorContext->EBus<InAppPurchasesResponseAccessorBus>("InAppPurchasesResponseAccessorBus")

--- a/Gems/InAppPurchases/Code/Source/InAppPurchasesSystemComponent.h
+++ b/Gems/InAppPurchases/Code/Source/InAppPurchasesSystemComponent.h
@@ -53,6 +53,9 @@ namespace InAppPurchases
 #if defined(CARBONATED)  // PR375
         AZStd::string GetTransactionReceipt() const override;
 #endif
+#if defined(CARBONATED) && defined(CARBONATED_CHECK_PURCHASE_SUPPORT)
+        bool IsInAppPurchaseSupported() const override;
+#endif
         
         void ConsumePurchase(const AZStd::string& purchaseToken) const override;
         


### PR DESCRIPTION
## What does this PR do?

During navigation through the menus in the Editor and the standalone client the user may try to purchase some item.
InApp purchases are not supported in the Editor and in the standalone client and the info about that is put into the log but the blocking spinner screen is never disappeared so the user have to terminate the application.
The method IsInAppPurchaseSupported has been implemented in the Engine to process this situation

## How was this PR tested?

In the standalone build try to purchase some item. The blocking spinner now disappears and the user can continue navigating.
