### PR TITLE
Improved bugsnag symbols uploading

### DIFF
--- a/scripts/o3de/o3de/android_support.py
+++ b/scripts/o3de/o3de/android_support.py
@@ -1022,12 +1022,16 @@ ADDITIONAL_DEPENDENCIES = """
 
 """
 
+# additional plugin for bugsnag. It should be at the top level of the project to create bugsnag tasks at the proper time
 ADDITIONAL_PLUGINS = """
     apply plugin: 'com.google.gms.google-services'
     apply plugin: 'com.bugsnag.android.gradle'
 
     bugsnag {
+        // Always enable upload so tasks are created in the Gradle graph.
+        // Actual execution is controlled via 'onlyIf' below using the marker file.
         uploadNdkMappings = true
+        
         // 3 * 60 * 1000 = 180000. 3 minutes
         requestTimeoutMs = 180000        
         retryCount = 3
@@ -1041,23 +1045,34 @@ ADDITIONAL_PLUGINS = """
         println "Performing 'afterEvaluate' for BUGSNAG"
     
         tasks.configureEach { task ->
-            if (task.name.contains('BugsnagNdk')) {
-                
+            // Capture both NDK tasks (C++ symbols) and Release tasks (Java/Kotlin mappings)
+            // Examples: uploadBugsnagNdkProfileMapping, bugsnagReleaseProfileTask
+            boolean isBugsnagTask = task.name.contains('BugsnagNdk') || task.name.startsWith('bugsnagRelease')
+
+            if (isBugsnagTask) {
                 task.onlyIf {
-                    // 1. Define the variant from the task name
-                    // uploadBugsnagNdkProfileMapping -> profile
-                    // uploadBugsnagNdkReleaseMapping -> release
                     String variantName = ""
-                    if (task.name.toLowerCase().contains("release")) variantName = "release"
-                    else if (task.name.toLowerCase().contains("profile")) variantName = "profile"
-                    else if (task.name.toLowerCase().contains("debug")) variantName = "debug"
+                    String taskNameLower = task.name.toLowerCase()
+
+                    // CRITICAL: Check specific variants first!
+                    // 'bugsnagReleaseProfileTask' contains both 'release' and 'profile'.
+                    // We must check 'profile' or 'debug' before 'release' to avoid incorrect classification.
+                    if (taskNameLower.contains("profile")) {
+                        variantName = "profile"
+                    } else if (taskNameLower.contains("debug")) {
+                        variantName = "debug"
+                    } else if (taskNameLower.contains("release")) {
+                        variantName = "release"
+                    }
                     
                     if (variantName.isEmpty()) return true
 
+                    // Check for the marker file created by CMake (if CARBONATED_DISABLE_BUGSNAG=ON)
+                    // Path: build/android/app/o3de/<variant>/bugsnag_disabled.marker
                     File markerFile = project.file("o3de/${variantName}/bugsnag_disabled.marker")
                     
                     if (markerFile.exists()) {
-                        println "BUGSNAG_CONFIG: Found marker at '${markerFile.name}' for ${variantName}. Skipping task. ${task.name}"
+                        println "BUGSNAG_CONFIG: Found marker at '${markerFile.name}' for ${variantName}. Skipping task ${task.name}"
                         return false
                     }
                     

--- a/scripts/o3de/o3de/android_support.py
+++ b/scripts/o3de/o3de/android_support.py
@@ -1026,27 +1026,53 @@ ADDITIONAL_PLUGINS = """
     apply plugin: 'com.google.gms.google-services'
     apply plugin: 'com.bugsnag.android.gradle'
 
-    def localProps = new Properties()
-    def localPropsFile = project.rootProject.file('local.properties')
-    boolean shouldUpload = true
-    if (localPropsFile.exists()) {
-        localProps.load(localPropsFile.newInputStream())
-        if (localProps.getProperty('bugsnag.upload.disabled') == 'true') {
-            shouldUpload = false
-        }
-    }
-    
-    println "BUGSNAG_CONFIG: Global NDK Upload Enabled: ${shouldUpload}"
-    
     bugsnag {
-        uploadNdkMappings = shouldUpload
-        // 3 * 60 * 1000 = 180000. 3 minutes
-        requestTimeoutMs = 180000
+        uploadNdkMappings = true
+        requestTimeoutMs = 1200000 
         retryCount = 3
         sharedObjectPaths = [
-            file('o3de'),
-            file('build/intermediates/cxx')
+            file('build/intermediates/cxx'),
+            file('o3de')
         ]
+    }
+
+    afterEvaluate {
+        tasks.configureEach { task ->
+            if (task.name.contains('BugsnagNdk')) {
+                
+                task.onlyIf {
+                    // 1. Define the variant from the task name
+                    // uploadBugsnagNdkProfileMapping -> profile
+                    // uploadBugsnagNdkReleaseMapping -> release
+                    String variantName = ""
+                    if (task.name.toLowerCase().contains("release")) {
+                        variantName = "release"
+                    } else if (task.name.toLowerCase().contains("profile")) {
+                        variantName = "profile"
+                    } else if (task.name.toLowerCase().contains("debug")) {
+                        variantName = "debug"
+                    }
+                    
+                    if (variantName.isEmpty()) return true
+
+                    // 2. Make a path to the correct subdirectory
+                    // app/o3de/profile/...
+                    def variantBuildDir = project.file("o3de/${variantName}")
+                    
+                    if (variantBuildDir.exists()) {
+                        // Find the marker only inside that subdirectory
+                        def markers = project.fileTree(dir: variantBuildDir, include: '**/bugsnag_disabled.marker')
+                        
+                        if (!markers.isEmpty()) {
+                            println "BUGSNAG_CONFIG: Found disable marker in '${variantName}' build! Skipping task ${task.name}."
+                            return false
+                        }
+                    }
+                    
+                    return true
+                }
+            }
+        }
     }
 """
 # CARBONATED -- end
@@ -1608,19 +1634,6 @@ class AndroidProjectGenerator(object):
         else:
             template_cmake_path = None
 
-        # --- CARBONATED START: Bugsnag Configuration ---
-        disable_bugsnag = True  # <-- Bugsnag is disabled by default
-
-        # Check command line arguments
-        # Absence of flag = bugsnag disabled, presence = bugsnag enabled
-        if self._extra_cmake_configure_args:
-            if re.search(r"CARBONATED_DISABLE_BUGSNAG=(OFF|FALSE|0)", self._extra_cmake_configure_args, re.IGNORECASE):
-                disable_bugsnag = False
-                logger.info("Bugsnag ENABLED via CLI arguments (CARBONATED_DISABLE_BUGSNAG=OFF).")
-
-        bugsnag_disabled_str = 'true' if disable_bugsnag else 'false'
-        # --- CARBONATED END ---
-
         local_properties_env = {
             "GENERATION_TIMESTAMP": str(datetime.datetime.now().strftime("%c")),
             "ANDROID_SDK_PATH": self._android_sdk_path.resolve().as_posix(),
@@ -1631,10 +1644,6 @@ class AndroidProjectGenerator(object):
         # Load template manually to append custom properties
         default_local_properties_content = utils.load_template_file(template_file_path=src_template_file_path,
                                                                     template_env=local_properties_env)
-
-        # Write the bugsnag configuration to local.properties so Gradle can read it
-        default_local_properties_content += f"\nbugsnag.upload.disabled={bugsnag_disabled_str}\n"
-
         dst_file = self._build_dir / 'local.properties'
         # Always overwrite to ensure the file reflects the current configuration
         dst_file.write_text(default_local_properties_content,

--- a/scripts/o3de/o3de/android_support.py
+++ b/scripts/o3de/o3de/android_support.py
@@ -1028,7 +1028,8 @@ ADDITIONAL_PLUGINS = """
 
     bugsnag {
         uploadNdkMappings = true
-        requestTimeoutMs = 1200000 
+        // 3 * 60 * 1000 = 180000. 3 minutes
+        requestTimeoutMs = 180000        
         retryCount = 3
         sharedObjectPaths = [
             file('build/intermediates/cxx'),
@@ -1037,6 +1038,8 @@ ADDITIONAL_PLUGINS = """
     }
 
     afterEvaluate {
+        println "Performing 'afterEvaluate' for BUGSNAG"
+    
         tasks.configureEach { task ->
             if (task.name.contains('BugsnagNdk')) {
                 
@@ -1045,28 +1048,17 @@ ADDITIONAL_PLUGINS = """
                     // uploadBugsnagNdkProfileMapping -> profile
                     // uploadBugsnagNdkReleaseMapping -> release
                     String variantName = ""
-                    if (task.name.toLowerCase().contains("release")) {
-                        variantName = "release"
-                    } else if (task.name.toLowerCase().contains("profile")) {
-                        variantName = "profile"
-                    } else if (task.name.toLowerCase().contains("debug")) {
-                        variantName = "debug"
-                    }
+                    if (task.name.toLowerCase().contains("release")) variantName = "release"
+                    else if (task.name.toLowerCase().contains("profile")) variantName = "profile"
+                    else if (task.name.toLowerCase().contains("debug")) variantName = "debug"
                     
                     if (variantName.isEmpty()) return true
 
-                    // 2. Make a path to the correct subdirectory
-                    // app/o3de/profile/...
-                    def variantBuildDir = project.file("o3de/${variantName}")
+                    File markerFile = project.file("o3de/${variantName}/bugsnag_disabled.marker")
                     
-                    if (variantBuildDir.exists()) {
-                        // Find the marker only inside that subdirectory
-                        def markers = project.fileTree(dir: variantBuildDir, include: '**/bugsnag_disabled.marker')
-                        
-                        if (!markers.isEmpty()) {
-                            println "BUGSNAG_CONFIG: Found disable marker in '${variantName}' build! Skipping task ${task.name}."
-                            return false
-                        }
+                    if (markerFile.exists()) {
+                        println "BUGSNAG_CONFIG: Found marker at '${markerFile.name}' for ${variantName}. Skipping task. ${task.name}"
+                        return false
                     }
                     
                     return true


### PR DESCRIPTION
## What does this PR do?

The option CARBONATED_DISABLE_BUGSNAG is used as -DCARBONATED_DISABLE_BUGSNAG=ON option from Jenkins as OPTION(CARBONATED_DISABLE_BUGSNAG OFF) in CMakeLists.txt to define should we upload bugsnag symbols or not

## How was this PR tested?

The android build is created and depends on the option the symbols are uploaded or don't to the bugsnag server.
