### PR TITLE
MAD-18528. Dealing with CPU stats not being recorded on Android

### DIFF
--- a/Code/Framework/AzCore/AzCore/Debug/Profiler.inl
+++ b/Code/Framework/AzCore/AzCore/Debug/Profiler.inl
@@ -28,6 +28,10 @@ namespace AZ::Debug
     #if !defined(_RELEASE)
         if (budget)
         {
+            Platform::BeginProfileRegion(budget, eventName, args...);
+
+            budget->BeginProfileRegion();
+
 #if defined (CARBONATED)
             // Initialize the cached pointer with the current handler or nullptr if no handlers are registered.
             // We do it here because Interface::Get will do a full mutex lock if no handlers are registered
@@ -45,17 +49,11 @@ namespace AZ::Debug
                     m_cachedProfiler = profiler;
                 }
                 else
+                {
                     return;
+                }
             }
-
-            Platform::BeginProfileRegion(budget, eventName, args...);
-
-            budget->BeginProfileRegion();
 #else
-            Platform::BeginProfileRegion(budget, eventName, args...);
-
-            budget->BeginProfileRegion();
-
             // Initialize the cached pointer with the current handler or nullptr if no handlers are registered.
             // We do it here because Interface::Get will do a full mutex lock if no handlers are registered
             // causing big performance hit.

--- a/Code/Framework/AzCore/AzCore/Debug/Profiler.inl
+++ b/Code/Framework/AzCore/AzCore/Debug/Profiler.inl
@@ -28,6 +28,30 @@ namespace AZ::Debug
     #if !defined(_RELEASE)
         if (budget)
         {
+#if defined (CARBONATED)
+            // Initialize the cached pointer with the current handler or nullptr if no handlers are registered.
+            // We do it here because Interface::Get will do a full mutex lock if no handlers are registered
+            // causing big performance hit.
+            if (!m_cachedProfiler.has_value())
+            {
+                if (auto profiler = AZ::Interface<Profiler>::Get())
+                {
+                    // We will assign "m_cachedProfiler" only if Get() returns something real
+                    // It happens only after
+                    // CpuProfiler::Init() {
+                    //   AZ::Interface<AZ::Debug::Profiler>::Register(this);
+                    //   ....
+                    // }
+                    m_cachedProfiler = profiler;
+                }
+                else
+                    return;
+            }
+
+            Platform::BeginProfileRegion(budget, eventName, args...);
+
+            budget->BeginProfileRegion();
+#else
             Platform::BeginProfileRegion(budget, eventName, args...);
 
             budget->BeginProfileRegion();
@@ -39,7 +63,7 @@ namespace AZ::Debug
             {
                 m_cachedProfiler = AZ::Interface<Profiler>::Get();
             }
-
+#endif
             if (m_cachedProfiler.value())
             {
                 m_cachedProfiler.value()->BeginRegion(budget, eventName, sizeof...(T), args...);
@@ -55,7 +79,11 @@ namespace AZ::Debug
         {
             budget->EndProfileRegion();
 
+#if defined(CARBONATED)
+            if (m_cachedProfiler.has_value() && m_cachedProfiler.value())
+#else
             if (m_cachedProfiler.value())
+#endif
             {
                 m_cachedProfiler.value()->EndRegion(budget);
             }


### PR DESCRIPTION
## What does this PR do?

When we issue “mw_cpu_profiler 1“ and then “mw_cpu_profiler 0“ commands for Android build then we see in the log:

```
(ProfilerSystemComponent) - Beginning serialization of 769 frames of profiling data 
(ProfilerSystemComponent) - Cpu profiling statistics was saved to file [/storage/emulated/0/Android/data/com.carbonated.madworld.android/files/user/Profiler/cpu_mw_228912.json]
```

But that file is almost empty:

```
{
    "Type": "JsonSerialization",
    "Version": 1,
    "ClassName": "CpuProfilingStatisticsSerializer",
    "ClassData": {
        "cpuProfilingStatisticsSerializerEntries": [],
        "timeTicksPerSecond": 1000000000
    }
}

```
The problem is in
`static AZStd::optional<Profiler*> m_cachedProfiler;`
The method "ProfileScope::BeginRegion()" is called when the Profiler is not registered yet and "AZStd::optional" stores "nullptr" and it NEVER tries to get the pointer again because "m_cachedProfiler.has_value()" reports that the "value" is present even if it is "nullptr".
Because an Android build is monolithic one then "m_cachedProfiler.value()" is always "nullptr" and the CPU statistics is never recorded.

So the solution is not to store "nullptr".

## How was this PR tested?

Now the file [/storage/emulated/0/Android/data/com.carbonated.madworld.android/files/user/Profiler/cpu_mw_XXXXX.json] contains a lot of entries in "cpuProfilingStatisticsSerializerEntries".

PS. Original o3de/o3de repository uses simple 
`static Profiler* m_cachedProfiler;`
and there is no problem with AZStd::optional that stores "nullptr".

PPS. Windows build is not monolithic so we "loose" only some module(s). The main module works as expected.
