### PR TITLE
NOTICKET. AssetProcessorBatch file mask - 'bootstrap.*.*.setreg' generation fix

### DIFF
--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -3624,11 +3624,12 @@ namespace AssetProcessor
         QStringList processedEngineFilesArguments = AssetUtilities::ReadProcessedAssetsFilesFromCommandLine(false);
         if (!processedProjectFilesArguments.isEmpty() || !processedEngineFilesArguments.isEmpty())
         {
-            auto projectPath = AssetUtilities::ComputeProjectPath();
-            auto enginePath = QString(AZ::Utils::GetEnginePath().c_str());
+            const auto projectPath = AssetUtilities::ComputeProjectPath();
+            const auto enginePath = QString(AZ::Utils::GetEnginePath().c_str());
             QStringList filesToProcess = AssetUtilities::ResolveAbsolutePathsWithExistingFiles(projectPath, processedProjectFilesArguments);
             QStringList filesToProcessInEngine = AssetUtilities::ResolveAbsolutePathsWithExistingFiles(enginePath, processedEngineFilesArguments);
-            auto engineJsonPath = enginePath + "\\engine.json";
+            const auto engineJsonPath = AZ::IO::Path(enginePath.toUtf8().constData()) / "engine.json";
+            const auto engineJsonPathStr = QString::fromUtf8(engineJsonPath.c_str());
             filesToProcess << filesToProcessInEngine;
             if (!filesToProcess.isEmpty())
             {
@@ -3640,7 +3641,7 @@ namespace AssetProcessor
                     {
                         if (!fileInProject.m_isDirectory)
                         {
-                            if (AssetUtilities::ArePathsEqual(file, fileInProject.m_filePath) || AssetUtilities::ArePathsEqual(engineJsonPath, fileInProject.m_filePath))
+                            if (AssetUtilities::ArePathsEqual(file, fileInProject.m_filePath) || AssetUtilities::ArePathsEqual(engineJsonPathStr, fileInProject.m_filePath))
                             {
                                 filteredFiles.insert(fileInProject);
                                 m_filesToProcess.insert(fileInProject);

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -3624,8 +3624,11 @@ namespace AssetProcessor
         QStringList processedEngineFilesArguments = AssetUtilities::ReadProcessedAssetsFilesFromCommandLine(false);
         if (!processedProjectFilesArguments.isEmpty() || !processedEngineFilesArguments.isEmpty())
         {
-            QStringList filesToProcess = AssetUtilities::ResolveAbsolutePathsWithExistingFiles(AssetUtilities::ComputeProjectPath(), processedProjectFilesArguments);
-            QStringList filesToProcessInEngine = AssetUtilities::ResolveAbsolutePathsWithExistingFiles(QString(AZ::Utils::GetEnginePath().c_str()), processedEngineFilesArguments);
+            auto projectPath = AssetUtilities::ComputeProjectPath();
+            auto enginePath = QString(AZ::Utils::GetEnginePath().c_str());
+            QStringList filesToProcess = AssetUtilities::ResolveAbsolutePathsWithExistingFiles(projectPath, processedProjectFilesArguments);
+            QStringList filesToProcessInEngine = AssetUtilities::ResolveAbsolutePathsWithExistingFiles(enginePath, processedEngineFilesArguments);
+            auto engineJsonPath = enginePath + "\\engine.json";
             filesToProcess << filesToProcessInEngine;
             if (!filesToProcess.isEmpty())
             {
@@ -3637,7 +3640,7 @@ namespace AssetProcessor
                     {
                         if (!fileInProject.m_isDirectory)
                         {
-                            if (AssetUtilities::ArePathsEqual(file, fileInProject.m_filePath))
+                            if (AssetUtilities::ArePathsEqual(file, fileInProject.m_filePath) || AssetUtilities::ArePathsEqual(engineJsonPath, fileInProject.m_filePath))
                             {
                                 filteredFiles.insert(fileInProject);
                                 m_filesToProcess.insert(fileInProject);


### PR DESCRIPTION
AssetProcessorBatch: added `{EnginePath}//engine.json` ignores file mask for generation `bootstrap.*.*.setreg` files  

```
bootstrap.client.debug.setreg
bootstrap.client.profile.setreg
bootstrap.client.release.setreg
bootstrap.server.debug.setreg
bootstrap.server.profile.setreg
bootstrap.server.release.setreg
bootstrap.unified.debug.setreg
bootstrap.unified.profile.setreg
bootstrap.unified.release.setreg
```

