### PR TITLE
Implement protection for setting "vsync_interval" to or from 0 for Vulkan RHI on the fly.

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/WindowContext.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/WindowContext.cpp
@@ -158,17 +158,15 @@ namespace AZ
             RHI::Ptr<RHI::SwapChain> defaultSwapChain = GetSwapChain(ViewType::Default);
             if (defaultSwapChain->GetDescriptor().m_verticalSyncInterval != interval)
             {
-#if !defined(AZ_PLATFORM_ANDROID) && !defined(AZ_PLATFORM_IOS)
                 if (AZ::RHI::Factory::Get().GetAPIUniqueIndex() == static_cast<uint32_t>(AZ::RHI::APIIndex::Vulkan))
                 {
                     uint32_t currentInterval = defaultSwapChain->GetDescriptor().m_verticalSyncInterval;
                     if (currentInterval * interval == 0 && currentInterval + interval != 0)
                     {
-                        AZ_Error("WindowContext", false, "It is impossible to change vsync_interval to or from 0 'on the fly' in Vulkan RHI");
+                        AZ_Error("WindowContext", false, "It is impossible to change vsync_interval to zero or from zero after engine initialization with Vulkan render");
                         return;
                     }
                 }
-#endif
                 defaultSwapChain->SetVerticalSyncInterval(interval);
             }
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/WindowContext.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/WindowContext.cpp
@@ -158,6 +158,17 @@ namespace AZ
             RHI::Ptr<RHI::SwapChain> defaultSwapChain = GetSwapChain(ViewType::Default);
             if (defaultSwapChain->GetDescriptor().m_verticalSyncInterval != interval)
             {
+#if !defined(AZ_PLATFORM_ANDROID) && !defined(AZ_PLATFORM_IOS)
+                if (AZ::RHI::Factory::Get().GetAPIUniqueIndex() == static_cast<uint32_t>(AZ::RHI::APIIndex::Vulkan))
+                {
+                    uint32_t currentInterval = defaultSwapChain->GetDescriptor().m_verticalSyncInterval;
+                    if (currentInterval * interval == 0 && currentInterval + interval != 0)
+                    {
+                        AZ_Error("WindowContext", false, "It is impossible to change vsync_interval to or from 0 'on the fly' in Vulkan RHI");
+                        return;
+                    }
+                }
+#endif
                 defaultSwapChain->SetVerticalSyncInterval(interval);
             }
         }


### PR DESCRIPTION
https://favro.com/organization/ab098f3312254434882b4396/579ee0f4d0168dab8e8d0252?card=Car-29678&secret=FwN6WJMOv7HYVuatYlpkUrgOKFYbJMM32fBuArfHmsX

## What does this PR do?

Upon starting a battle in the editor, the fps is set to game mode, which sets vsync to 0, which causes a vulkan semaphore to close causing an assert and a crash.

The PR compares old and new "vsync_interval" for Vulkan RHI on Windows, Max, Linux and protects from changing it to or from 0.
Error message is generated.

## How was this PR tested?

No more crashes in the Editor.
