### PR TITLE
adding bugsnag gem android project setting for the gradle template

### DIFF
--- a/Code/Tools/Android/ProjectBuilder/ProjectActivity.java
+++ b/Code/Tools/Android/ProjectBuilder/ProjectActivity.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
 package ${ANDROID_PACKAGE};
 
 import android.util.Log;

--- a/scripts/o3de/o3de/android_support.py
+++ b/scripts/o3de/o3de/android_support.py
@@ -1523,6 +1523,17 @@ class AndroidProjectGenerator(object):
         project_names.append("playerengagement")        
 # CARBONATED -- end
 
+# CARBONATED -- begin : Bugsnag gem Android project staging
+        bugsnag_dir = self._build_dir / "bugsnag"
+        (bugsnag_dir / "src/main").mkdir(parents=True, exist_ok=True)
+
+        shutil.copy(self._project_path / "Gems/Bugsnag/Projects/Android/build.gradle", bugsnag_dir)
+        shutil.copytree(self._project_path / "Gems/Bugsnag/Resources/Android", bugsnag_dir / "src/main", dirs_exist_ok=True)
+
+        project_names.append("bugsnag")
+# CARBONATED -- end
+
+
         project_names.extend(self.create_lumberyard_app(project_names))
         
 # CARBONATED -- begin : generate/append asset pack project to the project list 


### PR DESCRIPTION
adding bugsnag gem android project setting for the gradle template

## What does this PR do?
Adds section to android_support.py to pickup Gems/Bugsnag/Projects/Android/build.gradle from the project level Bugsnag Gem
to support early starting of Bugsnag.

Previously the build.gradle in the Bugsnag/Resources/Android folder would not be picked up (only PlayerEngagement gem was handled in android_support.py

Requires Gems/Bugsnag/Resources/Android/build.gradle in the client. (There is a client PR that includes this file in Madworld to move the startup of Bugsnag to a point prior to the main activity in an effort to catch early crashes for bugsnag reporting.

## How was this PR tested?
Tested in madworld build 38096 for Android. Applies only to Android builds.
