### PR TITLE
MAD-18451.  Fix freeze when trying to resume an android build

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
@@ -1645,9 +1645,7 @@ namespace AZ
         }
 
 #if defined(CARBONATED)
-        // Fix of crash for Android suspend/resume. "m_mainWindowCreated" is "true" by default.
-        // When an app suspends then the window is destroyed and "m_mainWindowCreated" is set to "false" to don't "Tick/Update" any Features/Gems
-        if (m_mainWindowCreated)
+        if (m_mainWindowCreated)    // Android app background/foreground fix
 #endif
         {
             AZ_PROFILE_SCOPE(AzCore, "ComponentApplication::Tick:OnTick");

--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
@@ -1644,6 +1644,11 @@ namespace AZ
             TickBus::ExecuteQueuedEvents();
         }
 
+#if defined(CARBONATED)
+        // Fix of crash for Android suspend/resume. "m_mainWindowCreated" is "true" by default.
+        // When an app suspends then the window is destroyed and "m_mainWindowCreated" is set to "false" to don't "Tick/Update" any Features/Gems
+        if (m_mainWindowCreated)
+#endif
         {
             AZ_PROFILE_SCOPE(AzCore, "ComponentApplication::Tick:OnTick");
             const AZ::TimeUs deltaTimeUs = m_timeSystem->AdvanceTickDeltaTimes();

--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplication.h
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplication.h
@@ -419,5 +419,10 @@ namespace AZ
         //! @return true to indicate a record event operation should occur in the current Tick() call
         using RecordMetricsCallback = AZStd::function<bool(AZStd::chrono::steady_clock::time_point)>;
         RecordMetricsCallback m_recordMetricsOnTickCallback;
+
+#if defined(CARBONATED)
+        bool m_mainWindowCreated = true; // Let's assign it to "true" so it will not affect other platforms. For now it will be changed from
+                                         // the Android when an app goes to background and resumes
+#endif
     };
 }

--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplication.h
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplication.h
@@ -421,8 +421,7 @@ namespace AZ
         RecordMetricsCallback m_recordMetricsOnTickCallback;
 
 #if defined(CARBONATED)
-        bool m_mainWindowCreated = true; // Let's assign it to "true" so it will not affect other platforms. For now it will be changed from
-                                         // the Android when an app goes to background and resumes
+        bool m_mainWindowCreated = true; // Keep "true" for platforms other than Android
 #endif
     };
 }

--- a/Code/Framework/AzFramework/AzFramework/API/ApplicationAPI.h
+++ b/Code/Framework/AzFramework/AzFramework/API/ApplicationAPI.h
@@ -87,6 +87,13 @@ namespace AzFramework
         /// Request to exit the main loop.
         virtual void ExitMainLoop() {}
 
+#if defined(CARBONATED)
+        /// Inform an application that the main window is created and initiated
+        virtual void OnWindowInit() {}
+
+        /// Inform an application that the main window is destroyed
+        virtual void OnWindowDestroy() {}
+#endif
         /// Returns true is ExitMainLoop has been called, false otherwise.
         virtual bool WasExitMainLoopRequested() { return false; }
 

--- a/Code/Framework/AzFramework/AzFramework/Application/Application.h
+++ b/Code/Framework/AzFramework/AzFramework/Application/Application.h
@@ -159,7 +159,6 @@ namespace AzFramework
         //////////////////////////////////////////////////////////////////////////
         NetworkContext* GetNetworkContext() override;
 #endif
-        // Fix for suspend/resume Android application
 #if defined(CARBONATED)
         /// Inform an application that the main window is created and initiated
         void OnWindowInit() override { m_mainWindowCreated = true; }

--- a/Code/Framework/AzFramework/AzFramework/Application/Application.h
+++ b/Code/Framework/AzFramework/AzFramework/Application/Application.h
@@ -159,6 +159,13 @@ namespace AzFramework
         //////////////////////////////////////////////////////////////////////////
         NetworkContext* GetNetworkContext() override;
 #endif
+        // Fix for suspend/resume Android application
+#if defined(CARBONATED)
+        /// Inform an application that the main window is created and initiated
+        void OnWindowInit() override { m_mainWindowCreated = true; }
+        /// Inform an application that the main window is destroyed
+        void OnWindowDestroy() override { m_mainWindowCreated = false; }
+#endif
         // carbonated end
 
     protected:

--- a/Code/LauncherUnified/Platform/Android/Launcher_Android.cpp
+++ b/Code/LauncherUnified/Platform/Android/Launcher_Android.cpp
@@ -256,7 +256,7 @@ namespace
                 AzFramework::AndroidLifecycleEvents::Bus::Broadcast(
                     &AzFramework::AndroidLifecycleEvents::Bus::Events::OnWindowInit);
 #if defined(CARBONATED)
-				AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::OnWindowInit);
+                AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::OnWindowInit);
 #endif
             }
             break;
@@ -267,7 +267,7 @@ namespace
                     &AzFramework::AndroidLifecycleEvents::Bus::Events::OnWindowDestroy);
 
 #if defined(CARBONATED)
-				AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::OnWindowDestroy);
+                AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::OnWindowDestroy);
 #endif
                 androidEnv->SetWindow(nullptr);
             }

--- a/Code/LauncherUnified/Platform/Android/Launcher_Android.cpp
+++ b/Code/LauncherUnified/Platform/Android/Launcher_Android.cpp
@@ -19,6 +19,9 @@
 #include <AzFramework/Input/Buses/Notifications/RawInputNotificationBus_Platform.h>
 #include <AzGameFramework/Application/GameApplication.h>
 
+#if defined(CARBONATED)
+#include <AzFramework/Application/Application.h>
+#endif
 #include <IConsole.h>
 
 #include <android/asset_manager_jni.h>
@@ -252,6 +255,9 @@ namespace
 
                 AzFramework::AndroidLifecycleEvents::Bus::Broadcast(
                     &AzFramework::AndroidLifecycleEvents::Bus::Events::OnWindowInit);
+#if defined(CARBONATED)
+				AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::OnWindowInit);
+#endif
             }
             break;
 
@@ -260,6 +266,9 @@ namespace
                 AzFramework::AndroidLifecycleEvents::Bus::Broadcast(
                     &AzFramework::AndroidLifecycleEvents::Bus::Events::OnWindowDestroy);
 
+#if defined(CARBONATED)
+				AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::OnWindowDestroy);
+#endif
                 androidEnv->SetWindow(nullptr);
             }
             break;


### PR DESCRIPTION
## What does this PR do?

When an android build suspends and then tries to resume it crashes because the main OnTick is performed before the MainWindow with its Context is re-created. Different parts of code (in OnTick, Update, etc...) are trying to access WindowContext which is nullptr.

The fix is to add the special events for APP_CMD_INIT_WINDOW and APP_CMD_TERM_WINDOW to not perform Ticks while the window is not created and initialized.

## How was this PR tested?

Try to suspend and resume the Android build. Now it resumes successfully.
