### PR TITLE
The possibility to include/exclude Vulkan Validation Layers library to .apk using project setting override

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/Platform/Android/PAL_android.cmake
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/Platform/Android/PAL_android.cmake
@@ -8,4 +8,15 @@
 
 set(PAL_TRAIT_ATOM_RHI_VULKAN_SUPPORTED TRUE)
 set(PAL_TRAIT_AFTERMATH_AVAILABLE FALSE)
-# set(VULKAN_VALIDATION_LAYER 3rdParty::vulkan-validationlayers)
+
+# CARBONATED begin
+# Allow project override to disable Vulkan validation layers
+if(DEFINED DISABLE_VULKAN_VALIDATION_LAYER AND DISABLE_VULKAN_VALIDATION_LAYER)
+    message(STATUS "Vulkan validation layers disabled by project override")
+    unset(VULKAN_VALIDATION_LAYER CACHE)
+    set(VULKAN_VALIDATION_LAYER "" CACHE STRING "Validation layers disabled")
+else()
+    message(STATUS "Vulkan validation layers included")
+    set(VULKAN_VALIDATION_LAYER 3rdParty::vulkan-validationlayers)
+endif()
+# CARBONATED end


### PR DESCRIPTION
## What does this PR do?

In the game project we can define the variable like:
	set(DISABLE_VULKAN_VALIDATION_LAYER TRUE CACHE BOOL "Disable Vulkan Validation Layers")
before 
    o3de_initialize()
and the Vulkan Validation Layers library will not be included in the .apk file.

## How was this PR tested?

The .apk file was created with this define and without (in the project's CMakeList.txt) and the library libVkLayer_khronos_validation.so either presents or does not.
