### PR TITLE
CAR-18076. Implement GPU profiling for Vulkan RHI (Android)

### DIFF
--- a/Gems/Atom/RHI/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Device.cpp
@@ -211,7 +211,7 @@ namespace AZ::RHI
 #if defined(AZ_PLATFORM_IOS) || defined(AZ_PLATFORM_MAC)
                         fc.m_commands[ib].m_commitTime = double(clock_gettime_nsec_np(CLOCK_UPTIME_RAW)) / 1000000000.0;
 #else
-                        fc.m_commands[ib].m_commitTime = static_cast<double>(AZ::GetRealElapsedTimeUs()) / 1000000.0;
+                        fc.m_commands[ib].m_commitTime = AZStd::GetTimeNowTicks() / 1e9;    // Use time since system start like all Vulkan timestamps
 #endif
                         break;
                     }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
@@ -750,9 +750,6 @@ namespace AZ
 
             uint64_t timestamps[2] = {};
 
-            const auto& physicalDevice = static_cast<const PhysicalDevice&>(GetDevice().GetPhysicalDevice());
-            double timestampPeriod = physicalDevice.GetDeviceLimits().timestampPeriod; // ns per tick
-
             VkResult result = context.GetQueryPoolResults(
                 device.GetNativeDevice(),
                 m_queryPool,
@@ -763,38 +760,39 @@ namespace AZ
                 sizeof(uint64_t),
                 VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
 
-            if (result == VK_SUCCESS)
-            {
-                uint64_t gpuStart = timestamps[0];
-                uint64_t gpuEnd = timestamps[1];
-
-                // Convert raw ticks → seconds
-                double gpuStartSec = (gpuStart * timestampPeriod) / 1e9;
-                double gpuEndSec = (gpuEnd * timestampPeriod) / 1e9;
-
-                // Align GPU timeline to CPU timeline
-                static bool s_hasBase = false;
-                static double s_gpuToCpuOffset = 0.0;
-
-                if (!s_hasBase)
-                {
-                    // Current time (CPU) in seconds since app start
-                    double currentTime = static_cast<double>(AZ::GetRealElapsedTimeUs()) / 1'000'000.0;
-
-                    // First time we establish offset
-                    s_gpuToCpuOffset = currentTime - gpuStartSec;
-                    s_hasBase = true;
-                }
-
-                gpuStartSec += s_gpuToCpuOffset;
-                gpuEndSec += s_gpuToCpuOffset;
-
-                GetDevice().CommandBufferCompleted(m_nativeCommandBuffer, gpuStartSec, gpuEndSec);
-            }
-            else
+            if (result != VK_SUCCESS)
             {
                 GetDevice().CommandBufferCompleted(m_nativeCommandBuffer, 0, 0);
+                return;
             }
+
+            const auto& physicalDevice = static_cast<const PhysicalDevice&>(device.GetPhysicalDevice());
+            double timestampPeriod = physicalDevice.GetDeviceLimits().timestampPeriod; // ns per tick
+
+            uint64_t gpuStart = timestamps[0];
+            uint64_t gpuEnd = timestamps[1];
+
+            // Convert GPU ticks to seconds
+            double gpuStartSec = (gpuStart * timestampPeriod) / 1e9;
+            double gpuEndSec = (gpuEnd * timestampPeriod) / 1e9;
+
+            // GPU->CPU offset, computed once
+            static bool s_hasBase = false;
+            static double s_gpuToCpuOffset = 0.0;
+
+            if (!s_hasBase)
+            {
+                double currentTime = static_cast<double>(AZ::GetRealElapsedTimeUs()) / 1'000'000.0;
+                s_gpuToCpuOffset = currentTime - gpuEndSec;
+                s_hasBase = true;
+            }
+
+            // Apply offset once
+            gpuStartSec += s_gpuToCpuOffset;
+            gpuEndSec += s_gpuToCpuOffset;
+
+            // Report results
+            GetDevice().CommandBufferCompleted(m_nativeCommandBuffer, gpuStartSec, gpuEndSec);
         }
 #endif
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
@@ -776,23 +776,42 @@ namespace AZ
             double gpuStartSec = (gpuStart * timestampPeriod) / 1e9;
             double gpuEndSec = (gpuEnd * timestampPeriod) / 1e9;
 
-            // GPU->CPU offset, computed once
-            static bool s_hasBase = false;
-            static double s_gpuToCpuOffset = 0.0;
+            // Calibration
+            VkCalibratedTimestampInfoEXT timestampInfos[2] = {};
+            timestampInfos[0].sType = VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_EXT;
+            timestampInfos[0].timeDomain = VK_TIME_DOMAIN_DEVICE_EXT; // GPU
 
