### PR TITLE
Improve asset loading log (noticket)

### DIFF
--- a/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
@@ -403,8 +403,12 @@ namespace AZ::Data
                     {
                         if (!m_waitEvent.try_acquire_for(AZStd::chrono::milliseconds(m_timeoutMillis)))
                         {
-                            AZ_Info("AssetManager", "Non-main thread blocking loading wait timeout %d exceeded for %s",
-                                    m_timeoutMillis, m_assetData.GetHint().c_str());
+                            AZStd::string path = m_assetData.GetHint();
+                            if (path.empty())
+                            {
+                                EBUS_EVENT_RESULT(path, AZ::Data::AssetCatalogRequestBus, GetAssetPathById, m_assetData.GetId());
+                            }
+                            AZ_Info("AssetManager", "Non-main thread blocking loading wait timeout %d exceeded for %s", m_timeoutMillis, path.c_str());
                         }
                     }
                     else


### PR DESCRIPTION
## What does this PR do?

Improve asset loading issues logging, pretty often there is no asset hint for such objects, but the asset catalog request always returns a valid name.

## How was this PR tested?

Local build tests on iOS.
