### PR TITLE
Support correct names of the threads on Android. Fix when CalibratedTimestamps extension is not supported.

### DIFF
--- a/Code/Framework/AzCore/Platform/Android/AzCore/std/parallel/internal/thread_Android.cpp
+++ b/Code/Framework/AzCore/Platform/Android/AzCore/std/parallel/internal/thread_Android.cpp
@@ -11,6 +11,12 @@
 #include <sched.h>
 #include <errno.h>
 
+#if defined(CARBONATED)
+#include <unordered_map>
+#include <mutex>
+#include <string>
+#endif
+
 namespace AZStd
 {
     namespace Platform
@@ -41,5 +47,31 @@ namespace AZStd
             // Don't use a scheduling policy value (e.g. SCHED_OTHER or SCHED_FIFO) here.
             return 1;
         }
+
+#if defined(CARBONATED)
+
+        // Global table  tid -> thread name
+        static std::unordered_map<pid_t, std::string> g_tidToName;
+        static std::mutex g_tidToNameMutex;
+
+        void RegisterThreadName(pid_t tid, const char* name)
+        {
+            std::lock_guard<std::mutex> lock(g_tidToNameMutex);
+            g_tidToName[tid] = name;
+        }
+
+        void UnregisterThreadName(pid_t tid)
+        {
+            std::lock_guard<std::mutex> lock(g_tidToNameMutex);
+            g_tidToName.erase(tid);
+        }
+
+        std::string GetThreadName(pid_t tid)
+        {
+            std::lock_guard<std::mutex> lock(g_tidToNameMutex);
+            auto it = g_tidToName.find(tid);
+            return it != g_tidToName.end() ? it->second : "";
+        }
+#endif
     }
 }

--- a/Code/Framework/AzCore/Platform/Android/AzCore/std/parallel/internal/thread_Android.cpp
+++ b/Code/Framework/AzCore/Platform/Android/AzCore/std/parallel/internal/thread_Android.cpp
@@ -15,7 +15,6 @@
 #include <AzCore/std/containers/unordered_map.h>
 #include <AzCore/std/string/string.h>
 #include <AzCore/std/parallel/mutex.h>
-//#include <AzCore/std/parallel/thread.h>
 #include <AzCore/std/parallel/lock.h>
 #endif
 

--- a/Code/Framework/AzCore/Platform/Android/AzCore/std/parallel/internal/thread_Android.cpp
+++ b/Code/Framework/AzCore/Platform/Android/AzCore/std/parallel/internal/thread_Android.cpp
@@ -12,9 +12,11 @@
 #include <errno.h>
 
 #if defined(CARBONATED)
-#include <unordered_map>
-#include <mutex>
-#include <string>
+#include <AzCore/std/containers/unordered_map.h>
+#include <AzCore/std/string/string.h>
+#include <AzCore/std/parallel/mutex.h>
+//#include <AzCore/std/parallel/thread.h>
+#include <AzCore/std/parallel/lock.h>
 #endif
 
 namespace AZStd
@@ -51,24 +53,24 @@ namespace AZStd
 #if defined(CARBONATED)
 
         // Global table  tid -> thread name
-        static std::unordered_map<pid_t, std::string> g_tidToName;
-        static std::mutex g_tidToNameMutex;
+        static AZStd::unordered_map<pid_t, AZStd::string> g_tidToName;
+        static AZStd::mutex g_tidToNameMutex;
 
         void RegisterThreadName(pid_t tid, const char* name)
         {
-            std::lock_guard<std::mutex> lock(g_tidToNameMutex);
+            AZStd::lock_guard<AZStd::mutex> lock(g_tidToNameMutex);
             g_tidToName[tid] = name;
         }
 
         void UnregisterThreadName(pid_t tid)
         {
-            std::lock_guard<std::mutex> lock(g_tidToNameMutex);
+            AZStd::lock_guard<AZStd::mutex> lock(g_tidToNameMutex);
             g_tidToName.erase(tid);
         }
 
