### PR TITLE
Switch Sampler to FILTER_NEAREST if FILTER_LINEAR is not supported

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Sampler.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Sampler.cpp
@@ -90,6 +90,36 @@ namespace AZ
             createInfo.magFilter = ConvertFilterMode(filterMag);
             createInfo.minFilter = ConvertFilterMode(filterMin);
 
+ #if defined(CARBONATED)
+            // Check support for linear filtering of the format via the PhysicalDevice API
+            {
+                // We only check depth formats - they are the ones that most often break during linear filtering
+                const RHI::Format depthFormats[] = {
+                    RHI::Format::D16_UNORM, RHI::Format::D32_FLOAT, RHI::Format::D24_UNORM_S8_UINT, RHI::Format::D32_FLOAT_S8X24_UINT
+                };
+
+                bool needsLinearForDepthFormat = (createInfo.magFilter == VK_FILTER_LINEAR) || (createInfo.minFilter == VK_FILTER_LINEAR) ||
+                    (filterMip == RHI::FilterMode::Linear);
+
+                for (RHI::Format format : depthFormats)
+                {
+                    VkFormatProperties props = physicalDevice.GetFormatProperties(format, false);
+
+                    if (!RHI::CheckBitsAll(
+                            props.optimalTilingFeatures,
+                            static_cast<VkFormatFeatureFlags>(VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT)))
+                    {
+                        if (needsLinearForDepthFormat)
+                        {
+                            createInfo.magFilter = VK_FILTER_NEAREST;
+                            createInfo.minFilter = VK_FILTER_NEAREST;
+                            filterMip = RHI::FilterMode::Point;
+                            break; // one match is enough
+                        }
+                    }
+                }
+            }
+#endif
             switch (filterMip)
             {
             case RHI::FilterMode::Point:


### PR DESCRIPTION
## What does this PR do?

If Khronos Validation Layers (rhi-device-validation) are enabled then on some device the log is full or errors like:

[ERROR][Validation] Validation Error: [ VUID-vkCmdDraw-magFilter-04553 ] Object 0: handle = 0x7cb244000000054a, name = NewDepthOfFieldComposite_PassSrg_1, type = VK_OBJECT_TYPE_DESCRIPTOR_SET; Object 1: handle = 0x80797400000002b2, type = VK_OBJECT_TYPE_SAMPLER; Object 2: handle = 0x166e38000000144a, type = VK_OBJECT_TYPE_IMAGE_VIEW; | MessageID = 0x6b4ef9a3 | vkCmdDraw: Descriptor set VkDescriptorSet 0x7cb244000000054a[NewDepthOfFieldComposite_PassSrg_1] Sampler (VkSampler 0x80797400000002b2[]) is set to use VK_FILTER_LINEAR with compareEnable is set to VK_FALSE, but image view's (VkImageView 0x166e38000000144a[]) format (VK_FORMAT_D32_SFLOAT_S8_UINT) does not contain VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT in its format features. The Vulkan spec states: If a VkSampler created with magFilter or minFilter equal to VK_FILTER_LINEAR and compareEnable equal to VK_FALSE is used to sample a VkImageView as a result of this command, then the image view's format features must contain VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkCmdDraw-magFilter-04553)

The fix is to set the Sampler into VK_FILTER_NEAREST if the feature VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT is not supported.

## How was this PR tested?

There are no more such errors in the log.
