### PR TITLE
Fix glitch with white and color "snow" in different 2D elements on Google Pixel 9

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
@@ -140,6 +140,12 @@ namespace AZ
                 copy.bufferOffset = sourceBufferMemoryView->GetOffset() + descriptor.m_sourceOffset;
                 copy.bufferRowLength = descriptor.m_sourceBytesPerRow / GetFormatSize(format) * formatDimensionAlignment.m_width;
                 copy.bufferImageHeight = RHI::AlignUp(descriptor.m_sourceSize.m_height, formatDimensionAlignment.m_height);
+#if defined(CARBONATED)
+                // VkBufferImageCopy::bufferImageHeight should be multiple to formatDimensionAlignment.m_height otherwise Validation Layer will issue an error.
+                copy.bufferImageHeight =
+                    ((copy.bufferImageHeight + formatDimensionAlignment.m_height - 1) / formatDimensionAlignment.m_height) *
+                    formatDimensionAlignment.m_height;
+#endif
                 copy.imageSubresource.aspectMask = destinationImage->GetImageAspectFlags();
                 copy.imageSubresource.mipLevel = descriptor.m_destinationSubresource.m_mipSlice;
                 copy.imageSubresource.baseArrayLayer = descriptor.m_destinationSubresource.m_arraySlice;
@@ -214,6 +220,12 @@ namespace AZ
                 copy.bufferOffset = destinationBufferMemoryView->GetOffset() + descriptor.m_destinationOffset;
                 copy.bufferRowLength = descriptor.m_destinationBytesPerRow / GetFormatSize(format) * formatDimensionAlignment.m_width;
                 copy.bufferImageHeight = RHI::AlignUp(descriptor.m_sourceSize.m_height, formatDimensionAlignment.m_height);
+#if defined(CARBONATED)
+                // VkBufferImageCopy::bufferImageHeight should be multiple to formatDimensionAlignment.m_height otherwise Validation Layer will issue an error.
+                copy.bufferImageHeight =
+                    ((copy.bufferImageHeight + formatDimensionAlignment.m_height - 1) / formatDimensionAlignment.m_height) *
+                    formatDimensionAlignment.m_height;
+#endif
                 copy.imageSubresource.aspectMask = ConvertImageAspect(descriptor.m_sourceSubresource.m_aspect);
                 copy.imageSubresource.mipLevel = descriptor.m_sourceSubresource.m_mipSlice;
                 copy.imageSubresource.baseArrayLayer = descriptor.m_sourceSubresource.m_arraySlice;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
@@ -610,14 +610,11 @@ namespace AZ
             auto presentCommand = [&device, swapchain]([[maybe_unused]] void* queue)
             {
                 device.GetContext().DeviceWaitIdle(device.GetNativeDevice());
+                if (swapchain != VK_NULL_HANDLE)
+                {
 #if defined(CARBONATED) && defined(AZ_PLATFORM_ANDROID) && defined(CARBONATED_DESIRED_FPS)
-                if (swapchain != VK_NULL_HANDLE)
-                {
                     SwappyVk_destroySwapchain(device.GetNativeDevice(), swapchain);
-                }
 #endif // CARBONATED && AZ_PLATFORM_ANDROID && CARBONATED_DESIRED_FPS
-                if (swapchain != VK_NULL_HANDLE)
-                {
                     device.GetContext().DestroySwapchainKHR(device.GetNativeDevice(), swapchain, VkSystemAllocator::Get());
                 }
             };

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
@@ -615,12 +615,11 @@ namespace AZ
                 {
                     SwappyVk_destroySwapchain(device.GetNativeDevice(), swapchain);
                 }
-#else
+#endif // CARBONATED && AZ_PLATFORM_ANDROID && CARBONATED_DESIRED_FPS
                 if (swapchain != VK_NULL_HANDLE)
                 {
                     device.GetContext().DestroySwapchainKHR(device.GetNativeDevice(), swapchain, VkSystemAllocator::Get());
                 }
-#endif // CARBONATED && AZ_PLATFORM_ANDROID && CARBONATED_DESIRED_FPS
             };
 
             m_presentationQueue->QueueCommand(AZStd::move(presentCommand));

