### PR TITLE
Asset Processor optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ OPTION(START_MEMORY_TRACING "Start memory tracing from app start" OFF)
 OPTION(ADVANCED_ASSET_TRACING "Take more CPU time to find asset names for precise asset size tracing" OFF)
 OPTION(LOD_REMOVAL "Enable conditional LOD removal at runtime to save RAM" ON)
 OPTION(MIP_REMOVAL "Enable conditional mipmap level removal at runtime to save RAM" ON)
+OPTION(AP_OPTIMIZATION "Improves AP startup scan speed, but next AP scan might be longer" ON)
 
 if(MEMORY_TAG_TRACING)
     add_compile_definitions(AZ_MEMORY_TAG_TRACING)
@@ -58,6 +59,10 @@ endif(LOD_REMOVAL)
 if(MIP_REMOVAL)
     add_compile_definitions(AZ_MIP_REMOVAL)  # enables dropping some high quality MIPs in runtime
 endif(MIP_REMOVAL)
+
+if(AP_OPTIMIZATION)
+    add_compile_definitions(AZ_AP_OPTIMIZATION)  # AP makes faster file assessment with no extra-analysis, but next AP scan might be longer
+endif(AP_OPTIMIZATION)
 
 include(cmake/LySet.cmake)
 include(cmake/GeneralSettings.cmake)

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -3270,6 +3270,9 @@ namespace AssetProcessor
                     }
                 }
                 m_jobEntries.clear();
+#if defined(CARBONATED) && defined(AZ_AP_OPTIMIZATION)
+                m_jobAssetPaths.clear();
+#endif
                 ProcessJobs();
             }
         }
@@ -3293,6 +3296,17 @@ namespace AssetProcessor
         {
             return;
         }
+
+#if defined(CARBONATED) && defined(AZ_AP_OPTIMIZATION)
+        {
+            const AZStd::string sourcePath = fullFile.toUtf8().constData();
+            if (m_jobAssetPaths.find(sourcePath) != m_jobAssetPaths.end())
+            {
+                AZ_Trace(AssetProcessor::DebugChannel, "Ignoring file: %s, job exists", sourcePath.c_str());
+                return;
+            }
+        }
+#endif
 
         QString normalizedFullFile = AssetUtilities::NormalizeFilePath(fullFile);
 
@@ -3913,18 +3927,18 @@ namespace AssetProcessor
         int maxPerIteration = 50;
 
         // Burn through all pending files
-        const FileEntry* firstEntry = &m_activeFiles.front();
         while (m_filesToExamine.size() < maxPerIteration)
         {
-            m_alreadyActiveFiles.remove(firstEntry->m_fileName);
-            CheckSource(*firstEntry);
+            // CheckSource modifies m_activeFiles, so we need to work with a copy of the current entry
+            FileEntry firstEntry = m_activeFiles.front();
+            m_alreadyActiveFiles.remove(firstEntry.m_fileName);
+            CheckSource(firstEntry);
             m_activeFiles.pop_front();
 
             if (m_activeFiles.size() == 0)
             {
                 break;
             }
-            firstEntry = &m_activeFiles.front();
         }
 
         if (!m_alreadyScheduledUpdate)
@@ -4526,7 +4540,9 @@ namespace AssetProcessor
         // now we can update the database with this new information:
         UpdateSourceFileDependenciesDatabase(entry);
         m_jobEntries.push_back(entry);
-
+#if defined(CARBONATED) && defined(AZ_AP_OPTIMIZATION)
+        m_jobAssetPaths.emplace(entry.m_sourceFileInfo.m_sourceAssetReference.AbsolutePath().c_str());
+#endif
         // Signals SourceAssetTreeModel so it can update the CreateJobs duration change
         Q_EMIT CreateJobsDurationChanged(sourceAsset.RelativePath().c_str(), sourceAsset.ScanFolderId());
     }

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
@@ -597,6 +597,9 @@ namespace AssetProcessor
         AZStd::unordered_set<AZStd::string> m_processingProductInfoList;
         AZ::s64 m_highestJobRunKeySoFar = 0;
         AZStd::vector<JobToProcessEntry> m_jobEntries;
+#if defined(CARBONATED) && defined(AZ_AP_OPTIMIZATION)
+        AZStd::unordered_set<AZStd::string> m_jobAssetPaths;
+#endif
         AZStd::unordered_set<JobDetails> m_jobsToProcess;
         //! This map is required to prevent multiple sourceFile modified events been send by the APM
         AZStd::unordered_map<AZ::Uuid, qint64> m_sourceFileModTimeMap;


### PR DESCRIPTION
## What does this PR do?

Improves file scanning speed for large scale assets change. There might be a side effect. The next run AP can re-build some assets, so the next run can be longer comparing to the original version.

## How was this PR tested?

Local tests on Windows platform. This change is platform agnostic, it drop re-assessing the same  file multiple times.
