### PR TITLE
Recreate ProjectedShadowAtlas only if the new one is greater than the current one to fix memory leak

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
@@ -159,7 +159,7 @@ namespace AZ::Render
     void ProjectedShadowFeatureProcessor::SetNearFarPlanes(ShadowId id, float nearPlaneDistance, float farPlaneDistance)
     {
         AZ_Assert(id.IsValid(), "Invalid ShadowId passed to ProjectedShadowFeatureProcessor::SetFrontBackPlanes().");
-        
+
         ShadowProperty& shadowProperty = GetShadowPropertyFromShadowId(id);
         shadowProperty.m_desc.m_nearPlaneDistance = GetMax(nearPlaneDistance, 0.0001f);
         shadowProperty.m_desc.m_farPlaneDistance = GetMax(farPlaneDistance, nearPlaneDistance + 0.0001f);
@@ -826,8 +826,60 @@ namespace AZ::Render
             return RPI::AttachmentImage::Create(createImageRequest);
         };
 
-        m_atlasImage = createAtlas(RHI::Format::D32_FLOAT, RHI::ImageBindFlags::Depth, RHI::ImageAspectFlags::Depth, "ProjectedShadowAtlas");
+#if defined(CARBONATED)
+        // Fix for memory fragmentation/leak.
+        // Implementing a "High Water Mark" strategy: do not release the large buffer if the new requirement is smaller.
+        // Recreate the atlas only if it is needed *more* space or if the format changes.
 