--- a/Gems/LyShine/Code/Source/RenderGraph.cpp
+++ b/Gems/LyShine/Code/Source/RenderGraph.cpp
@@ -80,7 +80,7 @@ namespace LyShine
         m_textures[1].m_isClampTextureMode = isClampTextureMode;
 
 #if defined(CARBONATED)
-        m_combinedVertices.reserve(1024);
+        m_combinedVertices.reserve(672);
         m_combinedIndices.reserve(1024);
 #if defined(CARBONATED_USE_MALI_G715_WORKAROUND)
         m_drawCommands.reserve(128);

--- a/Gems/LyShine/Code/Source/RenderGraph.cpp
+++ b/Gems/LyShine/Code/Source/RenderGraph.cpp
@@ -55,6 +55,9 @@ namespace LyShine
 #if defined(CARBONATED)
         m_combinedVertices.reserve(672);  // typically we have 1.5+ times more indices than vertices, sometimes it is even 2 times more
         m_combinedIndices.reserve(1024);
+#if defined(CARBONATED_USE_PIXEL_WORKAROUND)
+        m_drawCommands.reserve(128);
+#endif
 #endif
     }
 
@@ -79,6 +82,9 @@ namespace LyShine
 #if defined(CARBONATED)
         m_combinedVertices.reserve(1024);
         m_combinedIndices.reserve(1024);
+#if defined(CARBONATED_USE_PIXEL_WORKAROUND)
+        m_drawCommands.reserve(128);
+#endif
 #endif
     }
 
@@ -88,10 +94,20 @@ namespace LyShine
         m_primitives.clear();
 
 #if defined(CARBONATED)
+#if defined(CARBONATED_USE_PIXEL_WORKAROUND)
+        m_drawCommands.clear();
+#endif
         m_combinedVertices.clear();
         m_combinedIndices.clear();
 #endif
     }
