### PR TITLE
Hot fix for launching the game on Windows

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
@@ -305,10 +305,10 @@ namespace AZ
         {
             // The order must match the enum OptionalDeviceExtensions
             RawStringList optionalExtensions = { {
+                VK_EXT_SAMPLE_LOCATIONS_EXTENSION_NAME,
 #if defined(CARBONATED)
                 VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME,
 #endif
-                VK_EXT_SAMPLE_LOCATIONS_EXTENSION_NAME,
                 VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME,
                 VK_EXT_MEMORY_BUDGET_EXTENSION_NAME,
                 VK_EXT_DEPTH_CLIP_ENABLE_EXTENSION_NAME,

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.h
@@ -41,6 +41,9 @@ namespace AZ
         enum class OptionalDeviceExtension : uint32_t
         {
             SampleLocation = 0,
+#if defined(CARBONATED)
+            CalibratedTimestamps,
+#endif
             ConditionalRendering,
             MemoryBudget,
             DepthClipEnable,


### PR DESCRIPTION
## What does this PR do?

After launching the windows version of the game an assert happened. The reason is in the new OptionalDeviceExtension::CalibratedTimestamps that was added but android build ignores that assert.

## How was this PR tested?

Now the game is launched on the Windows.