+        // 1. Get current Allocated specs
+        uint32_t allocatedSize = 0;
+        uint32_t allocatedArrayCount = 0;
+        RHI::Format allocatedFormat = RHI::Format::Unknown;
+
+        if (m_atlasImage)
+        {
+            const RHI::ImageDescriptor& desc = m_atlasImage->GetDescriptor();
+            allocatedSize = desc.m_size.m_width;
+            allocatedArrayCount = desc.m_arraySize;
+            allocatedFormat = desc.m_format;
+        }
+
+        // 2. Get Required specs
+        const uint32_t requiredSize = static_cast<uint32_t>(m_atlas.GetBaseShadowmapSize());
+        const uint16_t requiredArrayCount = m_atlas.GetArraySliceCount();
+
+        // 3. Determine if recreation is needed
+        bool needsRecreate = (m_atlasImage == nullptr) || (requiredSize > allocatedSize) || (requiredArrayCount > allocatedArrayCount) || (allocatedFormat != RHI::Format::D32_FLOAT);
+
+        if (needsRecreate)
+        {
+            // Detach atlas from passes first so they don't hold references to the old image.
+            for (auto& [key, projectedShadowmapsPass] : m_projectedShadowmapsPasses)
+            {
+                projectedShadowmapsPass->SetAtlasAttachmentImage({});
+            }
+
+            // If we have an existing atlas image, unregister it from the ImageSystem (if registered) and
+            // release our reference so the instance can be destroyed.
+            if (m_atlasImage)
+            {
+                if (auto* imageSystem = RPI::ImageSystemInterface::Get())
+                {
+                    // UnregisterAttachmentImage is safe to call even if the image wasn't registered.
+                    imageSystem->UnregisterAttachmentImage(m_atlasImage.get());
+                }
+
+                // Drop our Data::Instance reference to allow destruction.
+                m_atlasImage = {};
+            }
+
+            // Create new atlas and attach to passes.
+            m_atlasImage = createAtlas(RHI::Format::D32_FLOAT, RHI::ImageBindFlags::Depth, RHI::ImageAspectFlags::Depth, "ProjectedShadowAtlas");
+
+        } // else: Reuse existing buffer.
+#else
+        m_atlasImage = createAtlas(RHI::Format::D32_FLOAT, RHI::ImageBindFlags::Depth, RHI::ImageAspectFlags::Depth, "ProjectedShadowAtlas");
+#endif
         for (auto& [key, projectedShadowmapsPass] : m_projectedShadowmapsPasses)
         {
             projectedShadowmapsPass->SetAtlasAttachmentImage(m_atlasImage);
@@ -836,7 +888,19 @@ namespace AZ::Render
 
         if (needsEsm)
         {
+#if defined(CARBONATED)
+            // Apply the same reuse logic for ESM atlas.
+            // If the main atlas needed recreation (needsRecreate) or if we don't have an ESM atlas yet, create it.
+            // Otherwise, we reuse the existing one to avoid memory thrashing.
+            bool esmRecreate = (m_esmAtlasImage == nullptr) || needsRecreate;
+
+            if (esmRecreate)
+            {
+                m_esmAtlasImage = createAtlas(RHI::Format::R16_FLOAT, RHI::ImageBindFlags::ShaderReadWrite, RHI::ImageAspectFlags::Color, "ProjectedShadowAtlasESM");
+            }
+#else
             m_esmAtlasImage = createAtlas(RHI::Format::R16_FLOAT, RHI::ImageBindFlags::ShaderReadWrite, RHI::ImageAspectFlags::Color, "ProjectedShadowAtlasESM");
+#endif
             for (auto& [key, esmShadowmapsPass] : m_esmShadowmapsPasses)
             {
                 esmShadowmapsPass->SetAtlasAttachmentImage(m_esmAtlasImage);

--- a/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
@@ -831,7 +831,7 @@ namespace AZ::Render
         // Implementing a "High Water Mark" strategy: do not release the large buffer if the new requirement is smaller.
         // Recreate the atlas only if it is needed *more* space or if the format changes.
 
-        bool needsRecreate = false;
+        bool needsRecreate = true;
         if (m_atlasImage)
         {
             // 1. Get current Allocated specs
@@ -845,8 +845,10 @@ namespace AZ::Render
             const uint32_t requiredArrayCount = m_atlas.GetArraySliceCount();
 
             // 3. Determine if recreation is needed
-            needsRecreate = (m_atlasImage == nullptr) || (requiredSize > allocatedSize) || (requiredArrayCount > allocatedArrayCount) ||
-                (allocatedFormat != RHI::Format::D32_FLOAT);
+            if ((requiredSize <= allocatedSize) && (requiredArrayCount <= allocatedArrayCount) && (allocatedFormat == RHI::Format::D32_FLOAT))
+            {
+                needsRecreate = false;
+            }
         }
 
         if (needsRecreate)

--- a/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
@@ -831,51 +831,27 @@ namespace AZ::Render
         // Implementing a "High Water Mark" strategy: do not release the large buffer if the new requirement is smaller.
         // Recreate the atlas only if it is needed *more* space or if the format changes.
 
-        // 1. Get current Allocated specs
-        uint32_t allocatedSize = 0;
-        uint32_t allocatedArrayCount = 0;
-        RHI::Format allocatedFormat = RHI::Format::Unknown;
-
+        bool needsRecreate = false;
         if (m_atlasImage)
         {
+            // 1. Get current Allocated specs
             const RHI::ImageDescriptor& desc = m_atlasImage->GetDescriptor();
-            allocatedSize = desc.m_size.m_width;
-            allocatedArrayCount = desc.m_arraySize;
-            allocatedFormat = desc.m_format;
+            const uint32_t allocatedSize = desc.m_size.m_width;
+            const uint32_t allocatedArrayCount = desc.m_arraySize;
+            const RHI::Format allocatedFormat = desc.m_format;
+
+            // 2. Get Required specs
+            const uint32_t requiredSize = static_cast<uint32_t>(m_atlas.GetBaseShadowmapSize());
+            const uint32_t requiredArrayCount = m_atlas.GetArraySliceCount();
+
+            // 3. Determine if recreation is needed
+            needsRecreate = (m_atlasImage == nullptr) || (requiredSize > allocatedSize) || (requiredArrayCount > allocatedArrayCount) ||
+                (allocatedFormat != RHI::Format::D32_FLOAT);
         }
-
-        // 2. Get Required specs
-        const uint32_t requiredSize = static_cast<uint32_t>(m_atlas.GetBaseShadowmapSize());
-        const uint16_t requiredArrayCount = m_atlas.GetArraySliceCount();
-
-        // 3. Determine if recreation is needed
-        bool needsRecreate = (m_atlasImage == nullptr) || (requiredSize > allocatedSize) || (requiredArrayCount > allocatedArrayCount) || (allocatedFormat != RHI::Format::D32_FLOAT);
 
         if (needsRecreate)
         {
-            // Detach atlas from passes first so they don't hold references to the old image.
-            for (auto& [key, projectedShadowmapsPass] : m_projectedShadowmapsPasses)
-            {
-                projectedShadowmapsPass->SetAtlasAttachmentImage({});
-            }
-
-            // If we have an existing atlas image, unregister it from the ImageSystem (if registered) and
-            // release our reference so the instance can be destroyed.
-            if (m_atlasImage)
-            {
-                if (auto* imageSystem = RPI::ImageSystemInterface::Get())
-                {
-                    // UnregisterAttachmentImage is safe to call even if the image wasn't registered.
-                    imageSystem->UnregisterAttachmentImage(m_atlasImage.get());
-                }
-
-                // Drop our Data::Instance reference to allow destruction.
-                m_atlasImage = {};
-            }
-
-            // Create new atlas and attach to passes.
             m_atlasImage = createAtlas(RHI::Format::D32_FLOAT, RHI::ImageBindFlags::Depth, RHI::ImageAspectFlags::Depth, "ProjectedShadowAtlas");
-
         } // else: Reuse existing buffer.
 #else
         m_atlasImage = createAtlas(RHI::Format::D32_FLOAT, RHI::ImageBindFlags::Depth, RHI::ImageAspectFlags::Depth, "ProjectedShadowAtlas");

--- a/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
@@ -845,7 +845,7 @@ namespace AZ::Render
             const uint32_t requiredArrayCount = m_atlas.GetArraySliceCount();
 
             // 3. Determine if recreation is needed
-            if ((requiredSize <= allocatedSize) && (requiredArrayCount <= allocatedArrayCount) && (allocatedFormat == RHI::Format::D32_FLOAT))
+            if (requiredSize <= allocatedSize && requiredArrayCount <= allocatedArrayCount && allocatedFormat == RHI::Format::D32_FLOAT)
             {
                 needsRecreate = false;
             }


### PR DESCRIPTION
## What does this PR do?

When navigating between menus where there are objects with materials that use shadows (ProjectedShadowFeatureProcessor) then the atlas (ProjectedShadowAtlas) is recreated each time but the previous atlas is not destroyed and we have memory leak.
O3DE engine releases images from the ImagePool only when the according Component is destroyed. There is no methods to destroy that atlas "by hands". 
So let's implement workaround with the strategy "High Water Mark": do not release the large buffer if the new requirement is smaller.
Now the atlas is created only 2 times: the first time with the size 1x1 and the second time with the size 512x512.
And it is not recreated till the end of the application. Now we can navigate between menus without memory leak.

## How was this PR tested?

Using "r_displayInfo 1" and navigating between menus we can observe that there is no memory leak anymore.
