### PR TITLE
Adding method to put CPU threads statstics to log for analyzing.

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Device.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Device.h
@@ -183,6 +183,7 @@ namespace AZ::RHI
         void LogGPUSnapshot(int nFrames);   // writes "commit+begin+end times" of nFrames into the Log
         void EnableGatheringStats();
         void DisableGatheringStats();
+        unsigned int GetLastFrameToLog() const { return m_lastFrameToLog; }
 #endif
     protected:
 

--- a/Gems/Atom/RHI/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Device.cpp
@@ -167,7 +167,7 @@ namespace AZ::RHI
 #else
                 const double t = AZStd::GetTimeNowTicks() / 1e9; // Use time since system start like all Vulkan timestamps
 #endif
-                AZ_Info("GPUtime", "Begin Frame at %f. Frame num=%u\n", (t - m_startLogTime), m_frameCounter);
+                AZ_Info("GPU/CPU", "Begin Frame at %f. Frame num=%u\n", (t - m_startLogTime), m_frameCounter);
             }
             m_FrameTimeLock.unlock();
 #endif
@@ -275,7 +275,7 @@ namespace AZ::RHI
                             if (m_lastFrameToLog >= m_frameCounter)
                             {
                                 AZ_Info(
-                                    "GPUtime",
+                                    "GPU/CPU",
                                     "frame %u, commit %f, begin: %f, end: %f\n",
                                     fc.m_frameNumber,
                                     fc.m_commands[ib].m_commitTime - m_startLogTime,
@@ -432,6 +432,12 @@ namespace AZ::RHI
 
     ResultCode Device::EndFrame()
     {
+#if defined(CARBONATED)
+        if (m_lastFrameToLog > 0 && m_lastFrameToLog < m_frameCounter + 1)
+        {
+            m_lastFrameToLog = 0;
+        }
+#endif
         if (ValidateIsInitialized() && ValidateIsInFrame())
         {
             AZ_PROFILE_SCOPE(RHI, "Device: EndFrame");

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
@@ -64,34 +64,36 @@ namespace AZ
             m_supportsPredication = physicalDevice.IsFeatureSupported(DeviceFeature::Predication);
             m_supportsDrawIndirectCount = physicalDevice.IsFeatureSupported(DeviceFeature::DrawIndirectCount);
 #if defined(CARBONATED) && !defined(_RELEASE)
+            const auto& context = device.GetContext();
+
             VkQueryPoolCreateInfo queryPoolInfo = {};
             queryPoolInfo.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
             queryPoolInfo.queryType = VK_QUERY_TYPE_TIMESTAMP;
             queryPoolInfo.queryCount = 2; // start + end
-            static_cast<Device&>(GetDevice()).GetContext().CreateQueryPool(device.GetNativeDevice(), &queryPoolInfo, nullptr, &m_queryPool);
+            context.CreateQueryPool(device.GetNativeDevice(), &queryPoolInfo, nullptr, &m_queryPool);
 
             { // Let's define supported "m_cpuTimeDomain" to use in GetCalibratedTimestampsEXT
-                uint32_t timeDomainCount = 0;
-                static_cast<Device&>(GetDevice())
-                    .GetContext()
-                    .GetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice.GetNativePhysicalDevice(), &timeDomainCount, nullptr);
-
-                AZStd::vector<VkTimeDomainEXT> timeDomains(timeDomainCount);
-                static_cast<Device&>(GetDevice())
-                    .GetContext()
-                    .GetPhysicalDeviceCalibrateableTimeDomainsEXT(
-                    physicalDevice.GetNativePhysicalDevice(), &timeDomainCount, timeDomains.data());
-
-                if (AZStd::find(timeDomains.begin(), timeDomains.end(), VK_TIME_DOMAIN_CLOCK_MONOTONIC_EXT) == timeDomains.end())
+                if (context.GetPhysicalDeviceCalibrateableTimeDomainsEXT)
                 {
-                    if (AZStd::find(timeDomains.begin(), timeDomains.end(), VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_EXT) !=
-                        timeDomains.end())
+                    uint32_t timeDomainCount = 0;
+                    context.GetPhysicalDeviceCalibrateableTimeDomainsEXT(
+                        physicalDevice.GetNativePhysicalDevice(), &timeDomainCount, nullptr);
+
+                    AZStd::vector<VkTimeDomainEXT> timeDomains(timeDomainCount);
+                    context.GetPhysicalDeviceCalibrateableTimeDomainsEXT(
+                        physicalDevice.GetNativePhysicalDevice(), &timeDomainCount, timeDomains.data());
+
+                    if (AZStd::find(timeDomains.begin(), timeDomains.end(), VK_TIME_DOMAIN_CLOCK_MONOTONIC_EXT) == timeDomains.end())
                     {
-                        m_cpuTimeDomain = VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_EXT;
-                    }
-                    else
-                    {
-                        m_cpuTimeDomain = VK_TIME_DOMAIN_DEVICE_EXT; // fallback
+                        if (AZStd::find(timeDomains.begin(), timeDomains.end(), VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_EXT) !=
+                            timeDomains.end())
+                        {
+                            m_cpuTimeDomain = VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_EXT;
+                        }
+                        else
+                        {
+                            m_cpuTimeDomain = VK_TIME_DOMAIN_DEVICE_EXT; // fallback
+                        }
                     }
                 }
             }

--- a/Tools/VulkanLogAnalyzer/README.txt
+++ b/Tools/VulkanLogAnalyzer/README.txt
@@ -1,0 +1,24 @@
+There is the console command 
+r_logGPUStats N
+where N - number of frames to log
+
+it puts into output log information about GPU and CPU threads in format like:
+
+<Info From Device> (GPU/CPU) - Begin Frame at 0.375855. Frame num=2951
+<Info From Device> (GPU/CPU) - frame 2950, commit 0.328881, begin: 0.330713, end: 0.335301
+
+You should extract them from the log with your preffered tool and remove <Info From Device> at the start of each line.
+Then you should remove duplicated lines with remove_duplicates.py:
+
+python remove_duplicates.py input.txt output.txt
+
+
+You should install python package matplotlib:
+
+pip install matplotlib
+
+Now you can get .png file with the visual representation of how GPU and CPU threads work
+
+python vulkan_timeline_plot.py output.txt
+
+As a result you will get "vulkan_timeline.png"

--- a/Tools/VulkanLogAnalyzer/remove_duplicates.py
+++ b/Tools/VulkanLogAnalyzer/remove_duplicates.py
@@ -23,7 +23,7 @@ def remove_duplicates(input_path, output_path):
     with open(output_path, "w", encoding="utf-8") as outfile:
         outfile.writelines(unique_lines)
 
-    print(f"Removed duplicates from '{input_path}' → saved to '{output_path}'")
+    print(f"Removed duplicates from '{input_path}' -> saved to '{output_path}'")
 
 if __name__ == "__main__":
     if len(sys.argv) != 3:

--- a/Tools/VulkanLogAnalyzer/remove_duplicates.py
+++ b/Tools/VulkanLogAnalyzer/remove_duplicates.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# remove_duplicates.py
+# Removes duplicate lines from a text file while preserving the order of first occurrences.
+
+import sys
+
+def remove_duplicates(input_path, output_path):
+    seen = set()
+    unique_lines = []
+
+    with open(input_path, "r", encoding="utf-8") as infile:
+        for line in infile:
+            stripped = line.rstrip("\n\r")
+            if stripped not in seen:
+                seen.add(stripped)
+                unique_lines.append(line)
+
+    with open(output_path, "w", encoding="utf-8") as outfile:
+        outfile.writelines(unique_lines)
+
+    print(f"Removed duplicates from '{input_path}' → saved to '{output_path}'")
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python remove_duplicates.py <input_file> <output_file>")
+        sys.exit(1)
+
+    input_file = sys.argv[1]
+    output_file = sys.argv[2]
+    remove_duplicates(input_file, output_file)

--- a/Tools/VulkanLogAnalyzer/remove_duplicates.py
+++ b/Tools/VulkanLogAnalyzer/remove_duplicates.py
@@ -1,5 +1,10 @@
-#!/usr/bin/env python3
-# remove_duplicates.py
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
 # Removes duplicate lines from a text file while preserving the order of first occurrences.
 
 import sys

--- a/Tools/VulkanLogAnalyzer/vulkan_timeline_plot.py
+++ b/Tools/VulkanLogAnalyzer/vulkan_timeline_plot.py
@@ -1,10 +1,17 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+# This script creates vulkan_timeline.png file with the visual representation of how GPU and CPU threads work
+# Data for profiling is put into output log when "r_logGPUStats N" console command is performed
+
 import re
 import matplotlib.pyplot as plt
 from collections import defaultdict
 import sys
-
-# This script creates vulkan_timeline.png file with the visual representation of how GPU and CPU threads work
-# Data for profiling is put into output log when "r_logGPUStats N" console command is performed
 
 def parse_log_file(filepath):
     frame_data_gpu = defaultdict(list)
@@ -30,7 +37,7 @@ def parse_log_file(filepath):
                 commit = float(m.group(2))
                 begin = float(m.group(3))
                 end = float(m.group(4))
-                # ✅ Фильтр: пропускаем слишком длинные GPU submissions
+                # Skip too long submissions
                 if end - begin < 0.1:
                     frame_data_gpu[fnum].append({'commit': commit, 'begin': begin, 'end': end})
                 continue

--- a/Tools/VulkanLogAnalyzer/vulkan_timeline_plot.py
+++ b/Tools/VulkanLogAnalyzer/vulkan_timeline_plot.py
@@ -3,6 +3,9 @@ import matplotlib.pyplot as plt
 from collections import defaultdict
 import sys
 
+# This script creates vulkan_timeline.png file with the visual representation of how GPU and CPU threads work
+# Data for profiling is put into output log when "r_logGPUStats N" console command is performed
+
 def parse_log_file(filepath):
     frame_data_gpu = defaultdict(list)
     frame_data_cpu = defaultdict(dict)
@@ -164,14 +167,11 @@ def plot_timeline(frame_data_gpu, frame_data_cpu, frame_start_times, output_path
     ax.set_yticks(y_ticks)
     ax.set_yticklabels(y_labels, fontsize=8)
 
-    # ❌ Убираем нижнюю временную шкалу
-    ax.set_xticks([])  # ←←← ключевое изменение
+    ax.set_xticks([])
     ax.set_xlabel("")
 
     ax.set_title("GPU Submissions (dark green) and CPU Threads (colored) — Per-Frame View", fontsize=10)
-    # Убираем сетку по X
     ax.grid(False, axis='x')
-    # Оставляем только Y-сетку, если нужно
     ax.grid(True, axis='y', linestyle=':', alpha=0.4)
 
     plt.tight_layout()

--- a/Tools/VulkanLogAnalyzer/vulkan_timeline_plot.py
+++ b/Tools/VulkanLogAnalyzer/vulkan_timeline_plot.py
@@ -1,0 +1,188 @@
+import re
+import matplotlib.pyplot as plt
+from collections import defaultdict
+import sys
+
+def parse_log_file(filepath):
+    frame_data_gpu = defaultdict(list)
+    frame_data_cpu = defaultdict(dict)
+    frame_start_times = {}
+
+    begin_frame_pat = re.compile(r"\(GPU/CPU\) - Begin Frame at ([+-]?\d*\.?\d+)\. Frame num=(\d+)")
+    gpu_pat = re.compile(r"\(GPU/CPU\) - frame (\d+), commit ([+-]?\d*\.?\d+), begin: ([+-]?\d*\.?\d+), end: ([+-]?\d*\.?\d+)")
+    cpu_pat = re.compile(r"\(GPU/CPU\) - frame=(\d+), threadName=([^,]+), lastFrameTime=([+-]?\d*\.?\d+)")
+
+    with open(filepath, 'r') as f:
+        for line in f:
+            m = begin_frame_pat.search(line)
+            if m:
+                t = float(m.group(1))
+                fnum = int(m.group(2))
+                frame_start_times[fnum] = t
+                continue
+
+            m = gpu_pat.search(line)
+            if m:
+                fnum = int(m.group(1))
+                commit = float(m.group(2))
+                begin = float(m.group(3))
+                end = float(m.group(4))
+                # ✅ Фильтр: пропускаем слишком длинные GPU submissions
+                if end - begin < 0.1:
+                    frame_data_gpu[fnum].append({'commit': commit, 'begin': begin, 'end': end})
+                continue
+
+            m = cpu_pat.search(line)
+            if m:
+                fnum = int(m.group(1))
+                name = m.group(2).strip()
+                dur = float(m.group(3))
+                frame_data_cpu[fnum][name] = dur
+
+    return frame_data_gpu, frame_data_cpu, frame_start_times
+
+def get_cpu_color(name):
+    if name == "Main":
+        return 'tab:blue'
+    elif name in ("GPU", "*GPUendMax", "*GPUwaitAvg"):
+        return 'lightgreen'
+    else:
+        return 'gold'
+
+def plot_timeline(frame_data_gpu, frame_data_cpu, frame_start_times, output_path='vulkan_timeline.png'):
+    if not frame_data_gpu and not frame_data_cpu:
+        print("No GPU or CPU data found.")
+        return
+
+    y_step = 0.15
+
+    # === GPU ===
+    all_gpu = []
+    max_gpu_per_frame = 0
+    for frame, subs in frame_data_gpu.items():
+        sorted_subs = sorted(subs, key=lambda x: x['commit'])
+        max_gpu_per_frame = max(max_gpu_per_frame, len(sorted_subs))
+        for idx, sub in enumerate(sorted_subs):
+            all_gpu.append({
+                'frame': frame,
+                'commit': sub['commit'],
+                'begin': sub['begin'],
+                'end': sub['end'],
+                'y': idx * y_step
+            })
+
+    # === CPU ===
+    all_cpu_threads = set()
+    for d in frame_data_cpu.values():
+        all_cpu_threads.update(d.keys())
+    all_cpu_threads = sorted(all_cpu_threads)
+
+    cpu_y_offset = - (len(all_cpu_threads) * y_step + y_step)
+    gpu_y_offset = 0.0
+
+    all_cpu = []
+    for frame, start_time in frame_start_times.items():
+        if frame in frame_data_cpu:
+            for name, duration in frame_data_cpu[frame].items():
+                if name in all_cpu_threads:
+                    idx = all_cpu_threads.index(name)
+                    y = cpu_y_offset + idx * y_step
+                    all_cpu.append({
+                        'name': name,
+                        'x0': start_time,
+                        'x1': start_time + duration,
+                        'y': y
+                    })
+
+    # === Compute frame durations ===
+    sorted_frames = sorted(frame_start_times.keys())
+    frame_durations = {}
+    for i, frame in enumerate(sorted_frames):
+        if i + 1 < len(sorted_frames):
+            frame_durations[frame] = frame_start_times[sorted_frames[i+1]] - frame_start_times[frame]
+        else:
+            # Last frame: use average or 0
+            if len(sorted_frames) > 1:
+                avg = sum(frame_durations[f] for f in sorted_frames[:-1]) / (len(sorted_frames) - 1)
+                frame_durations[frame] = avg
+            else:
+                frame_durations[frame] = 0.0
+
+    # === Plot ===
+    total_height = max(4.0, (max_gpu_per_frame + len(all_cpu_threads) + 2) * y_step * 2)
+    fig, ax = plt.subplots(figsize=(16, total_height))
+
+    # --- GPU ---
+    for item in all_gpu:
+        ax.hlines(item['y'], item['begin'], item['end'], color='darkgreen', linewidth=2, alpha=0.9)
+        ax.plot(item['commit'], item['y'], 'ko', markersize=2)
+
+    # --- CPU ---
+    for item in all_cpu:
+        color = get_cpu_color(item['name'])
+        ax.hlines(item['y'], item['x0'], item['x1'], color=color, linewidth=2, alpha=0.9)
+
+    # --- Begin Frame lines and annotations ---
+    for frame in sorted_frames:
+        start_time = frame_start_times[frame]
+        duration = frame_durations[frame]
+
+        # Vertical line at frame start
+        ax.axvline(x=start_time, color='gray', linestyle='--', alpha=0.7, linewidth=0.9)
+
+        # Top: Frame N
+        y_top = (max_gpu_per_frame * y_step) + y_step * 0.8
+        ax.text(start_time, y_top, f"Frame {frame}",
+                rotation=90, va='bottom', ha='center', fontsize=8, color='black')
+
+        # Middle: duration in ms
+        y_mid = (max_gpu_per_frame * y_step + cpu_y_offset) / 2
+        dur_ms = duration * 1000
+        ax.text(start_time + duration / 2, y_mid, f"{dur_ms:.1f} ms",
+                ha='center', va='center', fontsize=7, color='darkred', alpha=0.8)
+
+        # Bottom: start time
+        y_bottom = cpu_y_offset - y_step * 1.2
+        ax.text(start_time, y_bottom, f"{start_time:.3f}",
+                ha='center', va='top', fontsize=7, color='gray')
+
+    # --- Y axis ---
+    y_ticks = []
+    y_labels = []
+
+    for name in all_cpu_threads:
+        idx = all_cpu_threads.index(name)
+        y = cpu_y_offset + idx * y_step
+        y_ticks.append(y)
+        y_labels.append(name)
+
+    for i in range(max_gpu_per_frame):
+        y = gpu_y_offset + i * y_step
+        y_ticks.append(y)
+        y_labels.append(f"GPU #{i}")
+
+    ax.set_yticks(y_ticks)
+    ax.set_yticklabels(y_labels, fontsize=8)
+
+    # ❌ Убираем нижнюю временную шкалу
+    ax.set_xticks([])  # ←←← ключевое изменение
+    ax.set_xlabel("")
+
+    ax.set_title("GPU Submissions (dark green) and CPU Threads (colored) — Per-Frame View", fontsize=10)
+    # Убираем сетку по X
+    ax.grid(False, axis='x')
+    # Оставляем только Y-сетку, если нужно
+    ax.grid(True, axis='y', linestyle=':', alpha=0.4)
+
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=150, bbox_inches='tight')
+    print(f"Saved clean timeline to: {output_path}")
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python vulkan_timeline_plot.py <log_file.txt>")
+        sys.exit(1)
+
+    log_file = sys.argv[1]
+    frame_data_gpu, frame_data_cpu, frame_start_times = parse_log_file(log_file)
+    plot_timeline(frame_data_gpu, frame_data_cpu, frame_start_times, output_path='vulkan_timeline.png')

--- a/Tools/VulkanLogAnalyzer/vulkan_timeline_plot.py
+++ b/Tools/VulkanLogAnalyzer/vulkan_timeline_plot.py
@@ -177,7 +177,7 @@ def plot_timeline(frame_data_gpu, frame_data_cpu, frame_start_times, output_path
     ax.set_xticks([])
     ax.set_xlabel("")
 
-    ax.set_title("GPU Submissions (dark green) and CPU Threads (colored) — Per-Frame View", fontsize=10)
+    ax.set_title("GPU Submissions (dark green) and CPU Threads (colored) - Per-Frame View", fontsize=10)
     ax.grid(False, axis='x')
     ax.grid(True, axis='y', linestyle=':', alpha=0.4)
 


### PR DESCRIPTION
Adding pyton scripts to create PNG files for visualizing profiling data

## What does this PR do?

Added AI-generated python scripts that convert a special profiling data to .PNG file.
remove_duplicates.py removes duplicated lines from the file.
vulkan_timeline_plot.py creates .png file.

## How was this PR tested?

On Samsung A53, Samsung S24, Google Pixel 9, Windows the console commands
mw_thread_profiler 1
mw_thread_profiler 10
are performed.
All lines with (GPU/CPU) are extracted.
Duplicated lines are removed using remove_duplicates.py.
.PNG files are created for each part of profiling data.

An example:

<img width="2384" height="1156" alt="A53_Battle" src="https://github.com/user-attachments/assets/d12c1f8b-3351-475b-ab0b-eb3b3cceabbc" />