-            if (!s_hasBase)
+            timestampInfos[1].sType = VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_EXT;
+            timestampInfos[1].timeDomain = VK_TIME_DOMAIN_CLOCK_MONOTONIC_EXT; // CPU
+
+            uint64_t timestampsCalibration[2] = {};
+            uint64_t maxDeviation = 0;
+
+            result = context.GetCalibratedTimestampsEXT(device.GetNativeDevice(), 2, timestampInfos, timestampsCalibration, &maxDeviation);
+
+            if (result == VK_SUCCESS)
             {
-                double currentTime = static_cast<double>(AZ::GetRealElapsedTimeUs()) / 1'000'000.0;
-                s_gpuToCpuOffset = currentTime - gpuEndSec;
-                s_hasBase = true;
+                uint64_t gpuCalibTicks = timestampsCalibration[0];
+                uint64_t cpuCalibNs = timestampsCalibration[1];
+
+                // Calculate calibration in Seconds
+                double gpuCalibSec = (gpuCalibTicks * timestampPeriod) / 1e9;
+                double cpuCalibSec = cpuCalibNs / 1e9;
+
+                // Calculation time shift
+                double timeShiftSec = cpuCalibSec - gpuCalibSec;
+
+                // Apply calibration
+                double gpuStartCpuSec = gpuStartSec + timeShiftSec;
+                double gpuEndCpuSec = gpuEndSec + timeShiftSec;
+
+                GetDevice().CommandBufferCompleted(m_nativeCommandBuffer, gpuStartCpuSec, gpuEndCpuSec);
             }
-
-            // Apply offset once
-            gpuStartSec += s_gpuToCpuOffset;
-            gpuEndSec += s_gpuToCpuOffset;
-
-            // Report results
-            GetDevice().CommandBufferCompleted(m_nativeCommandBuffer, gpuStartSec, gpuEndSec);
+            else
+            {
+                // Fallback to not corrected values
+                GetDevice().CommandBufferCompleted(m_nativeCommandBuffer, gpuStartSec, gpuEndSec);
+            }
         }
 #endif
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
@@ -769,12 +769,12 @@ namespace AZ
             const auto& physicalDevice = static_cast<const PhysicalDevice&>(device.GetPhysicalDevice());
             double timestampPeriod = physicalDevice.GetDeviceLimits().timestampPeriod; // ns per tick
 
-            uint64_t gpuStart = timestamps[0];
-            uint64_t gpuEnd = timestamps[1];
+            const uint64_t gpuStart = timestamps[0];
+            const uint64_t gpuEnd = timestamps[1];
 
             // Convert GPU ticks to seconds
-            double gpuStartSec = (gpuStart * timestampPeriod) / 1e9;
-            double gpuEndSec = (gpuEnd * timestampPeriod) / 1e9;
+            const double gpuStartSec = (gpuStart * timestampPeriod) / 1e9;
+            const double gpuEndSec = (gpuEnd * timestampPeriod) / 1e9;
 
             // Calibration
             VkCalibratedTimestampInfoEXT timestampInfos[2] = {};
@@ -791,19 +791,19 @@ namespace AZ
 
             if (result == VK_SUCCESS)
             {
-                uint64_t gpuCalibTicks = timestampsCalibration[0];
-                uint64_t cpuCalibNs = timestampsCalibration[1];
+                const uint64_t gpuCalibTicks = timestampsCalibration[0];
+                const uint64_t cpuCalibNs = timestampsCalibration[1];
 
                 // Calculate calibration in Seconds
-                double gpuCalibSec = (gpuCalibTicks * timestampPeriod) / 1e9;
-                double cpuCalibSec = cpuCalibNs / 1e9;
+                const double gpuCalibSec = (gpuCalibTicks * timestampPeriod) / 1e9;
+                const double cpuCalibSec = cpuCalibNs / 1e9;
 
                 // Calculation time shift
-                double timeShiftSec = cpuCalibSec - gpuCalibSec;
+                const double timeShiftSec = cpuCalibSec - gpuCalibSec;
 
                 // Apply calibration
-                double gpuStartCpuSec = gpuStartSec + timeShiftSec;
-                double gpuEndCpuSec = gpuEndSec + timeShiftSec;
+                const double gpuStartCpuSec = gpuStartSec + timeShiftSec;
+                const double gpuEndCpuSec = gpuEndSec + timeShiftSec;
 
                 GetDevice().CommandBufferCompleted(m_nativeCommandBuffer, gpuStartCpuSec, gpuEndCpuSec);
             }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
