### PR TITLE
NO-TICKET: Fixed a crash in the editor when editing a string field in a prefab

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.cpp
@@ -5,6 +5,9 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+#if defined CARBONATED
+#include "ReflectionAdapter.h"
+#endif
 
 #include <AzCore/Console/IConsole.h>
 #include <AzCore/DOM/DomComparison.h>
@@ -104,6 +107,10 @@ namespace AZ::DocumentPropertyEditor
             // If it's a hard reset, or we don't have any lazily cached contents, just send the reset signal.
             m_cachedContents.SetNull();
             m_resetEvent.Signal();
+
+#if defined CARBONATED
+            DocumentAdapterEventBus::Broadcast(&DocumentAdapterEventBus::Events::ResumeInput);
+#endif
         }
         else
         {

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.h
@@ -97,6 +97,12 @@ namespace AZ::DocumentPropertyEditor
     };
 
 #if defined CARBONATED
+    // EventBus for fixing a crash in the editor when editing a string field in a prefab.
+    // When modifying a string input field in a prefab, all entities in the scene reload,
+    // and if a repeated input is made from the string field,
+    // there is an attempt to write data into an already destroyed prefab.
+    // The string input field may trigger twice if input is completed by pressing the Enter key
+    // or after entering text and switching to another input field.
     class DocumentAdapterEventBusTraits : public AZ::EBusTraits
     {
     public:
@@ -104,8 +110,8 @@ namespace AZ::DocumentPropertyEditor
         static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
 
         virtual ~DocumentAdapterEventBusTraits() = default;
-        virtual void SuspendInput() = 0;
-        virtual void ResumeInput() = 0;
+        virtual void SuspendInput() = 0;    // Event to suspend input in the editor.
+        virtual void ResumeInput() = 0;     // Event to resume input in the editor.
     };
 
     using DocumentAdapterEventBus = AZ::EBus<DocumentAdapterEventBusTraits>;

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.h
@@ -8,6 +8,10 @@
 
 #pragma once
 
+#if defined CARBONATED
+#include "AzCore/EBus/EBus.h"
+#endif
+
 #include <AzCore/DOM/DomPatch.h>
 #include <AzCore/DOM/DomValue.h>
 #include <AzCore/EBus/Event.h>
@@ -91,6 +95,21 @@ namespace AZ::DocumentPropertyEditor
         //! Returns the BoundAdapterMessage if successful.
         static AZStd::optional<BoundAdapterMessage> TryMarshalFromDom(const Dom::Value& value);
     };
+
+#if defined CARBONATED
+    class DocumentAdapterEventBusTraits : public AZ::EBusTraits
+    {
+    public:
+        static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
+        static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
+
+        virtual ~DocumentAdapterEventBusTraits() = default;
+        virtual void SuspendInput() = 0;
+        virtual void ResumeInput() = 0;
+    };
+
+    using DocumentAdapterEventBus = AZ::EBus<DocumentAdapterEventBusTraits>;
+#endif
 
     //! A DocumentAdapter provides an interface for transforming data from an arbitrary
     //! source into a DOM hierarchy that can be viewed and edited by a DocumentPropertyView.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceSerializer.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceSerializer.cpp
@@ -175,6 +175,9 @@ namespace AzToolsFramework
 
             if (instanceDomMetadata == nullptr || cachedInstanceDom == AZStd::nullopt)
             {
+#if defined CARBONATED
+                AZ::DocumentPropertyEditor::DocumentAdapterEventBus::Broadcast(&AZ::DocumentPropertyEditor::DocumentAdapterEventBus::Events::SuspendInput);
+#endif
                 ClearAndLoadInstances(inputValue, context, instance, result);
 
                 if (idMapper && *idMapper)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringLineEditCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringLineEditCtrl.cpp
@@ -38,6 +38,10 @@ namespace AzToolsFramework
         setLayout(pLayout);
         setFocusProxy(m_pLineEdit);
         setFocusPolicy(m_pLineEdit->focusPolicy());
+
+#if defined CARBONATED
+        AZ::DocumentPropertyEditor::DocumentAdapterEventBus::Handler::BusConnect();
+#endif
     };
 
     void PropertyStringLineEditCtrl::setValue(AZStd::string& value)
@@ -85,6 +89,9 @@ namespace AzToolsFramework
 
     PropertyStringLineEditCtrl::~PropertyStringLineEditCtrl()
     {
+#if defined CARBONATED
+        AZ::DocumentPropertyEditor::DocumentAdapterEventBus::Handler::BusDisconnect();
+#endif
     }
 
 