+
+#if defined(CARBONATED) && defined(CARBONATED_USE_PIXEL_WORKAROUND)
+    void PrimitiveListRenderNode::SetPixelWorkaround(bool useWorkaround)
+    {
+        m_usingPixelWorkaround = useWorkaround;
+    }
+#endif
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////
     void PrimitiveListRenderNode::Render(UiRenderer* uiRenderer
@@ -165,11 +181,49 @@ namespace LyShine
         drawSrg->Compile();
 
 #if defined(CARBONATED)
+#if defined(CARBONATED_USE_PIXEL_WORKAROUND)
+        if (m_usingPixelWorkaround)
+        {
+            for (const DrawCommand& cmd : m_drawCommands)
+            {
+                if (cmd.m_type == DrawCommand::Type::CombinedBatch)
+                {
+                    // draw subset of combined buffers
+                    dynamicDraw->DrawIndexed(
+                        &m_combinedVertices[cmd.m_combinedVertexStart],
+                        cmd.m_combinedVertexCount,
+                        &m_combinedIndices[cmd.m_combinedIndexStart],
+                        cmd.m_combinedIndexCount,
+                        AZ::RHI::IndexFormat::Uint16,
+                        drawSrg);
+                }
+                else // SinglePrimitive
+                {
+                    LyShine::UiPrimitive* prim = cmd.m_primitive;
+                    if (prim)
+                    {
+                        dynamicDraw->DrawIndexed(
+                            prim->m_vertices,
+                            static_cast<uint32_t>(prim->m_numVertices),
+                            prim->m_indices,
+                            static_cast<uint32_t>(prim->m_numIndices),
+                            AZ::RHI::IndexFormat::Uint16,
+                            drawSrg);
+                    }
+                }
+            }
+        }
+        else if (m_combinedIndices.size() > 0 && m_combinedVertices.size() > 0)
+        {
+            dynamicDraw->DrawIndexed(&m_combinedVertices[0], (uint32_t)m_combinedVertices.size(), &m_combinedIndices[0], (uint32_t)m_combinedIndices.size(), AZ::RHI::IndexFormat::Uint16, drawSrg);
+        }
+#else
         if (m_combinedIndices.size() > 0 && m_combinedVertices.size() > 0)
         {
             dynamicDraw->DrawIndexed(&m_combinedVertices[0], (uint32_t)m_combinedVertices.size(), &m_combinedIndices[0],  (uint32_t)m_combinedIndices.size(), AZ::RHI::IndexFormat::Uint16, drawSrg);
         }
-#else
+#endif // CARBONATED_USE_PIXEL_WORKAROUND
+#else // CARBONATED
         // Add the indexed primitives to the dynamic draw context for drawing
         //
         // [LYSHINE_ATOM_TODO][ATOM-15073] Combine into a single DrawIndexed call to take advantage of the draw call
@@ -187,11 +241,97 @@ namespace LyShine
     ////////////////////////////////////////////////////////////////////////////////////////////////////
     void PrimitiveListRenderNode::AddPrimitive(LyShine::UiPrimitive* primitive)
     {
+#if defined(CARBONATED)
+#if defined(CARBONATED_USE_PIXEL_WORKAROUND)
+        constexpr float MinSizeOfSideOfBigPrimitive = 24.0f;
+
         // always clear the next pointer before adding to list
         primitive->m_next = nullptr;
         m_primitives.push_back(*primitive);
 
-#if defined(CARBONATED)
+        if (m_usingPixelWorkaround)
+        {
+            float maxX = 0, maxY = 0, minX = 100000.0f, minY = 100000.0f;
+            float maxWidth, maxHeight;
+            bool bigPrimitive = false;
+            for (int i = 0; i < primitive->m_numVertices; ++i)
+            {
+                UiPrimitiveVertex& v = primitive->m_vertices[i];
+                maxX = AZ::GetMax(maxX, v.xy.x);
+                maxY = AZ::GetMax(maxY, v.xy.y);
+                minX = AZ::GetMin(minX, v.xy.x);
+                minY = AZ::GetMin(minY, v.xy.y);
+                maxWidth = maxX - minX;
+                maxHeight = maxY - minY;
+                if (maxWidth >= MinSizeOfSideOfBigPrimitive && maxHeight >= MinSizeOfSideOfBigPrimitive)
+                {
+                    bigPrimitive = true;
+                    break;
+                }
+            }
+            if (!bigPrimitive)
+            {
+                uint16 vertex_start = aznumeric_caster(m_combinedVertices.size());
+                uint16 index_start = aznumeric_caster(m_combinedIndices.size());
+
+                // Add the vertices at the end of the combined buffer.  We need to update the vertex indices with their new offset separately.
+                m_combinedVertices.insert(m_combinedVertices.end(), primitive->m_vertices, primitive->m_vertices + primitive->m_numVertices);
+                m_combinedIndices.resize_no_construct(m_combinedIndices.size() + primitive->m_numIndices);
+
+                int batchBaseVertex = static_cast<int>(vertex_start);
+
+                if (!m_drawCommands.empty() && m_drawCommands.back().m_type == DrawCommand::Type::CombinedBatch)
+                {
+                    DrawCommand& last = m_drawCommands.back();
+                    batchBaseVertex = last.m_combinedVertexStart;
+                    last.m_combinedVertexCount += primitive->m_numVertices;
+                    last.m_combinedIndexCount += primitive->m_numIndices;
+                }
+                else
+                {
+                    DrawCommand cmd;
+                    cmd.m_type = DrawCommand::Type::CombinedBatch;
+                    cmd.m_combinedVertexStart = vertex_start;
+                    cmd.m_combinedVertexCount = primitive->m_numVertices;
+                    cmd.m_combinedIndexStart = index_start;
+                    cmd.m_combinedIndexCount = primitive->m_numIndices;
+                    m_drawCommands.push_back(cmd);
+                }
+
+                for (int i = 0; i < primitive->m_numIndices; ++i)
+                {
+                    uint32_t rel = (vertex_start - batchBaseVertex) + primitive->m_indices[i];
+                    AZ_Assert(rel <= 0xFFFF, "Index overflow in CombinedBatch");
+                    m_combinedIndices[index_start + i] = static_cast<uint16>(rel);
+                }
+            }
+            else
+            {
+                DrawCommand cmd;
+                cmd.m_type = DrawCommand::Type::SinglePrimitive;
+                cmd.m_primitive = primitive;
+                m_drawCommands.push_back(cmd);
+            }
+        }
+        else
+        {
+            uint16 vertex_start = aznumeric_caster(m_combinedVertices.size());
+            uint16 index_start = aznumeric_caster(m_combinedIndices.size());
+
+            // Add the vertices at the end of the combined buffer.  We need to update the vertex indices with their new offset separately.
+            m_combinedVertices.insert(m_combinedVertices.end(), primitive->m_vertices, primitive->m_vertices + primitive->m_numVertices);
+            m_combinedIndices.resize_no_construct(m_combinedIndices.size() + primitive->m_numIndices);
+
+            for (int i = 0; i < primitive->m_numIndices; i++)
+            {
+                m_combinedIndices[index_start + i] = vertex_start + primitive->m_indices[i];
+            }
+        }
+#else
+        // always clear the next pointer before adding to list
+        primitive->m_next = nullptr;
+        m_primitives.push_back(*primitive);
+
         uint16 vertex_start = aznumeric_caster(m_combinedVertices.size());
         uint16 index_start = aznumeric_caster(m_combinedIndices.size());
 
@@ -203,7 +343,8 @@ namespace LyShine
         {
             m_combinedIndices[index_start + i] = vertex_start + primitive->m_indices[i];
         }
-#endif
+#endif // CARBONATED_USE_PIXEL_WORKAROUND
+#endif // CARBONATED
 
         m_totalNumVertices += primitive->m_numVertices;
         m_totalNumIndices += primitive->m_numIndices;
@@ -611,6 +752,21 @@ namespace LyShine
         // it is the main, top-level list of nodes. If we start defining a mask or render to texture
         // then it becomes the node list for that render node.
         m_renderNodeListStack.push(&m_renderNodes);
+
+#if defined(CARBONATED) && defined(CARBONATED_USE_PIXEL_WORKAROUND)
+        const AZ::RHI::Ptr<AZ::RHI::Device> rhiDevice = AZ::RHI::RHISystemInterface::Get()->GetDevice();
+        if (rhiDevice)
+        {
+            const auto& descriptor = rhiDevice->GetPhysicalDevice().GetDescriptor();
+            // Currently (September 2025) we 100% know that Google Pixel 9 has glitch with sparkling white/color snow on the UI elements
+            // The workaround is to not combine rectangular/square primitives with size > 30 into big batches
+            m_usingPixelWorkaround = descriptor.m_description.contains("Mali-G715");
+        }
+        else
+        {
+            AZ_Error("RenderGraph", false, "RHI::Device is not created yet");
+        }
+#endif
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -823,6 +979,9 @@ namespace LyShine
                 // this uses a pool allocator for fast allocation
                 renderNodeToAddTo = new PrimitiveListRenderNode(texture, isClampTextureMode, isTextureSRGB, isPreMultiplyAlpha, blendModeState);
 
+#if defined(CARBONATED) && defined(CARBONATED_USE_PIXEL_WORKAROUND)
+                renderNodeToAddTo->SetPixelWorkaround(m_usingPixelWorkaround);
+#endif
                 renderNodeList->push_back(renderNodeToAddTo);
                 texUnit = 0;
             }
@@ -905,6 +1064,9 @@ namespace LyShine
                 renderNodeToAddTo = new PrimitiveListRenderNode(contentAttachmentImage, maskAttachmentImage,
                     isClampTextureMode, isTextureSRGB, isPreMultiplyAlpha, alphaMaskType, blendModeState);
 
+#if defined(CARBONATED) && defined(CARBONATED_USE_PIXEL_WORKAROUND)
+                renderNodeToAddTo->SetPixelWorkaround(m_usingPixelWorkaround);
+#endif
                 renderNodeList->push_back(renderNodeToAddTo);
                 texUnit0 = 0;
                 texUnit1 = 1;

--- a/Gems/LyShine/Code/Source/RenderGraph.cpp
+++ b/Gems/LyShine/Code/Source/RenderGraph.cpp
@@ -53,8 +53,8 @@ namespace LyShine
         m_textures[0].m_isClampTextureMode = isClampTextureMode;
 
 #if defined(CARBONATED)
-        m_combinedVertices.reserve(672);  // typically we have 1.5+ times more indices than vertices, sometimes it is even 2 times more
-        m_combinedIndices.reserve(1024);
+        m_combinedVertices.reserve(1200);  // typically we have 1.5+ times more indices than vertices, sometimes it is even 2 times more
+        m_combinedIndices.reserve(2400);
 #if defined(CARBONATED_USE_MALI_G715_WORKAROUND)
         m_drawCommands.reserve(128);
 #endif
@@ -80,8 +80,8 @@ namespace LyShine
         m_textures[1].m_isClampTextureMode = isClampTextureMode;
 
 #if defined(CARBONATED)
-        m_combinedVertices.reserve(672);
-        m_combinedIndices.reserve(1024);
+        m_combinedVertices.reserve(1200);
+        m_combinedIndices.reserve(2400);
 #if defined(CARBONATED_USE_MALI_G715_WORKAROUND)
         m_drawCommands.reserve(128);
 #endif

--- a/Gems/LyShine/Code/Source/RenderGraph.cpp
+++ b/Gems/LyShine/Code/Source/RenderGraph.cpp
@@ -250,18 +250,18 @@ namespace LyShine
 
         if (m_usingMaliG715Workaround)
         {
-            float maxX = 0, maxY = 0, minX = 100000.0f, minY = 100000.0f;
-            float maxWidth, maxHeight;
+            const UiPrimitiveVertex& first = primitive->m_vertices[0];
+            float maxX = first.xy.x, minX = first.xy.x, maxY = first.xy.y, minY = first.xy.y;
             bool bigPrimitive = false;
-            for (int i = 0; i < primitive->m_numVertices; ++i)
+            for (int i = 1; i < primitive->m_numVertices; ++i)
             {
                 UiPrimitiveVertex& v = primitive->m_vertices[i];
                 maxX = AZ::GetMax(maxX, v.xy.x);
                 maxY = AZ::GetMax(maxY, v.xy.y);
                 minX = AZ::GetMin(minX, v.xy.x);
                 minY = AZ::GetMin(minY, v.xy.y);
-                maxWidth = maxX - minX;
-                maxHeight = maxY - minY;
+                const float maxWidth = maxX - minX;
+                const float maxHeight = maxY - minY;
                 if (maxWidth >= MinSizeOfSideOfBigPrimitive && maxHeight >= MinSizeOfSideOfBigPrimitive)
                 {
                     bigPrimitive = true;

--- a/Gems/LyShine/Code/Source/RenderGraph.cpp
+++ b/Gems/LyShine/Code/Source/RenderGraph.cpp
@@ -55,7 +55,7 @@ namespace LyShine
 #if defined(CARBONATED)
         m_combinedVertices.reserve(672);  // typically we have 1.5+ times more indices than vertices, sometimes it is even 2 times more
         m_combinedIndices.reserve(1024);
-#if defined(CARBONATED_USE_PIXEL_WORKAROUND)
+#if defined(CARBONATED_USE_MALI_G715_WORKAROUND)
         m_drawCommands.reserve(128);
 #endif
 #endif
@@ -82,7 +82,7 @@ namespace LyShine
 #if defined(CARBONATED)
         m_combinedVertices.reserve(1024);
         m_combinedIndices.reserve(1024);
-#if defined(CARBONATED_USE_PIXEL_WORKAROUND)
+#if defined(CARBONATED_USE_MALI_G715_WORKAROUND)
         m_drawCommands.reserve(128);
 #endif
 #endif
@@ -94,7 +94,7 @@ namespace LyShine
         m_primitives.clear();
 
 #if defined(CARBONATED)
-#if defined(CARBONATED_USE_PIXEL_WORKAROUND)
+#if defined(CARBONATED_USE_MALI_G715_WORKAROUND)
         m_drawCommands.clear();
 #endif
         m_combinedVertices.clear();
@@ -102,10 +102,10 @@ namespace LyShine
 #endif
     }
 
-#if defined(CARBONATED) && defined(CARBONATED_USE_PIXEL_WORKAROUND)
-    void PrimitiveListRenderNode::SetPixelWorkaround(bool useWorkaround)
+#if defined(CARBONATED) && defined(CARBONATED_USE_MALI_G715_WORKAROUND)
+    void PrimitiveListRenderNode::SetMaliG715Workaround(bool useWorkaround)
     {
-        m_usingPixelWorkaround = useWorkaround;
+        m_usingMaliG715Workaround = useWorkaround;
     }
 #endif
 
@@ -181,8 +181,8 @@ namespace LyShine
         drawSrg->Compile();
 
 #if defined(CARBONATED)
-#if defined(CARBONATED_USE_PIXEL_WORKAROUND)
-        if (m_usingPixelWorkaround)
+#if defined(CARBONATED_USE_MALI_G715_WORKAROUND)
+        if (m_usingMaliG715Workaround)
         {
             for (const DrawCommand& cmd : m_drawCommands)
             {
@@ -197,19 +197,15 @@ namespace LyShine
                         AZ::RHI::IndexFormat::Uint16,
                         drawSrg);
                 }
-                else // SinglePrimitive
+                else if (LyShine::UiPrimitive* prim = cmd.m_primitive) // SinglePrimitive
                 {
-                    LyShine::UiPrimitive* prim = cmd.m_primitive;
-                    if (prim)
-                    {
-                        dynamicDraw->DrawIndexed(
-                            prim->m_vertices,
-                            static_cast<uint32_t>(prim->m_numVertices),
-                            prim->m_indices,
-                            static_cast<uint32_t>(prim->m_numIndices),
-                            AZ::RHI::IndexFormat::Uint16,
-                            drawSrg);
-                    }
+                    dynamicDraw->DrawIndexed(
+                        prim->m_vertices,
+                        static_cast<uint32_t>(prim->m_numVertices),
+                        prim->m_indices,
+                        static_cast<uint32_t>(prim->m_numIndices),
+                        AZ::RHI::IndexFormat::Uint16,
+                        drawSrg);
                 }
             }
         }
@@ -222,7 +218,7 @@ namespace LyShine
         {
             dynamicDraw->DrawIndexed(&m_combinedVertices[0], (uint32_t)m_combinedVertices.size(), &m_combinedIndices[0],  (uint32_t)m_combinedIndices.size(), AZ::RHI::IndexFormat::Uint16, drawSrg);
         }
-#endif // CARBONATED_USE_PIXEL_WORKAROUND
+#endif // CARBONATED_USE_MALI_G715_WORKAROUND
 #else // CARBONATED
         // Add the indexed primitives to the dynamic draw context for drawing
         //
@@ -242,14 +238,17 @@ namespace LyShine
     void PrimitiveListRenderNode::AddPrimitive(LyShine::UiPrimitive* primitive)
     {
 #if defined(CARBONATED)
-#if defined(CARBONATED_USE_PIXEL_WORKAROUND)
+#if defined(CARBONATED_USE_MALI_G715_WORKAROUND)
+        // This is a certain "magic" number, determined experimentally on Google Pixel 9.
+        // In some menus containing small square and rectangular "cards" with a side size greater than 24 pixels, we almost always see a "snow glitch".
+        // The "snow glitch" does not occur on smaller UI elements (text strings, thin borders, horizontal margins, etc.)
         constexpr float MinSizeOfSideOfBigPrimitive = 24.0f;
 
         // always clear the next pointer before adding to list
         primitive->m_next = nullptr;
         m_primitives.push_back(*primitive);
 
-        if (m_usingPixelWorkaround)
+        if (m_usingMaliG715Workaround)
         {
             float maxX = 0, maxY = 0, minX = 100000.0f, minY = 100000.0f;
             float maxWidth, maxHeight;
@@ -343,7 +342,7 @@ namespace LyShine
         {
             m_combinedIndices[index_start + i] = vertex_start + primitive->m_indices[i];
         }
-#endif // CARBONATED_USE_PIXEL_WORKAROUND
+#endif // CARBONATED_USE_MALI_G715_WORKAROUND
 #endif // CARBONATED
 
         m_totalNumVertices += primitive->m_numVertices;
@@ -753,14 +752,14 @@ namespace LyShine
         // then it becomes the node list for that render node.
         m_renderNodeListStack.push(&m_renderNodes);
 
-#if defined(CARBONATED) && defined(CARBONATED_USE_PIXEL_WORKAROUND)
+#if defined(CARBONATED) && defined(CARBONATED_USE_MALI_G715_WORKAROUND)
         const AZ::RHI::Ptr<AZ::RHI::Device> rhiDevice = AZ::RHI::RHISystemInterface::Get()->GetDevice();
         if (rhiDevice)
         {
             const auto& descriptor = rhiDevice->GetPhysicalDevice().GetDescriptor();
-            // Currently (September 2025) we 100% know that Google Pixel 9 has glitch with sparkling white/color snow on the UI elements
-            // The workaround is to not combine rectangular/square primitives with size > 30 into big batches
-            m_usingPixelWorkaround = descriptor.m_description.contains("Mali-G715");
+            // At this time (September 2025) we know 100% that Google Pixel 8 and Pixel 9 have an issue with sparkling white/colored snow on UI elements.
+            // A workaround is to not combine rectangular/square primitives of size > 24 into large batches.
+            m_usingMaliG715Workaround = descriptor.m_description.contains("Mali-G715");
         }
         else
         {
@@ -979,8 +978,8 @@ namespace LyShine
                 // this uses a pool allocator for fast allocation
                 renderNodeToAddTo = new PrimitiveListRenderNode(texture, isClampTextureMode, isTextureSRGB, isPreMultiplyAlpha, blendModeState);
 
-#if defined(CARBONATED) && defined(CARBONATED_USE_PIXEL_WORKAROUND)
-                renderNodeToAddTo->SetPixelWorkaround(m_usingPixelWorkaround);
+#if defined(CARBONATED) && defined(CARBONATED_USE_MALI_G715_WORKAROUND)
+                renderNodeToAddTo->SetMaliG715Workaround(m_usingMaliG715Workaround);
 #endif
                 renderNodeList->push_back(renderNodeToAddTo);
                 texUnit = 0;
@@ -1064,8 +1063,8 @@ namespace LyShine
                 renderNodeToAddTo = new PrimitiveListRenderNode(contentAttachmentImage, maskAttachmentImage,
                     isClampTextureMode, isTextureSRGB, isPreMultiplyAlpha, alphaMaskType, blendModeState);
 
-#if defined(CARBONATED) && defined(CARBONATED_USE_PIXEL_WORKAROUND)
-                renderNodeToAddTo->SetPixelWorkaround(m_usingPixelWorkaround);
+#if defined(CARBONATED) && defined(CARBONATED_USE_MALI_G715_WORKAROUND)
+                renderNodeToAddTo->SetMaliG715Workaround(m_usingMaliG715Workaround);
 #endif
                 renderNodeList->push_back(renderNodeToAddTo);
                 texUnit0 = 0;

--- a/Gems/LyShine/Code/Source/RenderGraph.h
+++ b/Gems/LyShine/Code/Source/RenderGraph.h
@@ -106,8 +106,8 @@ namespace LyShine
         // Search to see if this texture is already used by this texture unit, returns -1 if not used
         int FindTexture(const AZ::Data::Instance<AZ::RPI::Image>& texture, bool isClampTextureMode) const;
 
-#if defined(CARBONATED) && defined(CARBONATED_USE_PIXEL_WORKAROUND)
-        void SetPixelWorkaround(bool useWorkaround);
+#if defined(CARBONATED) && defined(CARBONATED_USE_MALI_G715_WORKAROUND)
+        void SetMaliG715Workaround(bool useWorkaround);
 #endif
 
 #ifndef _RELEASE
@@ -138,7 +138,7 @@ namespace LyShine
         LyShine::UiPrimitiveList   m_primitives;
 
 #if defined(CARBONATED)
-#if defined(CARBONATED_USE_PIXEL_WORKAROUND)
+#if defined(CARBONATED_USE_MALI_G715_WORKAROUND)
         struct DrawCommand
         {
             enum class Type
@@ -157,8 +157,8 @@ namespace LyShine
         };
 
         AZStd::vector<DrawCommand> m_drawCommands;
-        bool m_usingPixelWorkaround = false;
-#endif // CARBONATED_USE_PIXEL_WORKAROUND
+        bool m_usingMaliG715Workaround = false;
+#endif // CARBONATED_USE_MALI_G715_WORKAROUND
 
         // Per-frame combined vertex and index buffers
         AZStd::vector<UiPrimitiveVertex> m_combinedVertices;
@@ -404,8 +404,8 @@ namespace LyShine
 #if defined(CARBONATED) && defined(CARBONATED_DROP_LYSHINE_OFFSCREEN_PRIMITIVES)
         AZ::Vector2                  m_viewportSize = AZ::Vector2(0.0f, 0.0f);
 #endif
-#if defined(CARBONATED) && defined(CARBONATED_USE_PIXEL_WORKAROUND)
-        bool m_usingPixelWorkaround = false;
+#if defined(CARBONATED) && defined(CARBONATED_USE_MALI_G715_WORKAROUND)
+        bool m_usingMaliG715Workaround = false;
 #endif
 
 #ifndef _RELEASE

--- a/Gems/LyShine/Code/Source/RenderGraph.h
+++ b/Gems/LyShine/Code/Source/RenderGraph.h
@@ -106,6 +106,10 @@ namespace LyShine
         // Search to see if this texture is already used by this texture unit, returns -1 if not used
         int FindTexture(const AZ::Data::Instance<AZ::RPI::Image>& texture, bool isClampTextureMode) const;
 
+#if defined(CARBONATED) && defined(CARBONATED_USE_PIXEL_WORKAROUND)
+        void SetPixelWorkaround(bool useWorkaround);
+#endif
+
 #ifndef _RELEASE
         // A debug-only function useful for debugging
         void ValidateNode() override;
@@ -134,6 +138,28 @@ namespace LyShine
         LyShine::UiPrimitiveList   m_primitives;
 
 #if defined(CARBONATED)
+#if defined(CARBONATED_USE_PIXEL_WORKAROUND)
+        struct DrawCommand
+        {
+            enum class Type
+            {
+                CombinedBatch,
+                SinglePrimitive
+            };
+
+            Type m_type;
+            int m_combinedVertexStart = 0;
+            int m_combinedVertexCount = 0;
+            int m_combinedIndexStart = 0;
+            int m_combinedIndexCount = 0;
+
+            LyShine::UiPrimitive* m_primitive = nullptr;
+        };
+
+        AZStd::vector<DrawCommand> m_drawCommands;
+        bool m_usingPixelWorkaround = false;
+#endif // CARBONATED_USE_PIXEL_WORKAROUND
+
         // Per-frame combined vertex and index buffers
         AZStd::vector<UiPrimitiveVertex> m_combinedVertices;
         AZStd::vector<uint16> m_combinedIndices;
@@ -377,6 +403,9 @@ namespace LyShine
 
 #if defined(CARBONATED) && defined(CARBONATED_DROP_LYSHINE_OFFSCREEN_PRIMITIVES)
         AZ::Vector2                  m_viewportSize = AZ::Vector2(0.0f, 0.0f);
+#endif
+#if defined(CARBONATED) && defined(CARBONATED_USE_PIXEL_WORKAROUND)
+        bool m_usingPixelWorkaround = false;
 #endif
 
 #ifndef _RELEASE


### PR DESCRIPTION
## What does this PR do?

1. Size of bufferImageHeight in Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp is adjusted to fix errors reported by Validation Layer.
2. DestroySwapchainKHR should be performed together with SwappyVk_destroySwapchain in Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
3. GPU drivers on Google Pixel 9 (GPU Mali-G715) have errors that produces white/color snow in different 2D UI elements. It was discovered that this bug can be fixed if UI Primitives which has X and Y size greater than 24 pixels are rendered separately, i.e. are not combined into one batch. 

The special DrawCommand list was implemented. It keeps the order of the single and combined primitives.

## How was this PR tested?

MadWorld on Google Pixel 9 now doesn't has any 'snow' in any menus.
