### PR TITLE
Fixed FPS drop on Vulkan + more accurate GPU statistics

### DIFF
--- a/Code/Legacy/CrySystem/System.cpp
+++ b/Code/Legacy/CrySystem/System.cpp
@@ -536,7 +536,7 @@ extern DWORD g_idDebugThreads[];
 extern int g_nDebugThreads;
 int prev_sys_float_exceptions = -1;
 
-#if defined(CARBONATED) && defined(CARBONATED_DESIRED_FPS) && defined(AZ_PLATFORM_WINDOWS)
+#if defined(CARBONATED) && defined(CARBONATED_DESIRED_FPS) && (defined(AZ_PLATFORM_WINDOWS) || !defined(CARBONATED_USE_SWAPPY))
 AZ_CVAR_EXTERNED(uint32_t, vsync_interval);
 AZ_CVAR_EXTERNED(int32_t, sys_MaxFPS);
 #endif
@@ -635,7 +635,7 @@ bool CSystem::UpdatePreTickBus(int updateFlags, int nPauseMode)
     //for consoles this is done inside renderthread to be vsync dependent
     {
 
-#if defined(CARBONATED) && defined(CARBONATED_DESIRED_FPS) && defined(AZ_PLATFORM_WINDOWS)
+#if defined(CARBONATED) && defined(CARBONATED_DESIRED_FPS) && (defined(AZ_PLATFORM_WINDOWS) || !defined(CARBONATED_USE_SWAPPY))
         {
             int32 maxFPS = sys_MaxFPS;
             uint32 vSync = vsync_interval;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Device.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Device.h
@@ -274,6 +274,7 @@ namespace AZ::RHI
         double m_FrameGPUEndMaxTime = 0.0;
         bool m_statsEnabled = false;
         unsigned int m_lastFrameToLog = 0;
+        double m_startLogTime = 0;
 #endif
     };
 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Device.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Device.h
@@ -179,6 +179,7 @@ namespace AZ::RHI
         void RegisterCommandBuffer(const void* buffer);
         void MarkCommandBufferCommit(const void* buffer);
         void CommandBufferCompleted(const void* buffer, double begin, double end);
+        bool GatheringStatsEnabled();
         void EnableGatheringStats();
         void DisableGatheringStats();
 #endif

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Device.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Device.h
@@ -180,7 +180,7 @@ namespace AZ::RHI
         void MarkCommandBufferCommit(const void* buffer);
         void CommandBufferCompleted(const void* buffer, double begin, double end);
         bool GatheringStatsEnabled() const { return m_statsEnabled; }
-        void PerformShortGPUGathering(int count);
+        void LogGPUSnapshot(int nFrames);   // writes "commit+begin+end times" of nFrames into the Log
         void EnableGatheringStats();
         void DisableGatheringStats();
 #endif
@@ -273,7 +273,7 @@ namespace AZ::RHI
         double m_FrameGPUWaitAvgTime = 0.0;
         double m_FrameGPUEndMaxTime = 0.0;
         bool m_statsEnabled = false;
-        unsigned int m_framesToPutToLog = 0;
+        unsigned int m_lastFrameToLog = 0;
 #endif
     };
 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Device.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Device.h
@@ -179,7 +179,8 @@ namespace AZ::RHI
         void RegisterCommandBuffer(const void* buffer);
         void MarkCommandBufferCommit(const void* buffer);
         void CommandBufferCompleted(const void* buffer, double begin, double end);
-        bool GatheringStatsEnabled();
+        bool GatheringStatsEnabled() const { return m_statsEnabled; }
+        void PerformShortGPUGathering(int count);
         void EnableGatheringStats();
         void DisableGatheringStats();
 #endif
@@ -272,6 +273,7 @@ namespace AZ::RHI
         double m_FrameGPUWaitAvgTime = 0.0;
         double m_FrameGPUEndMaxTime = 0.0;
         bool m_statsEnabled = false;
+        unsigned int m_framesToPutToLog = 0;
 #endif
     };
 }

--- a/Gems/Atom/RHI/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Device.cpp
@@ -160,7 +160,7 @@ namespace AZ::RHI
                 AZ_Info("GPUtime", "begin frame at %f, frame num %u", t, m_frameCounter);
             }*/
 
-            if (m_framesToPutToLog >= m_frameCounter)
+            if (m_lastFrameToLog >= m_frameCounter)
             {
 #if defined(AZ_PLATFORM_IOS) || defined(AZ_PLATFORM_MAC)
                 const double t = double(clock_gettime_nsec_np(CLOCK_UPTIME_RAW)) / 1000000000.0;
@@ -177,9 +177,9 @@ namespace AZ::RHI
     }
 
 #if defined(CARBONATED)
-    void Device::PerformShortGPUGathering(int count)
+    void Device::LogGPUSnapshot(int nFrames)
     {
-        m_framesToPutToLog = m_frameCounter + count;
+        m_lastFrameToLog = m_frameCounter + nFrames;
     }
 
     void Device::RegisterCommandBuffer(const void* buffer)
