### PR TITLE
Build/vlagutin/mad 18409 launch on samsung a53

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -1262,10 +1262,8 @@ namespace AZ
             const uint32_t majorVersion = VK_VERSION_MAJOR(physicalDeviceVersion);
             const uint32_t minorVersion = VK_VERSION_MINOR(physicalDeviceVersion);
             m_features.m_signalFenceFromCPU = (majorVersion > 1 || minorVersion > 1) ? physicalDevice.GetPhysicalDeviceTimelineSemaphoreFeatures().timelineSemaphore : false;
-            AZ_Printf("LVB", "Vulkan versions=%i.%i\n", majorVersion, minorVersion);
 #else
             m_features.m_signalFenceFromCPU = physicalDevice.GetPhysicalDeviceTimelineSemaphoreFeatures().timelineSemaphore;
-            AZ_Printf("LVB", "NO CARBONATED_DISABLE_TIMELINE_SEMAPHORES defined\n");
 #endif
 #endif
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -1257,7 +1257,16 @@ namespace AZ
 #ifdef DISABLE_TIMELINE_SEMAPHORES
             m_features.m_signalFenceFromCPU = false;
 #else
+#if defined(CARBONATED) && defined(CARBONATED_DISABLE_TIMELINE_SEMAPHORES_IF_VK_LESS_1_2)
+            const uint32_t physicalDeviceVersion = physicalDevice.GetVulkanVersion();
+            const uint32_t majorVersion = VK_VERSION_MAJOR(physicalDeviceVersion);
+            const uint32_t minorVersion = VK_VERSION_MINOR(physicalDeviceVersion);
+            m_features.m_signalFenceFromCPU = (majorVersion > 1 || minorVersion > 1) ? physicalDevice.GetPhysicalDeviceTimelineSemaphoreFeatures().timelineSemaphore : false;
+            AZ_Printf("LVB", "Vulkan versions=%i.%i\n", majorVersion, minorVersion);
+#else
             m_features.m_signalFenceFromCPU = physicalDevice.GetPhysicalDeviceTimelineSemaphoreFeatures().timelineSemaphore;
+            AZ_Printf("LVB", "NO CARBONATED_DISABLE_TIMELINE_SEMAPHORES defined\n");
+#endif
 #endif
 
             const auto& deviceLimits = physicalDevice.GetDeviceLimits();

--- a/scripts/o3de/o3de/android_support.py
+++ b/scripts/o3de/o3de/android_support.py
@@ -2081,7 +2081,7 @@ class AndroidProjectGenerator(object):
         # Check orientation type and convert if needed
         if isinstance(orientation_source, str):
             if orientation_source not in ORIENTATION_MAPPING:
-                raise RuntimeError(
+                raise AndroidToolError(
                     f'Invalid orientation "{orientation}" in android_project.json. '
                     f'Expected one of: {list(ORIENTATION_MAPPING.keys())}'
                 )
@@ -2089,13 +2089,13 @@ class AndroidProjectGenerator(object):
         elif isinstance(orientation_source, int):
             VALID_ORIENTATIONS = {ORIENTATION_LANDSCAPE, ORIENTATION_PORTRAIT, ORIENTATION_ALL}
             if orientation_source not in VALID_ORIENTATIONS:
-                raise RuntimeError(
+                raise AndroidToolError(
                     f'Invalid numeric orientation "{orientation}" in android_project.json. '
                     f'Expected one of: {VALID_ORIENTATIONS}'
                 )
             orientation = orientation_source
         else:
-            raise RuntimeError(
+            raise AndroidToolError(
                 f'ANDROID_SCREEN_ORIENTATION must be a string or int in android_project.json. '
                 f'Got: {type(orientation).__name__}'
             )


### PR DESCRIPTION
## What does this PR do?

It was discovered, that if the device contains Vulkan v. <1.2 then it crashes on instruction WaitSemaphores. 
The fix is to disable timelineSemaphore for the device with the version of Vulkan < 1.2

## How was this PR tested?

Application now runs on Samsung A53. It crashed before.

## Additional small fix:
The script scripts/o3de/o3de/android_support.py contains a lot of error reports and all of them are AndroidToolError, not any other type. So the fix is to use the same AndroidToolError for the recently added code for the custom icons and splashes in Android builds.