@@ -102,16 +109,43 @@ namespace AzToolsFramework
         // There's only one QT widget on this property.
     }
 
+#if defined CARBONATED
+    void PropertyStringLineEditCtrl::SuspendInput()
+    {
+        m_suspended = true;
+    }
+
+    void PropertyStringLineEditCtrl::ResumeInput()
+    {
+        m_suspended = false;
+    }
+#endif
+
     QWidget* StringPropertyLineEditHandler::CreateGUI(QWidget* pParent)
     {
         PropertyStringLineEditCtrl* newCtrl = aznew PropertyStringLineEditCtrl(pParent);
+#if defined CARBONATED
+        connect(newCtrl->GetLineEdit(), &QLineEdit::editingFinished, this, [this, newCtrl]() { OnEditingFinished(newCtrl); });
+#else
         connect(newCtrl->GetLineEdit(), &QLineEdit::editingFinished, this, [newCtrl]()
             {
                 PropertyEditorGUIMessagesBus::Broadcast(&PropertyEditorGUIMessages::RequestWrite, newCtrl);
                 PropertyEditorGUIMessagesBus::Broadcast(&PropertyEditorGUIMessages::OnEditingFinished, newCtrl);
             });
+#endif
         return newCtrl;
     }
+
+#if defined CARBONATED
+    void StringPropertyLineEditHandler::OnEditingFinished(PropertyStringLineEditCtrl* ctrl)
+    {
+        if (!ctrl->m_suspended)
+        {
+            PropertyEditorGUIMessagesBus::Broadcast(&PropertyEditorGUIMessages::RequestWrite, ctrl);
+            PropertyEditorGUIMessagesBus::Broadcast(&PropertyEditorGUIMessages::OnEditingFinished, ctrl);
+        }
+    }
+#endif
 
     void StringPropertyLineEditHandler::ConsumeAttribute(PropertyStringLineEditCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName)
     {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringLineEditCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringLineEditCtrl.hxx
@@ -25,6 +25,9 @@ namespace AzToolsFramework
 {
     class PropertyStringLineEditCtrl
         : public QWidget
+#if defined CARBONATED
+        , private AZ::DocumentPropertyEditor::DocumentAdapterEventBus::Handler
+#endif
     {
         friend class StringPropertyLineEditHandler;
         Q_OBJECT
@@ -53,6 +56,13 @@ namespace AzToolsFramework
         virtual void focusInEvent(QFocusEvent* e);
 
         QLineEdit* m_pLineEdit;
+#if defined CARBONATED
+    private:
+        void SuspendInput() override;
+        void ResumeInput() override;
+
+        bool m_suspended = false;
+#endif
     };
 
     class StringPropertyLineEditHandler
@@ -71,6 +81,11 @@ namespace AzToolsFramework
         virtual void UpdateWidgetInternalTabbing(PropertyStringLineEditCtrl* widget) override { widget->UpdateTabOrder(); }
 
         virtual QWidget* CreateGUI(QWidget* pParent) override;
+
+#if defined CARBONATED
+        virtual void OnEditingFinished(PropertyStringLineEditCtrl* ctrl);
+#endif
+
         virtual void ConsumeAttribute(PropertyStringLineEditCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName) override;
         virtual void WriteGUIValuesIntoProperty(size_t index, PropertyStringLineEditCtrl* GUI, property_t& instance, InstanceDataNode* node) override;
         virtual bool ReadValuesIntoGUI(size_t index, PropertyStringLineEditCtrl* GUI, const property_t& instance, InstanceDataNode* node)  override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringLineEditCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringLineEditCtrl.hxx
@@ -58,8 +58,11 @@ namespace AzToolsFramework
         QLineEdit* m_pLineEdit;
 #if defined CARBONATED
     private:
+        ////////////////////////////////////////////////////////////////////////
+        // DocumentAdapterEventBus interface implementation
         void SuspendInput() override;
         void ResumeInput() override;
+        ////////////////////////////////////////////////////////////////////////
 
         bool m_suspended = false;
 #endif


### PR DESCRIPTION
## What does this PR do?

Fixed a crash in the editor when editing a string field in a prefab. When modifying a string input field in a prefab, all entities in the scene reload, and if a repeated input is made from the string field, there is an attempt to write data into an already destroyed prefab. The string input field may trigger twice if input is completed by pressing the Enter key or after entering text and switching to another input field.

## How was this PR tested?

jenkins