@@ -267,17 +267,9 @@ namespace AZ::RHI
                         found = true;
                         if (end - begin > 0.0000005)  // there are zero execution time buffers, which we ignore
                         {
-                            if (m_framesToPutToLog >= m_frameCounter)
+                            if (m_lastFrameToLog >= m_frameCounter)
                             {
-                                AZ_Info(
-                                    "GPUtime", "Frame: %u. Buffer=%p. FrameNumber: %u. Commit: %f. Begin: %f. End: %f (%f)\n",
-                                    m_frameCounter,
-                                    buffer,
-                                    fc.m_frameNumber,
-                                    fc.m_commands[ib].m_commitTime,
-                                    begin,
-                                    end,
-                                    end - begin);
+                                AZ_Info("GPUtime", "frame %u, commit %f, begin: %f, end: %f\n", fc.m_frameNumber, fc.m_commands[ib].m_commitTime, begin, end);
                             }
                             //AZ_Info("GPUtime", "Add interval %f %f (%f) to frame %u", begin, end, end - begin, fc.m_frameNumber);
                             fc.RegisterInterval(fc.m_commands[ib].m_commitTime, begin, end);
@@ -422,7 +414,7 @@ namespace AZ::RHI
         m_FrameGPUWaitTime = 0.0;
         m_FrameGPUWaitAvgTime = 0.0;
         m_FrameGPUEndMaxTime = 0.0;
-        m_framesToPutToLog = 0;
+        m_lastFrameToLog = 0;
     }
 #endif
 

--- a/Gems/Atom/RHI/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Device.cpp
@@ -159,6 +159,16 @@ namespace AZ::RHI
                 const double t = double(clock_gettime_nsec_np(CLOCK_UPTIME_RAW)) / 1000000000.0;
                 AZ_Info("GPUtime", "begin frame at %f, frame num %u", t, m_frameCounter);
             }*/
+
+            if (m_framesToPutToLog > m_frameCounter)
+            {
+#if defined(AZ_PLATFORM_IOS) || defined(AZ_PLATFORM_MAC)
+                const double t = double(clock_gettime_nsec_np(CLOCK_UPTIME_RAW)) / 1000000000.0;
+#else
+                const double t = AZStd::GetTimeNowTicks() / 1e9; // Use time since system start like all Vulkan timestamps
+#endif
+                AZ_Info("GPUtime", "Begin Frame at %f. Frame num=%u\n", t, m_frameCounter);
+            }
             m_FrameTimeLock.unlock();
 #endif
             return BeginFrameInternal();
@@ -167,9 +177,9 @@ namespace AZ::RHI
     }
 
 #if defined(CARBONATED)
-    bool Device::GatheringStatsEnabled()
+    void Device::PerformShortGPUGathering(int count)
     {
-        return m_statsEnabled;
+        m_framesToPutToLog = m_frameCounter + count;
     }
 
     void Device::RegisterCommandBuffer(const void* buffer)
@@ -257,6 +267,18 @@ namespace AZ::RHI
                         found = true;
                         if (end - begin > 0.0000005)  // there are zero execution time buffers, which we ignore
                         {
+                            if (m_framesToPutToLog > m_frameCounter)
+                            {
+                                AZ_Info(
+                                    "GPUtime", "Frame: %u. Buffer=%p. FrameNumber: %u. Commit: %f. Begin: %f. End: %f (%f)\n",
+                                    m_frameCounter,
+                                    buffer,
+                                    fc.m_frameNumber,
+                                    fc.m_commands[ib].m_commitTime,
+                                    begin,
+                                    end,
+                                    end - begin);
+                            }
                             //AZ_Info("GPUtime", "Add interval %f %f (%f) to frame %u", begin, end, end - begin, fc.m_frameNumber);
                             fc.RegisterInterval(fc.m_commands[ib].m_commitTime, begin, end);
                         }
@@ -400,6 +422,7 @@ namespace AZ::RHI
         m_FrameGPUWaitTime = 0.0;
         m_FrameGPUWaitAvgTime = 0.0;
         m_FrameGPUEndMaxTime = 0.0;
+        m_framesToPutToLog = 0;
     }
 #endif
 

--- a/Gems/Atom/RHI/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Device.cpp
@@ -160,7 +160,7 @@ namespace AZ::RHI
                 AZ_Info("GPUtime", "begin frame at %f, frame num %u", t, m_frameCounter);
             }*/
 
