### PR TITLE
NOTICKET: Native Dialod "is in background" check fix

### DIFF
--- a/Code/Framework/AzAndroid/java/com/amazon/lumberyard/NativeUI/LumberyardNativeUI.java
+++ b/Code/Framework/AzAndroid/java/com/amazon/lumberyard/NativeUI/LumberyardNativeUI.java
@@ -73,7 +73,7 @@ public class LumberyardNativeUI
         final CountDownLatch latchUserSelection = new CountDownLatch(1);
         final CountDownLatch latchShow = new CountDownLatch(1);
 
-        if (IsActivityResumed(activity))
+        if (!IsActivityResumed(activity))
         {
             Log.e(TAG, "The dialog cannot be shown because the application is in the background.");
             return "";

--- a/Code/Framework/AzAndroid/java/com/amazon/lumberyard/NativeUI/LumberyardNativeUI.java
+++ b/Code/Framework/AzAndroid/java/com/amazon/lumberyard/NativeUI/LumberyardNativeUI.java
@@ -207,6 +207,9 @@ public class LumberyardNativeUI
         Log.e(TAG, "Deadlock detected at " + dateStr + "\nfile path '" + logFile.getAbsolutePath() + "'");
         Log.e(TAG, "Dialog title: " + title);
         Log.e(TAG, "Dialog message: " + message);
+
+        android.os.Process.killProcess(android.os.Process.myPid());
+        System.exit(10);
     }
 
     public static boolean IsDialogShowing()

--- a/Code/Framework/AzAndroid/java/com/amazon/lumberyard/NativeUI/LumberyardNativeUI.java
+++ b/Code/Framework/AzAndroid/java/com/amazon/lumberyard/NativeUI/LumberyardNativeUI.java
@@ -182,7 +182,14 @@ public class LumberyardNativeUI
         Context context = activity.getApplicationContext();
         String dateStr = new SimpleDateFormat("MM-dd-yyyy hh.mma", Locale.US).format(new Date());
         String fileName = "BlockingDialogDeadlock " + dateStr + ".txt";
-        File logFile = new File(context.getFilesDir(), fileName);
+
+        File logDir = context.getExternalFilesDir("deadlock_logs");
+        if (logDir == null) {
+            Log.e(TAG, "External files dir is null, fallback to internal");
+            logDir = new File(context.getFilesDir(), "deadlock_logs");
+        }
+
+        File logFile = new File(logDir, fileName);
 
         try (FileWriter writer = new FileWriter(logFile, true))
         {

--- a/Code/Framework/AzAndroid/java/com/amazon/lumberyard/NativeUI/LumberyardNativeUI.java
+++ b/Code/Framework/AzAndroid/java/com/amazon/lumberyard/NativeUI/LumberyardNativeUI.java
@@ -207,9 +207,6 @@ public class LumberyardNativeUI
         Log.e(TAG, "Deadlock detected at " + dateStr + "\nfile path '" + logFile.getAbsolutePath() + "'");
         Log.e(TAG, "Dialog title: " + title);
         Log.e(TAG, "Dialog message: " + message);
-
-        android.os.Process.killProcess(android.os.Process.myPid());
-        System.exit(10);
     }
 
     public static boolean IsDialogShowing()


### PR DESCRIPTION
Native Dialod "is in background" check has been fixed
log file path changed to "/storage/emulated/0/Android/data/com.carbonated.madworld.android/files/deadlock_logs/..."
