### PR TITLE
NO-TICKET: display blocking dialog deadlock fix

### DIFF
--- a/Code/Framework/AzAndroid/java/com/amazon/lumberyard/NativeUI/LumberyardNativeUI.java
+++ b/Code/Framework/AzAndroid/java/com/amazon/lumberyard/NativeUI/LumberyardNativeUI.java
@@ -10,15 +10,30 @@ package com.amazon.lumberyard.NativeUI;
 
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.util.Log;
+import android.view.View;
+import android.view.Window;
 import android.widget.TextView;
-
-import java.util.ArrayList;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleOwner;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class LumberyardNativeUI
 {
+    private static final String TAG = "LMBR";
+    private static AlertDialog currentDialog;
+    private static AtomicReference<String> userSelection;
+
     public static void DisplayDialog(final Activity activity, final String title, final String message, final String[] options)
     {
         Log.d("LMBR", "DisplayDialog called");
@@ -53,5 +68,155 @@ public class LumberyardNativeUI
         return userSelection.get();
     }
 
-    public static AtomicReference<String> userSelection;
+    public static String DisplayDialogCarbonated(final Activity activity, final String title, final String message, final String[] options)
+    {
+        AtomicReference<String> selection = new AtomicReference<String>("");
+        if (!CanShowDialog(activity))
+        {
+            return selection.get();
+        }
+
+        final CountDownLatch latchUserSelection = new CountDownLatch(1);
+        final CountDownLatch latchShow = new CountDownLatch(1);
+
+        Runnable uiDialog = () ->
+        {
+            try
+            {
+                if (!CanShowDialog(activity))
+                {
+                    latchShow.countDown();
+                    latchUserSelection.countDown();
+                    return;
+                }
+
+                if (IsDialogShowing())
+                {
+                    latchShow.countDown();
+                    latchUserSelection.countDown();
+                    return;
+                }
+
+                AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+                builder.setTitle(title);
+                builder.setMessage(message);
+                builder.setItems(options, (dialog, index) ->
+                {
+                    try
+                    {
+                        selection.set(options[index]);
+                    }
+                    catch (Exception e)
+                    {
+                        Log.e(TAG, "Error in item callback", e);
+                        selection.set("");
+                    }
+                    finally
+                    {
+                        latchUserSelection.countDown();
+                    }
+                });
+
+                currentDialog = builder.create();
+                currentDialog.setOnShowListener(dialog -> latchShow.countDown());
+                currentDialog.setOnDismissListener(dialog -> currentDialog = null);
+
+                currentDialog.show();
+            }
+            catch (Exception e)
+            {
+                Log.e(TAG, "Error showing dialog", e);
+                latchShow.countDown();
+                latchUserSelection.countDown();
+            }
+        };
+
+        activity.runOnUiThread(uiDialog);
+
+        try
+        {
+            boolean completed = latchShow.await(5, TimeUnit.SECONDS);
+            if (!completed)
+            {
+                latchUserSelection.countDown();
+                return "";
+            }
+            latchUserSelection.await();
+        }
+        catch (InterruptedException e)
+        {
+            Log.e(TAG, "Interrupted while waiting for dialog", e);
+            return "";
+        }
+
+        return selection.get();
+    }
+
+    public static void OnDeadlock(final Activity activity, final String title, final String message)
+    {
+        Context context = activity.getApplicationContext();
+        String dateStr = new SimpleDateFormat("MM-dd-yyyy hh.mma", Locale.US).format(new Date());
+        String fileName = "BlockingDialogDeadlock " + dateStr + ".txt";
+        File logFile = new File(context.getFilesDir(), fileName);
+
+        try (FileWriter writer = new FileWriter(logFile, true))
+        {
+            writer.write("Main thread is locked (likely waiting for semaphore) while another thread requests a blocking popup at " + dateStr + ".\n");
+            writer.write("Dialog title: " + title + "\n");
+            writer.write("Dialog message: " + message + "\n\n");
+            writer.flush();
+        }
+        catch (IOException e)
+        {
+            Log.e(TAG, "Failed to write deadlock log", e);
+        }
+
+        Log.e(TAG, "Deadlock detected at " + dateStr + "\nfile path '" + logFile.getAbsolutePath() + "'");
+        Log.e(TAG, "Dialog title: " + title);
+        Log.e(TAG, "Dialog message: " + message);
+
+        android.os.Process.killProcess(android.os.Process.myPid());
+        System.exit(10);
+    }
+
+    public static boolean IsDialogShowing()
+    {
+        return currentDialog != null && currentDialog.isShowing();
+    }
+
+    public static boolean CanShowDialog(final Activity activity)
+    {
+        if (activity == null)
+        {
+            return false;
+        }
+
+        if (activity.isFinishing() || activity.isDestroyed())
+        {
+            return false;
+        }
+
+        if (activity instanceof LifecycleOwner)
+        {
+            Lifecycle.State state = ((LifecycleOwner) activity).getLifecycle().getCurrentState();
+            if (!state.isAtLeast(Lifecycle.State.RESUMED))
+            {
+                return false;
+            }
+        }
+
+        Window window = activity.getWindow();
+        if (window == null)
+        {
+            return false;
+        }
+
+        View decorView = window.getDecorView();
+        if (!decorView.isShown())
+        {
+            return false;
+        }
+
+        return decorView.hasWindowFocus();
+    }
 }

