### PR TITLE
MAD-18377 Fixes in python script to support overrides for the splash screen and icons on Android

### DIFF
--- a/scripts/o3de/o3de/android_support.py
+++ b/scripts/o3de/o3de/android_support.py
@@ -2074,18 +2074,20 @@ class AndroidProjectGenerator(object):
         if not splash_overrides:
             return
             
-# CARBONATED -- begin : process orientation for custom splash screens
-        orientation = az_android_package_env['ANDROID_SCREEN_ORIENTATION']
+# CARBONATED -- begin : process 'orientation' for custom splash screens
+        orientation_source = az_android_package_env['ANDROID_SCREEN_ORIENTATION']
 
         # Check orientation type and convert if needed
-        if isinstance(orientation, str):
-            if orientation not in ORIENTATION_MAPPING:
+        if isinstance(orientation_source, str):
+            if orientation_source not in ORIENTATION_MAPPING:
                 raise RuntimeError(
                     f'Invalid orientation "{orientation}" in android_project.json. '
                     f'Expected one of: {list(ORIENTATION_MAPPING.keys())}'
                 )
-            orientation = ORIENTATION_MAPPING[orientation]
-        elif not isinstance(orientation, int):
+            orientation = ORIENTATION_MAPPING[orientation_source]
+        elif isinstance(orientation_source, int):
+            orientation = orientation_source
+        else:
             raise RuntimeError(
                 f'ANDROID_SCREEN_ORIENTATION must be a string or int in android_project.json. '
                 f'Got: {type(orientation).__name__}'

--- a/scripts/o3de/o3de/android_support.py
+++ b/scripts/o3de/o3de/android_support.py
@@ -2075,8 +2075,8 @@ class AndroidProjectGenerator(object):
             return
             
 # CARBONATED -- begin : process 'orientation' for custom splash screens
-        VALID_ORIENTATIONS = {ORIENTATION_LANDSCAPE, ORIENTATION_PORTRAIT, ORIENTATION_ALL}
         orientation_source = az_android_package_env['ANDROID_SCREEN_ORIENTATION']
+        orientation = ORIENTATION_LANDSCAPE
 
         # Check orientation type and convert if needed
         if isinstance(orientation_source, str):
@@ -2087,6 +2087,7 @@ class AndroidProjectGenerator(object):
                 )
             orientation = ORIENTATION_MAPPING[orientation_source]
         elif isinstance(orientation_source, int):
