### PR TITLE
MAD-1845 Fix in android build to correctly resume from the suspend

### DIFF
--- a/Code/LauncherUnified/Platform/Android/Launcher_Android.cpp
+++ b/Code/LauncherUnified/Platform/Android/Launcher_Android.cpp
@@ -89,11 +89,7 @@ namespace
             bool continueRunning = true;
             while (continueRunning) 
             {
-#if defined(CARBONATED)
                 continueRunning = PumpEvents(&ALooper_pollOnce);
-#else
-                continueRunning = PumpEvents(&ALooper_pollAll);
-#endif
             }
         }
 

--- a/Code/LauncherUnified/Platform/Android/Launcher_Android.cpp
+++ b/Code/LauncherUnified/Platform/Android/Launcher_Android.cpp
@@ -231,7 +231,9 @@ namespace
 
             case APP_CMD_RESUME:
             {
-#if !defined(CARBONATED)
+#if defined(CARBONATED)
+                // moved to APP_CMD_GAINED_FOCUS
+#else
                 androidEnv->SetIsRunning(true);
 #endif
                 AzFramework::AndroidLifecycleEvents::Bus::Broadcast(

--- a/Code/LauncherUnified/Platform/Android/Launcher_Android.cpp
+++ b/Code/LauncherUnified/Platform/Android/Launcher_Android.cpp
@@ -231,8 +231,8 @@ namespace
 
             case APP_CMD_RESUME:
             {
-#if defined(CARBONATED)
-                //androidEnv->SetIsRunning(true);
+#if !defined(CARBONATED)
+                androidEnv->SetIsRunning(true);
 #endif
                 AzFramework::AndroidLifecycleEvents::Bus::Broadcast(
                     &AzFramework::AndroidLifecycleEvents::Bus::Events::OnResume);

--- a/Code/LauncherUnified/Platform/Android/Launcher_Android.cpp
+++ b/Code/LauncherUnified/Platform/Android/Launcher_Android.cpp
@@ -210,6 +210,9 @@ namespace
         {
             case APP_CMD_GAINED_FOCUS:
             {
+#if defined(CARBONATED)
+                androidEnv->SetIsRunning(true);
+#endif
                 AzFramework::AndroidLifecycleEvents::Bus::Broadcast(
                     &AzFramework::AndroidLifecycleEvents::Bus::Events::OnGainedFocus);
             }
@@ -232,7 +235,9 @@ namespace
 
             case APP_CMD_RESUME:
             {
-                androidEnv->SetIsRunning(true);
+#if defined(CARBONATED)
+                //androidEnv->SetIsRunning(true);
+#endif
                 AzFramework::AndroidLifecycleEvents::Bus::Broadcast(
                     &AzFramework::AndroidLifecycleEvents::Bus::Events::OnResume);
             }


### PR DESCRIPTION
## What does this PR do?

When an android build suspends and then tries to resume it crashes because the main OnTick is performed before the MainWindow with its Context is re-created. Different parts of the code (in OnTick, Update, etc...) are trying to access WindowContext which is nullptr.

The fix is to restore an execution of 
void RunMainLoop(AzGameFramework::GameApplication& gameApplication)
via androidEnv->SetIsRunning(true); only in APP_CMD_GAINED_FOCUS, but not in APP_CMD_RESUME because APP_CMD_INIT_WINDOW happens after APP_CMD_RESUME.

IsRunning() is used in 
const int result = looperFunc(androidEnv->IsRunning() ? 0 : -1, nullptr, &events, reinterpret_cast<void**>(&source));
when IsRunning() is "true" then RunMainLoop is executed but when IsRunning() is "false" then an execution is stopped and it is waiting for some Android Event like APP_CMD_START.

Also removed unneeded "#if defined(CARBONATED)" because the latest O3DE version already contains the same fix

## How was this PR tested?

Try to suspend and resume the Android build. Now it resumes successfully.