--- a/Code/Framework/AzAndroid/java/com/amazon/lumberyard/NativeUI/LumberyardNativeUI.java
+++ b/Code/Framework/AzAndroid/java/com/amazon/lumberyard/NativeUI/LumberyardNativeUI.java
@@ -146,7 +146,7 @@ public class LumberyardNativeUI
             }
             latchUserSelection.await();
         }
-        catch (InterruptedException e)
+        catch (Exception e)
         {
             Log.e(TAG, "Interrupted while waiting for dialog", e);
             return "";

--- a/Code/Framework/AzAndroid/java/com/amazon/lumberyard/NativeUI/LumberyardNativeUI.java
+++ b/Code/Framework/AzAndroid/java/com/amazon/lumberyard/NativeUI/LumberyardNativeUI.java
@@ -13,11 +13,7 @@ import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.util.Log;
-import android.view.View;
-import android.view.Window;
 import android.widget.TextView;
-import androidx.lifecycle.Lifecycle;
-import androidx.lifecycle.LifecycleOwner;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -31,6 +27,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class LumberyardNativeUI
 {
     private static final String TAG = "LMBR";
+    private static final int TIMEOUT = 3;
     private static AlertDialog currentDialog;
     private static AtomicReference<String> userSelection;
 
@@ -71,11 +68,6 @@ public class LumberyardNativeUI
     public static String DisplayDialogCarbonated(final Activity activity, final String title, final String message, final String[] options)
     {
         AtomicReference<String> selection = new AtomicReference<String>("");
-        if (!CanShowDialog(activity))
-        {
-            return selection.get();
-        }
-
         final CountDownLatch latchUserSelection = new CountDownLatch(1);
         final CountDownLatch latchShow = new CountDownLatch(1);
 
@@ -83,13 +75,6 @@ public class LumberyardNativeUI
         {
             try
             {
-                if (!CanShowDialog(activity))
-                {
-                    latchShow.countDown();
-                    latchUserSelection.countDown();
-                    return;
-                }
-
                 if (IsDialogShowing())
                 {
                     latchShow.countDown();
@@ -122,8 +107,12 @@ public class LumberyardNativeUI
 
                 currentDialog = builder.create();
                 currentDialog.setOnShowListener(dialog -> latchShow.countDown());
-                currentDialog.setOnDismissListener(dialog -> currentDialog = null);
+                currentDialog.setOnDismissListener(dialog -> {
+                    currentDialog = null;
+                    latchUserSelection.countDown();
+                });
 
+                currentDialog.setCancelable(false);
                 currentDialog.show();
             }
             catch (Exception e)
@@ -138,10 +127,9 @@ public class LumberyardNativeUI
 
         try
         {
-            boolean completed = latchShow.await(5, TimeUnit.SECONDS);
+            boolean completed = latchShow.await(TIMEOUT, TimeUnit.SECONDS);
             if (!completed)
             {
-                latchUserSelection.countDown();
                 return "";
             }
             latchUserSelection.await();
@@ -164,7 +152,8 @@ public class LumberyardNativeUI
 
         try (FileWriter writer = new FileWriter(logFile, true))
         {
-            writer.write("Main thread is locked (likely waiting for semaphore) while another thread requests a blocking popup at " + dateStr + ".\n");
+            writer.write("At the moment, there is no way to show a native dialog (the application is in the background or for some other reason)");
+            writer.write("Date: " + dateStr + "\n");
             writer.write("Dialog title: " + title + "\n");
             writer.write("Dialog message: " + message + "\n\n");
             writer.flush();
@@ -185,41 +174,5 @@ public class LumberyardNativeUI
     public static boolean IsDialogShowing()
     {
         return currentDialog != null && currentDialog.isShowing();
-    }
-
-    public static boolean CanShowDialog(final Activity activity)
-    {
-        if (activity == null)
-        {
-            return false;
-        }
-
-        if (activity.isFinishing() || activity.isDestroyed())
-        {
-            return false;
-        }
-
-        if (activity instanceof LifecycleOwner)
-        {
-            Lifecycle.State state = ((LifecycleOwner) activity).getLifecycle().getCurrentState();
-            if (!state.isAtLeast(Lifecycle.State.RESUMED))
-            {
-                return false;
-            }
-        }
-
-        Window window = activity.getWindow();
-        if (window == null)
-        {
-            return false;
-        }
-
-        View decorView = window.getDecorView();
-        if (!decorView.isShown())
-        {
-            return false;
-        }
-
-        return decorView.hasWindowFocus();
     }
 }

--- a/Code/Framework/AzAndroid/java/com/amazon/lumberyard/NativeUI/LumberyardNativeUI.java
+++ b/Code/Framework/AzAndroid/java/com/amazon/lumberyard/NativeUI/LumberyardNativeUI.java
@@ -98,22 +98,25 @@ public class LumberyardNativeUI
                 }
 
                 AlertDialog.Builder builder = new AlertDialog.Builder(activity);
-                builder.setTitle(title);
-                builder.setMessage(message);
-                builder.setItems(options, (dialog, index) ->
-                {
-                    try
-                    {
-                        selection.set(options[index]);
-                    }
-                    catch (Exception e)
-                    {
-                        Log.e(TAG, "Error in item callback", e);
-                        selection.set("");
-                    }
-                    finally
-                    {
-                        latchUserSelection.countDown();
+                TextView textView = new TextView(activity);
+                textView.setText(title + "\n" + message);
+                builder.setCustomTitle(textView);
+                builder.setItems(options, new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int index) {
+                        try
+                        {
+                            selection.set(options[index]);
+                            Log.d(TAG, "Selected option: " + selection.get());
+                        }
+                        catch (Exception e)
+                        {
+                            Log.e(TAG, "Error in item callback", e);
+                            selection.set("");
+                        }
+                        finally
+                        {
+                            latchUserSelection.countDown();
+                        }
                     }
                 });
 

--- a/Code/Framework/AzAndroid/java/com/amazon/lumberyard/NativeUI/LumberyardNativeUI.java
+++ b/Code/Framework/AzAndroid/java/com/amazon/lumberyard/NativeUI/LumberyardNativeUI.java
@@ -14,6 +14,8 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.util.Log;
 import android.widget.TextView;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleOwner;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -71,17 +73,16 @@ public class LumberyardNativeUI
         final CountDownLatch latchUserSelection = new CountDownLatch(1);
         final CountDownLatch latchShow = new CountDownLatch(1);
 
+        if (IsActivityResumed(activity) && IsDialogShowing())
+        {
+            Log.e(TAG, "Can't show dialog");
+            return "";
+        }
+
         Runnable uiDialog = () ->
         {
             try
             {
-                if (IsDialogShowing())
-                {
-                    latchShow.countDown();
-                    latchUserSelection.countDown();
-                    return;
-                }
-
                 AlertDialog.Builder builder = new AlertDialog.Builder(activity);
                 TextView textView = new TextView(activity);
                 textView.setText(title + "\n" + message);
@@ -128,11 +129,15 @@ public class LumberyardNativeUI
         try
         {
             boolean completed = latchShow.await(TIMEOUT, TimeUnit.SECONDS);
-            if (!completed)
+            if (completed && currentDialog != null && currentDialog.isShowing() && IsActivityResumed(activity))
             {
+                latchUserSelection.await();
+            }
+            else
+            {
+                Log.e(TAG, "Can't show dialog");
                 return "";
             }
-            latchUserSelection.await();
         }
         catch (Exception e)
         {
@@ -141,6 +146,29 @@ public class LumberyardNativeUI
         }
 
         return selection.get();
+    }
+
+    private static boolean IsActivityResumed(Activity activity)
+    {
+        if (activity == null)
+        {
+            return false;
+        }
+
+        if (activity instanceof LifecycleOwner)
+        {
+            LifecycleOwner lifecycleOwner = (LifecycleOwner) activity;
+            return lifecycleOwner.getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.RESUMED);
+        }
+
+        try
+        {
+            return activity.hasWindowFocus() && !activity.isFinishing() && !activity.isDestroyed();
+        }
+        catch (Exception e)
+        {
+            return false;
+        }
     }
 
     public static void OnDeadlock(final Activity activity, final String title, final String message)

--- a/Code/Framework/AzAndroid/java/com/amazon/lumberyard/NativeUI/LumberyardNativeUI.java
+++ b/Code/Framework/AzAndroid/java/com/amazon/lumberyard/NativeUI/LumberyardNativeUI.java
@@ -73,9 +73,15 @@ public class LumberyardNativeUI
         final CountDownLatch latchUserSelection = new CountDownLatch(1);
         final CountDownLatch latchShow = new CountDownLatch(1);
 
-        if (IsActivityResumed(activity) && IsDialogShowing())
+        if (IsActivityResumed(activity))
         {
-            Log.e(TAG, "Can't show dialog");
+            Log.e(TAG, "The dialog cannot be shown because the application is in the background.");
+            return "";
+        }
+
+        if (IsDialogShowing())
+        {
+            Log.e(TAG, "The dialog cannot be shown because another window is already shown.");
             return "";
         }
 

--- a/Code/Framework/AzCore/Platform/Android/AzCore/NativeUI/NativeUISystemComponent_Android.cpp
+++ b/Code/Framework/AzCore/Platform/Android/AzCore/NativeUI/NativeUISystemComponent_Android.cpp
@@ -18,13 +18,17 @@ namespace AZ
 {
     namespace NativeUI
     {
-
-#if defined(CARBONATED) // TODO : implement for platform
+#if defined(CARBONATED)
         bool NativeUISystem::IsDisplayingBlockingDialog() const
         {
-            return false;
+            AZ::Android::JNI::Object object("com/amazon/lumberyard/NativeUI$LumberyardNativeUI");
+            object.RegisterStaticMethod("IsDialogShowing", "()Z");
+
+            auto isDialogShowing = object.InvokeStaticBooleanMethod("IsDialogShowing");
+            return isDialogShowing;
         }
 #endif
+
         AZStd::string NativeUISystem::DisplayBlockingDialog(const AZStd::string& title, const AZStd::string& message, const AZStd::vector<AZStd::string>& options) const
         {
             if (m_mode == NativeUI::Mode::DISABLED)
@@ -33,9 +37,13 @@ namespace AZ
             }
 
             AZ::Android::JNI::Object object("com/amazon/lumberyard/NativeUI/LumberyardNativeUI");
+#if defined(CARBONATED)
+            object.RegisterStaticMethod("DisplayDialogCarbonated", "(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;)Ljava/lang/String;");
+            object.RegisterStaticMethod("OnDeadlock", "(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;)V");
+#else
             object.RegisterStaticMethod("DisplayDialog", "(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;)V");
             object.RegisterStaticMethod("GetUserSelection", "()Ljava/lang/String;");
-
+#endif
             JNIEnv* env = AZ::Android::JNI::GetEnv();
             AZ::Android::JNI::scoped_ref<jobjectArray> joptions(static_cast<jobjectArray>(env->NewObjectArray(options.size(), env->FindClass("java/lang/String"), env->NewStringUTF(""))));
             for (int i = 0; i < options.size(); i++)
@@ -45,7 +53,9 @@ namespace AZ
 
             AZ::Android::JNI::scoped_ref<jstring> jtitle(AZ::Android::JNI::ConvertStringToJstring(title));
             AZ::Android::JNI::scoped_ref<jstring> jmessage(AZ::Android::JNI::ConvertStringToJstring(message));
-
+#if defined(CARBONATED)
+            AZStd::string userSelection = object.InvokeStaticStringMethod("DisplayDialogCarbonated", AZ::Android::Utils::GetActivityRef(), jtitle.get(), jmessage.get(), joptions.get());
+#else
             object.InvokeStaticVoidMethod("DisplayDialog", AZ::Android::Utils::GetActivityRef(), jtitle.get(), jmessage.get(), joptions.get());
 
             AZStd::string userSelection = "";
@@ -53,13 +63,18 @@ namespace AZ
             {
                 userSelection = object.InvokeStaticStringMethod("GetUserSelection");
             }
-
+#endif
             for (int i = 0; i < options.size(); i++)
             {
                 jstring str = static_cast<jstring>(env->GetObjectArrayElement(joptions.get(), i));
                 env->DeleteLocalRef(str);
             }
-
+#if defined(CARBONATED)
+            if (userSelection.empty())
+            {
+                object.InvokeStaticVoidMethod("OnDeadlock", AZ::Android::Utils::GetActivityRef(), jtitle.get(), jmessage.get());
+            }
+#endif
             return userSelection;
         }
     }


### PR DESCRIPTION
Fixed deadloop when trying to show a native window when it cannot be shown.
In case of a deadloop, the message text will be written to a file.

The native method for NativeUISystem::IsDisplayingBlockingDialog (Android) has also been implemented.