### PR TITLE
Disable warning as errors after setting NDK to 28. Removing VulkanValidationLayers from .apk

### DIFF
--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -732,3 +732,14 @@ set(FILES
     XML/rapidxml_print.h
     XML/rapidxml_utils.h
 )
+
+# CARBONATED
+# Disabling -ffast-math for 'ScriptContext.cpp' file only.
+# After switching to NDK 28 we have a lot of errors 
+# 'error: use of infinity is undefined behavior due to the currently enabled floating-point options'
+# in many lines of this file
+ly_add_source_properties(
+    SOURCES ${CMAKE_CURRENT_LIST_DIR}/Script/ScriptContext.cpp
+    PROPERTY COMPILE_OPTIONS
+    VALUES -fno-fast-math
+)

--- a/Gems/Atom/RHI/Vulkan/Code/Source/Platform/Android/PAL_android.cmake
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/Platform/Android/PAL_android.cmake
@@ -8,4 +8,4 @@
 
 set(PAL_TRAIT_ATOM_RHI_VULKAN_SUPPORTED TRUE)
 set(PAL_TRAIT_AFTERMATH_AVAILABLE FALSE)
-set(VULKAN_VALIDATION_LAYER 3rdParty::vulkan-validationlayers)
+# set(VULKAN_VALIDATION_LAYER 3rdParty::vulkan-validationlayers)


### PR DESCRIPTION
## What does this PR do?

After switching to NDK 28 the file ScriptContext.cpp reported a lot of errors about new infinity behavior.
For that file the options "no-fast-math" is applied.

Also the option
set(VULKAN_VALIDATION_LAYER 3rdParty::vulkan-validationlayers)
is temporary disabled in the Engine.
It will be restored after finding the way to disable it from the project

## How was this PR tested?

The APK is 16 Kb size page now.
Checked using: https://developer.android.com/guide/practices/page-sizes#windows-powershell