-            if (m_framesToPutToLog > m_frameCounter)
+            if (m_framesToPutToLog >= m_frameCounter)
             {
 #if defined(AZ_PLATFORM_IOS) || defined(AZ_PLATFORM_MAC)
                 const double t = double(clock_gettime_nsec_np(CLOCK_UPTIME_RAW)) / 1000000000.0;
@@ -267,7 +267,7 @@ namespace AZ::RHI
                         found = true;
                         if (end - begin > 0.0000005)  // there are zero execution time buffers, which we ignore
                         {
-                            if (m_framesToPutToLog > m_frameCounter)
+                            if (m_framesToPutToLog >= m_frameCounter)
                             {
                                 AZ_Info(
                                     "GPUtime", "Frame: %u. Buffer=%p. FrameNumber: %u. Commit: %f. Begin: %f. End: %f (%f)\n",

--- a/Gems/Atom/RHI/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Device.cpp
@@ -167,6 +167,11 @@ namespace AZ::RHI
     }
 
 #if defined(CARBONATED)
+    bool Device::GatheringStatsEnabled()
+    {
+        return m_statsEnabled;
+    }
+
     void Device::RegisterCommandBuffer(const void* buffer)
     {
         if (!m_statsEnabled)

--- a/Gems/Atom/RHI/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Device.cpp
@@ -167,7 +167,7 @@ namespace AZ::RHI
 #else
                 const double t = AZStd::GetTimeNowTicks() / 1e9; // Use time since system start like all Vulkan timestamps
 #endif
-                AZ_Info("GPUtime", "Begin Frame at %f. Frame num=%u\n", t, m_frameCounter);
+                AZ_Info("GPUtime", "Begin Frame at %f. Frame num=%u\n", (t - m_startLogTime), m_frameCounter);
             }
             m_FrameTimeLock.unlock();
 #endif
@@ -180,6 +180,11 @@ namespace AZ::RHI
     void Device::LogGPUSnapshot(int nFrames)
     {
         m_lastFrameToLog = m_frameCounter + nFrames;
+#if defined(AZ_PLATFORM_IOS) || defined(AZ_PLATFORM_MAC)
+        m_startLogTime = double(clock_gettime_nsec_np(CLOCK_UPTIME_RAW)) / 1000000000.0;
+#else
+        m_startLogTime = AZStd::GetTimeNowTicks() / 1e9; // Use time since system start like all Vulkan timestamps
+#endif
     }
 
     void Device::RegisterCommandBuffer(const void* buffer)
@@ -269,7 +274,13 @@ namespace AZ::RHI
                         {
                             if (m_lastFrameToLog >= m_frameCounter)
                             {
-                                AZ_Info("GPUtime", "frame %u, commit %f, begin: %f, end: %f\n", fc.m_frameNumber, fc.m_commands[ib].m_commitTime, begin, end);
+                                AZ_Info(
+                                    "GPUtime",
+                                    "frame %u, commit %f, begin: %f, end: %f\n",
+                                    fc.m_frameNumber,
+                                    fc.m_commands[ib].m_commitTime - m_startLogTime,
+                                    begin - m_startLogTime,
+                                    end - m_startLogTime);
                             }
                             //AZ_Info("GPUtime", "Add interval %f %f (%f) to frame %u", begin, end, end - begin, fc.m_frameNumber);
                             fc.RegisterInterval(fc.m_commands[ib].m_commitTime, begin, end);
@@ -415,6 +426,7 @@ namespace AZ::RHI
         m_FrameGPUWaitAvgTime = 0.0;
         m_FrameGPUEndMaxTime = 0.0;
         m_lastFrameToLog = 0;
+        m_startLogTime = 0;
     }
 #endif
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
@@ -36,7 +36,7 @@
 #include <Atom/RHI.Reflect/IndirectBufferLayout.h>
 #include <Atom/RHI/DispatchRaysItem.h>
 
-#if defined(CARBONATED)
+#if defined(CARBONATED) && !defined(_RELEASE)
 #include <RHI/ReleaseContainer.h>
 #include <AzCore/Time/ITime.h>
 #endif
@@ -63,7 +63,7 @@ namespace AZ
             const auto& physicalDevice = static_cast<const PhysicalDevice&>(device.GetPhysicalDevice());
             m_supportsPredication = physicalDevice.IsFeatureSupported(DeviceFeature::Predication);
             m_supportsDrawIndirectCount = physicalDevice.IsFeatureSupported(DeviceFeature::DrawIndirectCount);
-#if defined(CARBONATED)
+#if defined(CARBONATED) && !defined(_RELEASE)
             VkQueryPoolCreateInfo queryPoolInfo = {};
             queryPoolInfo.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
             queryPoolInfo.queryType = VK_QUERY_TYPE_TIMESTAMP;
@@ -654,7 +654,7 @@ namespace AZ
 
         void CommandList::Shutdown()
         {
-#if defined(CARBONATED)
+#if defined(CARBONATED) && !defined(_RELEASE)
             if (m_queryPool)
             {
                 auto& device = static_cast<Device&>(GetDevice());
@@ -701,18 +701,23 @@ namespace AZ
 
             VkResult vkResult = static_cast<Device&>(GetDevice()).GetContext().BeginCommandBuffer(m_nativeCommandBuffer, &beginInfo);
             AssertSuccess(vkResult);
-#if defined(CARBONATED)
+#if defined(CARBONATED) && !defined(_RELEASE)
             if (m_queryPool)
             {
-                // Reset both queries before using them
-                static_cast<Device&>(GetDevice())
-                    .GetContext()
-                    .CmdResetQueryPool(m_nativeCommandBuffer, m_queryPool, m_timestampStartIndex, 2);
-
-                // Write timestamp at beginning
-                static_cast<Device&>(GetDevice())
-                    .GetContext()
-                    .CmdWriteTimestamp(m_nativeCommandBuffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, m_queryPool, m_timestampStartIndex);
+                if (m_collectingGPUStats = GetDevice().GatheringStatsEnabled())
+                {
+                    // Register and mark CommandBuffer
+                    GetDevice().RegisterCommandBuffer(m_nativeCommandBuffer);
+                    GetDevice().MarkCommandBufferCommit(m_nativeCommandBuffer);
+                    // Reset both queries before using them
+                    static_cast<Device&>(GetDevice())
+                        .GetContext()
+                        .CmdResetQueryPool(m_nativeCommandBuffer, m_queryPool, m_timestampStartIndex, 2);
+                    // Write timestamp at beginning
+                    static_cast<Device&>(GetDevice())
+                        .GetContext()
+                        .CmdWriteTimestamp(m_nativeCommandBuffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, m_queryPool, m_timestampStartIndex);
+                }
             }
 #endif
         }
@@ -721,13 +726,11 @@ namespace AZ
         {
             AZ_Assert(m_isUpdating, "Not in updating state");
 
-#if defined(CARBONATED)
-            if (m_queryPool)
+#if defined(CARBONATED) && !defined(_RELEASE)
+            if (m_queryPool && m_collectingGPUStats)
             {
                 // Write timestamp at the end
-                static_cast<Device&>(GetDevice())
-                    .GetContext()
-                    .CmdWriteTimestamp(m_nativeCommandBuffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, m_queryPool, m_timestampEndIndex);
+                static_cast<Device&>(GetDevice()).GetContext().CmdWriteTimestamp(m_nativeCommandBuffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, m_queryPool, m_timestampEndIndex);
             }
 #endif
             m_state.m_framebuffer = nullptr;
@@ -736,15 +739,13 @@ namespace AZ
             m_isUpdating = false;
         }
 
-#if defined(CARBONATED)
-        void CommandList::StartGPUStatistics()
-        {
-            GetDevice().RegisterCommandBuffer(m_nativeCommandBuffer);
-            GetDevice().MarkCommandBufferCommit(m_nativeCommandBuffer);
-        }
-
+#if defined(CARBONATED) && !defined(_RELEASE)
         void CommandList::CollectGPUStatistics()
         {
+            if (!m_collectingGPUStats)
+            {
+                return;
+            }
             const auto& device = static_cast<Device&>(GetDevice());
             const auto& context = device.GetContext();
 
@@ -758,8 +759,7 @@ namespace AZ
                 sizeof(timestamps),
                 timestamps,
                 sizeof(uint64_t),
-                VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
-
+                VK_QUERY_RESULT_64_BIT);
             if (result != VK_SUCCESS)
             {
                 GetDevice().CommandBufferCompleted(m_nativeCommandBuffer, 0, 0);
@@ -785,11 +785,11 @@ namespace AZ
             timestampInfos[1].timeDomain = VK_TIME_DOMAIN_CLOCK_MONOTONIC_EXT; // CPU
 
             uint64_t timestampsCalibration[2] = {};
-            uint64_t maxDeviation = 0;
 
             result = VK_NOT_READY;
             if (context.GetCalibratedTimestampsEXT)
             {
+                uint64_t maxDeviation = 0;
                 result = context.GetCalibratedTimestampsEXT(device.GetNativeDevice(), 2, timestampInfos, timestampsCalibration, &maxDeviation);
             }
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
@@ -706,9 +706,6 @@ namespace AZ
             {
                 if (m_collectingGPUStats = GetDevice().GatheringStatsEnabled())
                 {
-                    // Register and mark CommandBuffer
-                    GetDevice().RegisterCommandBuffer(m_nativeCommandBuffer);
-                    GetDevice().MarkCommandBufferCommit(m_nativeCommandBuffer);
                     // Reset both queries before using them
                     static_cast<Device&>(GetDevice())
                         .GetContext()

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
@@ -704,7 +704,8 @@ namespace AZ
 #if defined(CARBONATED) && !defined(_RELEASE)
             if (m_queryPool)
             {
-                if (m_collectingGPUStats = GetDevice().GatheringStatsEnabled())
+                m_collectingGPUStats = GetDevice().GatheringStatsEnabled();
+                if (m_collectingGPUStats)
                 {
                     // Reset both queries before using them
                     static_cast<Device&>(GetDevice())

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.h
@@ -120,8 +120,7 @@ namespace AZ
 
             RHI::CommandListValidator& GetValidator();
 
-#if defined(CARBONATED)
-            void StartGPUStatistics();
+#if defined(CARBONATED) && !defined(_RELEASE)
             void CollectGPUStatistics();
 #endif
         private:
@@ -190,7 +189,8 @@ namespace AZ
             bool m_supportsPredication = false;
             bool m_supportsDrawIndirectCount = false;
             RHI::CommandListValidator m_validator;
-#if defined(CARBONATED)
+#if defined(CARBONATED) && !defined(_RELEASE)
+            bool m_collectingGPUStats = false;
             VkQueryPool m_queryPool = VK_NULL_HANDLE;
             const uint32_t m_timestampStartIndex = 0;
             const uint32_t m_timestampEndIndex = 1;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandQueue.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandQueue.cpp
@@ -51,9 +51,6 @@ namespace AZ
 
                 Queue* vulkanQueue = static_cast<Queue*>(queue);
 
-#if defined(CARBONATED)
-                request.m_commandList->StartGPUStatistics();
-#endif
                 if (!request.m_debugLabel.empty())
                 {
                     vulkanQueue->BeginDebugLabel(request.m_debugLabel.c_str());
@@ -65,6 +62,12 @@ namespace AZ
                     semaphoresToSignal[index] = request.m_semaphoresToSignal[index]->GetNativeSemaphore();
                 }
 
+#if defined(CARBONATED) && !defined(_RELEASE)
+                // Create a temporary internal fence if no external fence was provided.
+                // Keep the RHI::Ptr alive by capturing it into the lambda (tempFenceCapture).
+                RHI::Ptr<Fence> tempFenceCapture = nullptr;
+                bool isTempFence = false;
+#endif
                 Fence* fenceToSignal = nullptr;
                 if (!request.m_fencesToSignal.empty())
                 {
@@ -73,7 +76,16 @@ namespace AZ
                     RHI::Ptr<Fence> fence = request.m_fencesToSignal.front();
                     fenceToSignal = fence.get();
                 }
-
+#if defined(CARBONATED) && !defined(_RELEASE)
+                else if (GetDevice().GatheringStatsEnabled())
+                {
+                    // Create a temporary internal fence for GPU statistics callback
+                    tempFenceCapture = Fence::Create();
+                    tempFenceCapture->Init(static_cast<Device&>(GetDevice()), AZ::RHI::FenceState::Reset);
+                    fenceToSignal = tempFenceCapture.get();
+                    isTempFence = true;
+                }
+#endif
                 // Submit commands to queue for the current frame.
                 vulkanQueue->SubmitCommandBuffers(
                     { request.m_commandList },
@@ -87,9 +99,6 @@ namespace AZ
                    const auto& fence = request.m_fencesToSignal[i];
                    Signal(*fence);
                 }
-#if defined(CARBONATED)
-                request.m_commandList->CollectGPUStatistics();
-#endif
                 {
                     AZ::Debug::ScopedTimer presentTimer(m_lastPresentDuration);
 
@@ -104,8 +113,99 @@ namespace AZ
                 {
                     vulkanQueue->EndDebugLabel();
                 }
+#if defined(CARBONATED) && !defined(_RELEASE)
+                if (GetDevice().GatheringStatsEnabled())
+                {
+                    // Register callback — store tempFenceCapture in the pending entry to keep it alive
+                    RegisterFenceCallback(
+                        AZStd::move(tempFenceCapture),
+                        fenceToSignal,
+                        isTempFence,
+                        [cmdList = request.m_commandList, isTempFence, tempFenceCapture]()
+                        {
+                            // This callback will be called from ProcessPendingFenceCallbacks when fence signaled
+                            cmdList->CollectGPUStatistics();
+                            if (isTempFence && tempFenceCapture)
+                            {
+                                tempFenceCapture->Shutdown();
+                            }
+                        });
+                }
+#endif
             });
+
+#if defined(CARBONATED) && !defined(_RELEASE)
+            if (GetDevice().GatheringStatsEnabled())
+            {
+                ProcessPendingFenceCallbacks();
+            }
+#endif
         }
+
+#if defined(CARBONATED) && !defined(_RELEASE)
+        void CommandQueue::RegisterFenceCallback(RHI::Ptr<Fence> fencePtr, Fence* fenceRaw, bool isTemp, AZStd::function<void()> cb)
+        {
+            PendingFenceCallback entry;
+            entry.fencePtr = AZStd::move(fencePtr); // may be null for external fence
+            entry.fenceRaw = fenceRaw;
+            entry.isTemp = isTemp;
+            entry.callback = AZStd::move(cb);
+
+            AZStd::scoped_lock lock(m_pendingFenceMutex);
+            m_pendingFenceCallbacks.push_back(AZStd::move(entry));
+        }
+
+        void CommandQueue::ProcessPendingFenceCallbacks()
+        {
+            AZStd::scoped_lock lock(m_pendingFenceMutex);
+
+            if (m_pendingFenceCallbacks.empty())
+            {
+                return;
+            }
+
+            // iterate with index because we may erase entries
+            size_t i = 0;
+            while (i < m_pendingFenceCallbacks.size())
+            {
+                PendingFenceCallback& entry = m_pendingFenceCallbacks[i];
+                bool signaled = false;
+
+                if (entry.fenceRaw)
+                {
+                    // Non-blocking check: see if Fence is signaled
+                    signaled = (entry.fenceRaw->GetFenceState() == AZ::RHI::FenceState::Signaled);
+                }
+
+                if (signaled)
+                {
+                    // Move callback out before erasing to avoid dangling reference
+                    AZStd::function<void()> callback = AZStd::move(entry.callback);
+
+                    // Erase by swap+pop (fast removal)
+                    if (i + 1 < m_pendingFenceCallbacks.size())
+                    {
+                        m_pendingFenceCallbacks[i] = AZStd::move(m_pendingFenceCallbacks.back());
+                        m_pendingFenceCallbacks.pop_back();
+                    }
+                    else
+                    {
+                        m_pendingFenceCallbacks.pop_back();
+                    }
+
+                    if (callback)
+                    {
+                        callback();
+                    }
+                    // Do not increment i, since we swapped a new element into index i
+                }
+                else
+                {
+                    ++i;
+                }
+            }
+        }
+#endif
         
         void CommandQueue::Signal(Fence& fence)
         {
@@ -130,6 +230,23 @@ namespace AZ
 
         void CommandQueue::ShutdownInternal()
         {
+#if defined(CARBONATED) && !defined(_RELEASE)
+            // Acquire lock to safely clear pending fence callbacks
+            AZStd::scoped_lock lock(m_pendingFenceMutex);
+
+            for (auto& entry : m_pendingFenceCallbacks)
+            {
+                // If you have a flag for temp/internal fences, shutdown them safely
+                if (entry.isTemp && entry.fencePtr)
+                {
+                    entry.fencePtr->Shutdown();
+                }
+                // Clear callback to release captured references
+                entry.callback = nullptr;
+            }
+
+            m_pendingFenceCallbacks.clear();
+#endif
             if (m_queue)
             {
                 m_queue = nullptr;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandQueue.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandQueue.cpp
@@ -86,6 +86,14 @@ namespace AZ
                     isTempFence = true;
                 }
 #endif
+#if defined(CARBONATED) && !defined(_RELEASE)
+                if (GetDevice().GatheringStatsEnabled())
+                {
+                    // Register and mark CommandBuffer
+                    GetDevice().RegisterCommandBuffer(request.m_commandList->GetNativeCommandBuffer());
+                    GetDevice().MarkCommandBufferCommit(request.m_commandList->GetNativeCommandBuffer());
+                }
+#endif
                 // Submit commands to queue for the current frame.
                 vulkanQueue->SubmitCommandBuffers(
                     { request.m_commandList },
@@ -116,7 +124,7 @@ namespace AZ
 #if defined(CARBONATED) && !defined(_RELEASE)
                 if (GetDevice().GatheringStatsEnabled())
                 {
-                    // Register callback — store tempFenceCapture in the pending entry to keep it alive
+                    // Register callback - store tempFenceCapture in the pending entry to keep it alive
                     RegisterFenceCallback(
                         AZStd::move(tempFenceCapture),
                         fenceToSignal,

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandQueue.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandQueue.h
@@ -97,6 +97,26 @@ namespace AZ
 
             AZStd::sys_time_t m_lastExecuteDuration{};
             AZStd::sys_time_t m_lastPresentDuration{};
+
+#if defined(CARBONATED) && !defined(_RELEASE)
+            // pending callback entry
+            struct PendingFenceCallback
+            {
+                RHI::Ptr<Fence> fencePtr;  // keeps temporary fence alive; for external fences can be nullptr
+                Fence* fenceRaw = nullptr; // raw pointer to fence (external or temp)
+                bool isTemp = false;
+                AZStd::function<void()> callback;
+            };
+
+            AZStd::mutex m_pendingFenceMutex;
+            AZStd::vector<PendingFenceCallback> m_pendingFenceCallbacks;
+
+
+            // Register a fence + callback that will be invoked once the fence is signaled.
+            // fencePtr may be non-nullptr if we created a temp fence and want to keep it alive here.
+            void RegisterFenceCallback(RHI::Ptr<Fence> fencePtr, Fence* fenceRaw, bool isTemp, AZStd::function<void()> cb);
+            void ProcessPendingFenceCallbacks();
+#endif
         };
     }
 }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
@@ -28,11 +28,11 @@
 #include <RHI/ReleaseContainer.h>
 #include <Atom/RHI.Reflect/VkAllocator.h>
 
-#if defined(CARBONATED) && defined(AZ_PLATFORM_ANDROID) && defined(CARBONATED_DESIRED_FPS)
+#if defined(CARBONATED) && defined(AZ_PLATFORM_ANDROID) && defined(CARBONATED_DESIRED_FPS) && defined(CARBONATED_USE_SWAPPY)
 #include <AzCore/Android/JNI/Object.h>
 #include <AzCore/Android/Utils.h>
 #include <swappy/swappyVk.h>
-#endif // CARBONATED && AZ_PLATFORM_ANDROID && CARBONATED_DESIRED_FPS
+#endif // CARBONATED && AZ_PLATFORM_ANDROID && CARBONATED_DESIRED_FPS && CARBONATED_USE_SWAPPY
 
 namespace AZ
 {
@@ -107,7 +107,7 @@ namespace AZ
 #if defined(CARBONATED) && defined(CARBONATED_DESIRED_FPS)
         void SwapChain::SetDesiredFPSInternal([[maybe_unused]] uint32_t desiredFPS)
         {
-#if defined(AZ_PLATFORM_ANDROID)
+#if defined(AZ_PLATFORM_ANDROID) && defined(CARBONATED_USE_SWAPPY)
             if (m_refreshNs == 0 || desiredFPS <= 0)
             {
                 AZ_Error("SwapChain", false, "Swappy not initialized or invalid FPS");
@@ -130,7 +130,7 @@ namespace AZ
             // Set SwapIntervalNS
             auto& device = static_cast<Device&>(GetDevice());
             SwappyVk_setSwapIntervalNS(device.GetNativeDevice(), m_nativeSwapChain, swappyTargetNs);
-#endif // AZ_PLATFORM_ANDROID
+#endif // AZ_PLATFORM_ANDROID && CARBONATED_USE_SWAPPY
         }
 #endif // CARBONATED && CARBONATED_DESIRED_FPS
 
@@ -330,11 +330,11 @@ namespace AZ
                 info.pImageIndices = &imageIndex;
                 info.pResults = nullptr;
 
-#if defined(CARBONATED) && defined(AZ_PLATFORM_ANDROID) && defined(CARBONATED_DESIRED_FPS)
+#if defined(CARBONATED) && defined(AZ_PLATFORM_ANDROID) && defined(CARBONATED_DESIRED_FPS) && defined(CARBONATED_USE_SWAPPY)
                 const VkResult result = SwappyVk_queuePresent(vulkanQueue->GetNativeQueue(), &info);
 #else
                 const VkResult result = device.GetContext().QueuePresentKHR(vulkanQueue->GetNativeQueue(), &info);
-#endif // CARBONATED && AZ_PLATFORM_ANDROID && CARBONATED_DESIRED_FPS
+#endif // CARBONATED && AZ_PLATFORM_ANDROID && CARBONATED_DESIRED_FPS && CARBONATED_USE_SWAPPY
 
                 // Vulkan's definition of the two types of errors.
                 // VK_ERROR_OUT_OF_DATE_KHR: "A surface has changed in such a way that it is no longer compatible with the swapchain,
@@ -612,9 +612,9 @@ namespace AZ
                 device.GetContext().DeviceWaitIdle(device.GetNativeDevice());
                 if (swapchain != VK_NULL_HANDLE)
                 {
-#if defined(CARBONATED) && defined(AZ_PLATFORM_ANDROID) && defined(CARBONATED_DESIRED_FPS)
+#if defined(CARBONATED) && defined(AZ_PLATFORM_ANDROID) && defined(CARBONATED_DESIRED_FPS) && defined(CARBONATED_USE_SWAPPY)
                     SwappyVk_destroySwapchain(device.GetNativeDevice(), swapchain);
-#endif // CARBONATED && AZ_PLATFORM_ANDROID && CARBONATED_DESIRED_FPS
+#endif // CARBONATED && AZ_PLATFORM_ANDROID && CARBONATED_DESIRED_FPS && CARBONATED_USE_SWAPPY
                     device.GetContext().DestroySwapchainKHR(device.GetNativeDevice(), swapchain, VkSystemAllocator::Get());
                 }
             };
@@ -685,7 +685,7 @@ namespace AZ
             RETURN_RESULT_IF_UNSUCCESSFUL(result);
             AZLOG_DEBUG("Acquired the first image.\n");
 
-#if defined(CARBONATED) && defined(AZ_PLATFORM_ANDROID) && defined(CARBONATED_DESIRED_FPS)
+#if defined(CARBONATED) && defined(AZ_PLATFORM_ANDROID) && defined(CARBONATED_DESIRED_FPS) && defined(CARBONATED_USE_SWAPPY)
             auto presentCommand = [this, &device](void* queue)
             {
                 Queue* vulkanQueue = static_cast<Queue*>(queue);
@@ -715,7 +715,7 @@ namespace AZ
             };
             m_presentationQueue->QueueCommand(AZStd::move(presentCommand));
             m_presentationQueue->FlushCommands();
-#endif // CARBONATED && AZ_PLATFORM_ANDROID && CARBONATED_DESIRED_FPS
+#endif // CARBONATED && AZ_PLATFORM_ANDROID && CARBONATED_DESIRED_FPS && CARBONATED_USE_SWAPPY
             return RHI::ResultCode::Success;
         }
     }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.h
@@ -124,10 +124,10 @@ namespace AZ
                 bool m_isValid = false;
             } m_swapChainBarrier;
 
-#if defined(CARBONATED) && defined(CARBONATED_DESIRED_FPS) && defined(AZ_PLATFORM_ANDROID)
+#if defined(CARBONATED) && defined(CARBONATED_DESIRED_FPS) && defined(AZ_PLATFORM_ANDROID) && defined(CARBONATED_USE_SWAPPY)
             // Display refresh rate in nanoseconds, assigned when SwappyVk is initialized.
             uint64_t m_refreshNs = 0;
-#endif // CARBONATED && CARBONATED_DESIRED_FPS
+#endif // CARBONATED && CARBONATED_DESIRED_FPS && AZ_PLATFORM_ANDROID && CARBONATED_USE_SWAPPY
         };
     }
 }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/WindowContext.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/WindowContext.cpp
@@ -174,7 +174,7 @@ namespace AZ
 #if defined(CARBONATED) && defined(CARBONATED_DESIRED_FPS)
         void WindowContext::OnDesiredFPSChanged(uint32_t desiredFPS)
         {
-#if defined(AZ_PLATFORM_ANDROID) || defined(AZ_PLATFORM_IOS)
+#if (defined(AZ_PLATFORM_ANDROID) && defined(CARBONATED_USE_SWAPPY)) || defined(AZ_PLATFORM_IOS)
             RHI::Ptr<RHI::SwapChain> defaultSwapChain = GetSwapChain(ViewType::Default);
             defaultSwapChain->SetDesiredFPS(desiredFPS);
 #else
@@ -191,7 +191,7 @@ namespace AZ
                 }
                 else // if (AZ::RHI::Factory::Get().GetAPIUniqueIndex() == static_cast<uint32_t>(AZ::RHI::APIIndex::Vulkan))
                 {
-#if !defined(AZ_PLATFORM_WINDOWS)
+#if !defined(AZ_PLATFORM_WINDOWS) && !defined(AZ_PLATFORM_ANDROID)
                     AZ_Warning("WindowContext::OnDesiredFPSChanged", false, "desired_fps not tested for this platform\n");
 #endif
                     console->PerformCommand("vsync_interval 0");

--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
@@ -73,7 +73,7 @@ namespace AZ::Render
             AZ::RHI::Device* pDevice = AZ::RHI::RHISystemInterface::Get()->GetDevice();
             if (pDevice && count >= 0)
             {
-                pDevice->PerformShortGPUGathering(count);
+                pDevice->LogGPUSnapshot(count);
             }
         },
         AZ::ConsoleFunctorFlags::DontReplicate,

--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
@@ -63,6 +63,23 @@ namespace AZ::Render
         AZ::Vector2, r_topRightBorderPadding, AZ::Vector2(-40.0f, 22.0f), nullptr, AZ::ConsoleFunctorFlags::DontReplicate,
         "The top right border padding for the viewport debug display text");
 
+#if defined(CARBONATED)
+    AZ_CVAR(
+        int,
+        r_logGPUStats,
+        0,
+        [](const int& count) -> void
+        {
+            AZ::RHI::Device* pDevice = AZ::RHI::RHISystemInterface::Get()->GetDevice();
+            if (pDevice && count >= 0)
+            {
+                pDevice->PerformShortGPUGathering(count);
+            }
+        },
+        AZ::ConsoleFunctorFlags::DontReplicate,
+        "Usage: r_logGPUStats N (N - number of frames to put info into the log)\n");
+#endif
+
     void AtomViewportDisplayInfoSystemComponent::Reflect(AZ::ReflectContext* context)
     {
         if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))

--- a/Gems/LyShine/Code/Source/RenderGraph.cpp
+++ b/Gems/LyShine/Code/Source/RenderGraph.cpp
@@ -759,7 +759,7 @@ namespace LyShine
             const auto& descriptor = rhiDevice->GetPhysicalDevice().GetDescriptor();
             // At this time (September 2025) we know 100% that Google Pixel 8 and Pixel 9 have an issue with sparkling white/colored snow on UI elements.
             // A workaround is to not combine rectangular/square primitives of size > 24 into large batches.
-            m_usingMaliG715Workaround = descriptor.m_description.contains("Mali-G715");
+            m_usingMaliG715Workaround = descriptor.m_description.contains("Mali-G715") || descriptor.m_description.starts_with("Samsung Xclipse 9");
         }
         else
         {

--- a/Gems/LyShine/Code/Source/RenderGraph.cpp
+++ b/Gems/LyShine/Code/Source/RenderGraph.cpp
@@ -758,6 +758,7 @@ namespace LyShine
         {
             const auto& descriptor = rhiDevice->GetPhysicalDevice().GetDescriptor();
             // At this time (September 2025) we know 100% that Google Pixel 8 and Pixel 9 have an issue with sparkling white/colored snow on UI elements.
+            // October 2025: Samsung S24 (with GPU "Samsung Xclipse 940") also affected.
             // A workaround is to not combine rectangular/square primitives of size > 24 into large batches.
             m_usingMaliG715Workaround = descriptor.m_description.contains("Mali-G715") || descriptor.m_description.starts_with("Samsung Xclipse 9");
         }


### PR DESCRIPTION
## What does this PR do?

VK_QUERY_RESULT_WAIT_BIT flag has  been removed and now it doesn't slow an execution.
Added Fence check to gathering GPU statistic when GPU finishes a frame.
Added the condition Device::GatheringStatsEnabled() to avoid unneeded operations when Profiling is not visible

## How was this PR tested?

Test on Google Pixel 9 and Samsung A53.
No more sudden FPS drops.