@@ -69,7 +69,7 @@ namespace AZ
             queryPoolInfo.queryType = VK_QUERY_TYPE_TIMESTAMP;
             queryPoolInfo.queryCount = 2; // start + end
             static_cast<Device&>(GetDevice()).GetContext().CreateQueryPool(device.GetNativeDevice(), &queryPoolInfo, nullptr, &m_queryPool);
-#endif						
+#endif
             return result;
         }
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
@@ -36,6 +36,10 @@
 #include <Atom/RHI.Reflect/IndirectBufferLayout.h>
 #include <Atom/RHI/DispatchRaysItem.h>
 
+#if defined(CARBONATED)
+#include <RHI/ReleaseContainer.h>
+#include <AzCore/Time/ITime.h>
+#endif
 namespace AZ
 {
     namespace Vulkan
@@ -59,6 +63,13 @@ namespace AZ
             const auto& physicalDevice = static_cast<const PhysicalDevice&>(device.GetPhysicalDevice());
             m_supportsPredication = physicalDevice.IsFeatureSupported(DeviceFeature::Predication);
             m_supportsDrawIndirectCount = physicalDevice.IsFeatureSupported(DeviceFeature::DrawIndirectCount);
+#if defined(CARBONATED)
+            VkQueryPoolCreateInfo queryPoolInfo = {};
+            queryPoolInfo.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
+            queryPoolInfo.queryType = VK_QUERY_TYPE_TIMESTAMP;
+            queryPoolInfo.queryCount = 2; // start + end
+            static_cast<Device&>(GetDevice()).GetContext().CreateQueryPool(device.GetNativeDevice(), &queryPoolInfo, nullptr, &m_queryPool);
+#endif						
             return result;
         }
 
@@ -643,6 +654,15 @@ namespace AZ
 
         void CommandList::Shutdown()
         {
+#if defined(CARBONATED)
+            if (m_queryPool)
+            {
+                auto& device = static_cast<Device&>(GetDevice());
+                device.QueueForRelease(
+                    new ReleaseContainer<VkQueryPool>(device.GetNativeDevice(), m_queryPool, device.GetContext().DestroyQueryPool));
+                m_queryPool = VK_NULL_HANDLE;
+            }
+#endif
             m_nativeCommandBuffer = VK_NULL_HANDLE; // do not call vkFreeCommanBuffers().
             DeviceObject::Shutdown();
         }
@@ -681,17 +701,102 @@ namespace AZ
 
             VkResult vkResult = static_cast<Device&>(GetDevice()).GetContext().BeginCommandBuffer(m_nativeCommandBuffer, &beginInfo);
             AssertSuccess(vkResult);
+#if defined(CARBONATED)
+            if (m_queryPool)
+            {
+                // Reset both queries before using them
+                static_cast<Device&>(GetDevice())
+                    .GetContext()
+                    .CmdResetQueryPool(m_nativeCommandBuffer, m_queryPool, m_timestampStartIndex, 2);
+
+                // Write timestamp at beginning
+                static_cast<Device&>(GetDevice())
+                    .GetContext()
+                    .CmdWriteTimestamp(m_nativeCommandBuffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, m_queryPool, m_timestampStartIndex);
+            }
+#endif
         }
 
         void CommandList::EndCommandBuffer()
         {
             AZ_Assert(m_isUpdating, "Not in updating state");
 
+#if defined(CARBONATED)
+            if (m_queryPool)
+            {
+                // Write timestamp at the end
+                static_cast<Device&>(GetDevice())
+                    .GetContext()
+                    .CmdWriteTimestamp(m_nativeCommandBuffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, m_queryPool, m_timestampEndIndex);
+            }
+#endif
             m_state.m_framebuffer = nullptr;
             m_state.m_subpassIndex = 0;
             AssertSuccess(static_cast<Device&>(GetDevice()).GetContext().EndCommandBuffer(m_nativeCommandBuffer));
             m_isUpdating = false;
         }