-        std::string GetThreadName(pid_t tid)
+        AZStd::string GetThreadName(pid_t tid)
         {
-            std::lock_guard<std::mutex> lock(g_tidToNameMutex);
+            AZStd::lock_guard<AZStd::mutex> lock(g_tidToNameMutex);
             auto it = g_tidToName.find(tid);
             return it != g_tidToName.end() ? it->second : "";
         }

--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/std/parallel/internal/thread_UnixLike.h
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/std/parallel/internal/thread_UnixLike.h
@@ -22,6 +22,13 @@ namespace AZStd
         pthread_t create_thread(const thread_desc* desc, thread_info* ti);
     }
 
+#if defined(CARBONATED) && defined(AZ_PLATFORM_ANDROID)
+    namespace Platform
+    {
+        void RegisterThreadName(pid_t tid, const char* name);
+        void UnregisterThreadName(pid_t tid);
+    }
+#endif
     //////////////////////////////////////////////////////////////////////////
     // thread
     template<class F, class... Args, typename>
@@ -32,10 +39,22 @@ namespace AZStd
     template<class F, class... Args>
     thread::thread(const thread_desc& desc, F&& f, Args&&... args)
     {
+#if defined(CARBONATED) && defined(AZ_PLATFORM_ANDROID)
+        auto threadfunc = [fn = AZStd::forward<F>(f), argsTuple = AZStd::make_tuple(AZStd::forward<Args>(args)...), name = std::string(desc.m_name)]() mutable -> void
+        {
+            pid_t tid = gettid();
+            AZStd::Platform::RegisterThreadName(tid, name.c_str());
+
+            AZStd::apply(AZStd::move(fn), AZStd::move(argsTuple));
+
+            AZStd::Platform::UnregisterThreadName(tid);
+        };
+#else
         auto threadfunc = [fn = AZStd::forward<F>(f), argsTuple = AZStd::make_tuple(AZStd::forward<Args>(args)...)]() mutable -> void
         {
             AZStd::apply(AZStd::move(fn), AZStd::move(argsTuple));
         };
+#endif
         Internal::thread_info* ti = Internal::create_thread_info(AZStd::move(threadfunc));
         m_thread = Internal::create_thread(&desc, ti);
     }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
@@ -787,7 +787,11 @@ namespace AZ
             uint64_t timestampsCalibration[2] = {};
             uint64_t maxDeviation = 0;
 
-            result = context.GetCalibratedTimestampsEXT(device.GetNativeDevice(), 2, timestampInfos, timestampsCalibration, &maxDeviation);
+            result = VK_NOT_READY;
+            if (context.GetCalibratedTimestampsEXT)
+            {
+                result = context.GetCalibratedTimestampsEXT(device.GetNativeDevice(), 2, timestampInfos, timestampsCalibration, &maxDeviation);
+            }
 
             if (result == VK_SUCCESS)
             {

--- a/scripts/commit_validation/commit_validation/carbonated_pal_allowedlist.txt
+++ b/scripts/commit_validation/commit_validation/carbonated_pal_allowedlist.txt
@@ -1,6 +1,7 @@
 */Code/Framework/AzCore/AzCore/Settings/SettingsRegistryMergeUtils.h
 */Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
 */Code/Framework/AzCore/AzCore/Console/Console.cpp
+*/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/std/parallel/internal/thread_UnixLike.h
 */Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
 */Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialTypeAsset.cpp
 */Gems/Atom/RHI/Metal/Code/Source/RHI/PipelineState.cpp


### PR DESCRIPTION
## What does this PR do?

When some O3DE thread is started then we store its name in the map and remove it when the thread finishes.
The correct name's thread can be used to show in the thread profiling menu.

Protection from the crash if the CalibratedTimestamps extension is not supported.

## How was this PR tested?

Thread statistics is enabled and the correct names (instead of "Thread-2", "Thread-14") are displayed.
