### PR TITLE
Adding [[maybe_unused]]  into Device::BeginFrame

### DIFF
--- a/Gems/Atom/RHI/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Device.cpp
@@ -163,9 +163,9 @@ namespace AZ::RHI
             if (m_lastFrameToLog >= m_frameCounter)
             {
 #if defined(AZ_PLATFORM_IOS) || defined(AZ_PLATFORM_MAC)
-                const double t = double(clock_gettime_nsec_np(CLOCK_UPTIME_RAW)) / 1000000000.0;
+                [[maybe_unused]] const double t = double(clock_gettime_nsec_np(CLOCK_UPTIME_RAW)) / 1000000000.0;
 #else
-                const double t = AZStd::GetTimeNowTicks() / 1e9; // Use time since system start like all Vulkan timestamps
+                [[maybe_unused]] const double t = AZStd::GetTimeNowTicks() / 1e9; // Use time since system start like all Vulkan timestamps
 #endif
                 AZ_Info("GPU/CPU", "Begin Frame at %f. Frame num=%u\n", (t - m_startLogTime), m_frameCounter);
             }


### PR DESCRIPTION
## What does this PR do?
In RELEASE build AZ_Info is empty and the variables that are used in it become not used. 
So we should add [[maybe_unused]]

## How was this PR tested?

The build should be compiled in RELEASE variant.