+
+#if defined(CARBONATED)
+        void CommandList::StartGPUStatistics()
+        {
+            GetDevice().RegisterCommandBuffer(m_nativeCommandBuffer);
+            GetDevice().MarkCommandBufferCommit(m_nativeCommandBuffer);
+        }
+
+        void CommandList::CollectGPUStatistics()
+        {
+            const auto& device = static_cast<Device&>(GetDevice());
+            const auto& context = device.GetContext();
+
+            uint64_t timestamps[2] = {};
+
+            const auto& physicalDevice = static_cast<const PhysicalDevice&>(GetDevice().GetPhysicalDevice());
+            double timestampPeriod = physicalDevice.GetDeviceLimits().timestampPeriod; // ns per tick
+
+            VkResult result = context.GetQueryPoolResults(
+                device.GetNativeDevice(),
+                m_queryPool,
+                m_timestampStartIndex,
+                2,
+                sizeof(timestamps),
+                timestamps,
+                sizeof(uint64_t),
+                VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
+
+            if (result == VK_SUCCESS)
+            {
+                uint64_t gpuStart = timestamps[0];
+                uint64_t gpuEnd = timestamps[1];
+
+                // Convert raw ticks → seconds
+                double gpuStartSec = (gpuStart * timestampPeriod) / 1e9;
+                double gpuEndSec = (gpuEnd * timestampPeriod) / 1e9;
+
+                // Align GPU timeline to CPU timeline
+                static bool s_hasBase = false;
+                static double s_gpuToCpuOffset = 0.0;
+
+                if (!s_hasBase)
+                {
+                    // Current time (CPU) in seconds since app start
+                    double currentTime = static_cast<double>(AZ::GetRealElapsedTimeUs()) / 1'000'000.0;
+
+                    // First time we establish offset
+                    s_gpuToCpuOffset = currentTime - gpuStartSec;
+                    s_hasBase = true;
+                }
+
+                gpuStartSec += s_gpuToCpuOffset;
+                gpuEndSec += s_gpuToCpuOffset;
+
+                GetDevice().CommandBufferCompleted(m_nativeCommandBuffer, gpuStartSec, gpuEndSec);
+            }
+            else
+            {
+                GetDevice().CommandBufferCompleted(m_nativeCommandBuffer, 0, 0);
+            }
+        }
+#endif
 
         void CommandList::BeginRenderPass(const BeginRenderPassInfo& beginInfo)
         {

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.h
@@ -120,6 +120,10 @@ namespace AZ
 
             RHI::CommandListValidator& GetValidator();
 
+#if defined(CARBONATED)
+            void StartGPUStatistics();
+            void CollectGPUStatistics();
+#endif
         private:
             struct Descriptor
             {
@@ -186,6 +190,11 @@ namespace AZ
             bool m_supportsPredication = false;
             bool m_supportsDrawIndirectCount = false;
             RHI::CommandListValidator m_validator;
+#if defined(CARBONATED)
+            VkQueryPool m_queryPool = VK_NULL_HANDLE;
+            const uint32_t m_timestampStartIndex = 0;
+            const uint32_t m_timestampEndIndex = 1;
+#endif
         };
 
         template<class Item>

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandQueue.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandQueue.cpp
@@ -51,6 +51,9 @@ namespace AZ
 
                 Queue* vulkanQueue = static_cast<Queue*>(queue);
 
+#if defined(CARBONATED)
+                request.m_commandList->StartGPUStatistics();
+#endif
                 if (!request.m_debugLabel.empty())
                 {
                     vulkanQueue->BeginDebugLabel(request.m_debugLabel.c_str());
@@ -99,6 +102,10 @@ namespace AZ
                 {
                     vulkanQueue->EndDebugLabel();
                 }
+
+#if defined(CARBONATED)
+                request.m_commandList->CollectGPUStatistics();
+#endif
             });
         }
         

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandQueue.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandQueue.cpp
@@ -87,7 +87,9 @@ namespace AZ
                    const auto& fence = request.m_fencesToSignal[i];
                    Signal(*fence);
                 }
-
+#if defined(CARBONATED)
+                request.m_commandList->CollectGPUStatistics();
+#endif
                 {
                     AZ::Debug::ScopedTimer presentTimer(m_lastPresentDuration);
 
@@ -102,10 +104,6 @@ namespace AZ
                 {
                     vulkanQueue->EndDebugLabel();
                 }
-
-#if defined(CARBONATED)
-                request.m_commandList->CollectGPUStatistics();
-#endif
             });
         }
         

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
@@ -305,6 +305,9 @@ namespace AZ
         {
             // The order must match the enum OptionalDeviceExtensions
             RawStringList optionalExtensions = { {
+#if defined(CARBONATED)
+                VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME,
+#endif
                 VK_EXT_SAMPLE_LOCATIONS_EXTENSION_NAME,
                 VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME,
                 VK_EXT_MEMORY_BUDGET_EXTENSION_NAME,


### PR DESCRIPTION
## What does this PR do?

Inserts timestamps into the beginning and into the end of the Vulkan Command Buffer to calculate what time GPU works and show in the profiling window (activated with "mw_thread_profiler 1")

## How was this PR tested?

Profiling is enabled and the screen is observed.
