### PR TITLE
Fix unused var for other platforms than Android

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.h
@@ -124,7 +124,7 @@ namespace AZ
                 bool m_isValid = false;
             } m_swapChainBarrier;
 
-#if defined(CARBONATED) && defined(CARBONATED_DESIRED_FPS)
+#if defined(CARBONATED) && defined(CARBONATED_DESIRED_FPS) && defined(AZ_PLATFORM_ANDROID)
             // Display refresh rate in nanoseconds, assigned when SwappyVk is initialized.
             uint64_t m_refreshNs = 0;
 #endif // CARBONATED && CARBONATED_DESIRED_FPS

--- a/scripts/commit_validation/commit_validation/carbonated_pal_allowedlist.txt
+++ b/scripts/commit_validation/commit_validation/carbonated_pal_allowedlist.txt
@@ -8,6 +8,7 @@
 */Gems/Atom/RHI/Metal/Code/Source/RHI/MetalViewController.mm
 */Gems/Atom/RHI/Metal/Code/Source/RHI/MetalViewController.h
 */Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
+*/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.h
 */Gems/Atom/RPI/Code/Source/RPI.Public/WindowContext.cpp
 */Code/Framework/AzFramework/AzFramework/Windowing/NativeWindow.cpp
 */Code/Legacy/CrySystem/System.cpp


### PR DESCRIPTION
## What does this PR do?

Building on Jenkins shown that unused (on Linux and iOS) var "m_refreshNs" produces error that fails the builds

## How was this PR tested?

After a new build on Jenkins the error should disappear.
