### PR TITLE
Fix error in Windows Vulkan GPU profiling.

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
@@ -69,6 +69,32 @@ namespace AZ
             queryPoolInfo.queryType = VK_QUERY_TYPE_TIMESTAMP;
             queryPoolInfo.queryCount = 2; // start + end
             static_cast<Device&>(GetDevice()).GetContext().CreateQueryPool(device.GetNativeDevice(), &queryPoolInfo, nullptr, &m_queryPool);
+
+            { // Let's define supported "m_cpuTimeDomain" to use in GetCalibratedTimestampsEXT
+                uint32_t timeDomainCount = 0;
+                static_cast<Device&>(GetDevice())
+                    .GetContext()
+                    .GetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice.GetNativePhysicalDevice(), &timeDomainCount, nullptr);
+
+                AZStd::vector<VkTimeDomainEXT> timeDomains(timeDomainCount);
+                static_cast<Device&>(GetDevice())
+                    .GetContext()
+                    .GetPhysicalDeviceCalibrateableTimeDomainsEXT(
+                    physicalDevice.GetNativePhysicalDevice(), &timeDomainCount, timeDomains.data());
+
+                if (AZStd::find(timeDomains.begin(), timeDomains.end(), VK_TIME_DOMAIN_CLOCK_MONOTONIC_EXT) == timeDomains.end())
+                {
+                    if (AZStd::find(timeDomains.begin(), timeDomains.end(), VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_EXT) !=
+                        timeDomains.end())
+                    {
+                        m_cpuTimeDomain = VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_EXT;
+                    }
+                    else
+                    {
+                        m_cpuTimeDomain = VK_TIME_DOMAIN_DEVICE_EXT; // fallback
+                    }
+                }
+            }
 #endif
             return result;
         }
@@ -738,7 +764,7 @@ namespace AZ
         }
 
 #if defined(CARBONATED) && !defined(_RELEASE)
-        void CommandList::CollectGPUStatistics()
+        void CommandList::CollectGPUStatistics(double commitTime)
         {
             if (!m_collectingGPUStats)
             {
@@ -780,7 +806,7 @@ namespace AZ
             timestampInfos[0].timeDomain = VK_TIME_DOMAIN_DEVICE_EXT; // GPU
 
             timestampInfos[1].sType = VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_EXT;
-            timestampInfos[1].timeDomain = VK_TIME_DOMAIN_CLOCK_MONOTONIC_EXT; // CPU
+            timestampInfos[1].timeDomain = m_cpuTimeDomain; // CPU
 
             uint64_t timestampsCalibration[2] = {};
 
@@ -790,7 +816,6 @@ namespace AZ
                 uint64_t maxDeviation = 0;
                 result = context.GetCalibratedTimestampsEXT(device.GetNativeDevice(), 2, timestampInfos, timestampsCalibration, &maxDeviation);
             }
-
             if (result == VK_SUCCESS)
             {
                 const uint64_t gpuCalibTicks = timestampsCalibration[0];
@@ -804,8 +829,17 @@ namespace AZ
                 const double timeShiftSec = cpuCalibSec - gpuCalibSec;
 
                 // Apply calibration
-                const double gpuStartCpuSec = gpuStartSec + timeShiftSec;
-                const double gpuEndCpuSec = gpuEndSec + timeShiftSec;
+                double gpuStartCpuSec = gpuStartSec + timeShiftSec;
+                double gpuEndCpuSec = gpuEndSec + timeShiftSec;
+
+                // --- Clamp GPU time not to be earlier than commit time ---
+                // GPU cannot start rendering before we actually submitted the command buffer as it is reported on Windows by Radeon RX 480
+                if (gpuStartCpuSec < commitTime)
+                {
+                    const double offset = commitTime - gpuStartCpuSec;
+                    gpuStartCpuSec += offset;
+                    gpuEndCpuSec += offset;
+                }
 
                 GetDevice().CommandBufferCompleted(m_nativeCommandBuffer, gpuStartCpuSec, gpuEndCpuSec);
             }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.h
@@ -121,7 +121,7 @@ namespace AZ
             RHI::CommandListValidator& GetValidator();
 
 #if defined(CARBONATED) && !defined(_RELEASE)
-            void CollectGPUStatistics();
+            void CollectGPUStatistics(double commitTime);
 #endif
         private:
             struct Descriptor
@@ -194,6 +194,7 @@ namespace AZ
             VkQueryPool m_queryPool = VK_NULL_HANDLE;
             const uint32_t m_timestampStartIndex = 0;
             const uint32_t m_timestampEndIndex = 1;
+            VkTimeDomainEXT m_cpuTimeDomain = VK_TIME_DOMAIN_CLOCK_MONOTONIC_EXT;
 #endif
         };
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandQueue.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandQueue.cpp
@@ -67,6 +67,7 @@ namespace AZ
                 // Keep the RHI::Ptr alive by capturing it into the lambda (tempFenceCapture).
                 RHI::Ptr<Fence> tempFenceCapture = nullptr;
                 bool isTempFence = false;
+                double commitTime = 0;
 #endif
                 Fence* fenceToSignal = nullptr;
                 if (!request.m_fencesToSignal.empty())
@@ -92,6 +93,11 @@ namespace AZ
                     // Register and mark CommandBuffer
                     GetDevice().RegisterCommandBuffer(request.m_commandList->GetNativeCommandBuffer());
                     GetDevice().MarkCommandBufferCommit(request.m_commandList->GetNativeCommandBuffer());
+#if defined(AZ_PLATFORM_IOS) || defined(AZ_PLATFORM_MAC)
+                    commitTime = double(clock_gettime_nsec_np(CLOCK_UPTIME_RAW)) / 1000000000.0;
+#else
+                    commitTime = AZStd::GetTimeNowTicks() / 1e9; // Use time since system start like all Vulkan timestamps
+#endif
                 }
 #endif
                 // Submit commands to queue for the current frame.
@@ -129,10 +135,10 @@ namespace AZ
                         AZStd::move(tempFenceCapture),
                         fenceToSignal,
                         isTempFence,
-                        [cmdList = request.m_commandList, isTempFence, tempFenceCapture]()
+                        [cmdList = request.m_commandList, isTempFence, tempFenceCapture, commitTime]()
                         {
                             // This callback will be called from ProcessPendingFenceCallbacks when fence signaled
-                            cmdList->CollectGPUStatistics();
+                            cmdList->CollectGPUStatistics(commitTime);
                             if (isTempFence && tempFenceCapture)
                             {
                                 tempFenceCapture->Shutdown();

--- a/scripts/commit_validation/commit_validation/carbonated_pal_allowedlist.txt
+++ b/scripts/commit_validation/commit_validation/carbonated_pal_allowedlist.txt
@@ -10,6 +10,7 @@
 */Gems/Atom/RHI/Metal/Code/Source/RHI/MetalViewController.h
 */Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
 */Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.h
+*/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandQueue.cpp
 */Gems/Atom/RPI/Code/Source/RPI.Public/WindowContext.cpp
 */Code/Framework/AzFramework/AzFramework/Windowing/NativeWindow.cpp
 */Code/Legacy/CrySystem/System.cpp


### PR DESCRIPTION
## What does this PR do?

Changes into CommandList so CommandBuffer for the GPU profiling works correctly on Windows Vulkan.
Due to limitations on very old Radeon RX 480 the time between Commit and BeginRender is reported as negative. So the fix is to pass "commit" time into CollectGPUStatistics and perform corrections so Commit == BeginRender.

## How was this PR tested?

Profiler on Windows shows GPU data and doesn't put an error into the log.