+            VALID_ORIENTATIONS = {ORIENTATION_LANDSCAPE, ORIENTATION_PORTRAIT, ORIENTATION_ALL}
             if orientation_source not in VALID_ORIENTATIONS:
                 raise RuntimeError(
                     f'Invalid numeric orientation "{orientation}" in android_project.json. '

--- a/scripts/o3de/o3de/android_support.py
+++ b/scripts/o3de/o3de/android_support.py
@@ -1989,8 +1989,9 @@ class AndroidProjectGenerator(object):
             # Always return itself if the path is already and absolute path
             return Path(source_path)
 
-        game_gem_resources = self._project_path / 'Gem' / 'Resources'
-        if game_gem_resources.is_dir(game_gem_resources):
+        # game_gem_resources = self._project_path / 'Gem' / 'Resources' # CARBONATED. Let's use splashes/icons from '<project>/Resources/' subdirectory
+        game_gem_resources = self._project_path / 'Resources'
+        if game_gem_resources.is_dir():
             # If the source is relative and the game gem's resource is present, construct the path based on that
             return game_gem_resources / source_path
 
@@ -2031,7 +2032,7 @@ class AndroidProjectGenerator(object):
         for resolution in ANDROID_RESOLUTION_SETTINGS:
 
             target_directory = dst_resource_path / f'{MIPMAP_PATH_PREFIX}-{resolution}'
-            target_directory.mkdir(parent=True, exist_ok=True)
+            target_directory.mkdir(parents=True, exist_ok=True)
 
             # get the current resolution icon override
             icon_source = icon_overrides.get(resolution, default_icon)
@@ -2072,8 +2073,28 @@ class AndroidProjectGenerator(object):
         splash_overrides = az_android_package_env['SPLASH_SCREEN']
         if not splash_overrides:
             return
+            
+# CARBONATED -- begin : process orientation for custom splash screens
+        orientation = az_android_package_env['ANDROID_SCREEN_ORIENTATION']
 
-        orientation = az_android_package_env['ORIENTATION']
+        # Check orientation type and convert if needed
+        if isinstance(orientation, str):
+            if orientation not in ORIENTATION_MAPPING:
+                raise RuntimeError(
+                    f'Invalid orientation "{orientation}" in android_project.json. '
+                    f'Expected one of: {list(ORIENTATION_MAPPING.keys())}'
+                )
+            orientation = ORIENTATION_MAPPING[orientation]
+        elif not isinstance(orientation, int):
+            raise RuntimeError(
+                f'ANDROID_SCREEN_ORIENTATION must be a string or int in android_project.json. '
+                f'Got: {type(orientation).__name__}'
+            )
+            
+# CARBONATED -- original code below
+        """ orientation = az_android_package_env['ORIENTATION'] """
+# CARBONATED -- end
+        
         drawable_path_prefix = 'drawable-'
 
         for orientation_flag, orientation_key in ORIENTATION_FLAG_TO_KEY_MAP.items():

--- a/scripts/o3de/o3de/android_support.py
+++ b/scripts/o3de/o3de/android_support.py
@@ -2075,6 +2075,7 @@ class AndroidProjectGenerator(object):
             return
             
 # CARBONATED -- begin : process 'orientation' for custom splash screens
+        VALID_ORIENTATIONS = {ORIENTATION_LANDSCAPE, ORIENTATION_PORTRAIT, ORIENTATION_ALL}
         orientation_source = az_android_package_env['ANDROID_SCREEN_ORIENTATION']
 
         # Check orientation type and convert if needed
@@ -2086,6 +2087,11 @@ class AndroidProjectGenerator(object):
                 )
             orientation = ORIENTATION_MAPPING[orientation_source]
         elif isinstance(orientation_source, int):
+            if orientation_source not in VALID_ORIENTATIONS:
+                raise RuntimeError(
+                    f'Invalid numeric orientation "{orientation}" in android_project.json. '
+                    f'Expected one of: {VALID_ORIENTATIONS}'
+                )
             orientation = orientation_source
         else:
             raise RuntimeError(


### PR DESCRIPTION
## What does this PR do?

The script scripts/o3de/o3de/android_support.py contains methods to support splash screen and icons overrides for the android builds but it has never been tested and contained as syntax as logical errors. 

This scripts reads configuration from <project>/Platform/Android/android_project.json like:
`
{
    "Tags": [
        "Android"
    ],
    "android_settings": {
        "package_name": "com.carbonated.madworld.android",
        "version_number": 0,
        "version_name": "1.0.3",
        "orientation": "landscape"
        "orientation": "landscape",
        "splash_screen": {
          "land": {
            "default": "Platform/Android/app_splash-default.png",
            "mdpi": "Platform/Android/app_splash-mdpi.png",
            "hdpi": "Platform/Android/app_splash-hdpi.png",
            "xhdpi": "Platform/Android/app_splash-xhdpi.png",
            "xxhdpi": "Platform/Android/app_splash-xxhdpi.png"
          }
        },
        "icons": {
          "mdpi": "Platform/Android/app_icon-mdpi.png",
          "hdpi": "Platform/Android/app_icon-hdpi.png",
          "xhdpi": "Platform/Android/app_icon-xhdpi.png",
          "xxhdpi": "Platform/Android/app_icon-xxhdpi.png",
          "xxxhdpi": "Platform/Android/app_icon-xxxhdpi.png"
        }
    }
}`


## How was this PR tested?

APK was built and installed on the android device. Now it contains game's icon and splash screen.
