### PR TITLE
Background crash fix (car-30929)

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
@@ -168,11 +168,17 @@ namespace AZ
 
             MaterialComponentRequestBus::Handler::BusConnect(m_entityId);
             MaterialConsumerNotificationBus::Handler::BusConnect(m_entityId);
+#if defined(CARBONATED)
+            AzFramework::ApplicationLifecycleEvents::Bus::Handler::BusConnect();
+#endif
             LoadMaterials();
         }
 
         void MaterialComponentController::Deactivate()
         {
+#if defined(CARBONATED)
+            AzFramework::ApplicationLifecycleEvents::Bus::Handler::BusDisconnect();
+#endif
             MaterialComponentRequestBus::Handler::BusDisconnect();
             MaterialConsumerNotificationBus::Handler::BusDisconnect();
 
@@ -218,8 +224,27 @@ namespace AZ
             InitializeMaterialInstance(asset);
         }
 
+#if defined(CARBONATED)
+        void MaterialComponentController::OnApplicationConstrained(AzFramework::ApplicationLifecycleEvents::Event)
+        {
+            m_onPause = true;
+        }
+        void MaterialComponentController::OnApplicationUnconstrained(AzFramework::ApplicationLifecycleEvents::Event)
+        {
+            m_onPause = false;
+        }
+#endif
+
         void MaterialComponentController::OnSystemTick()
         {
+#if defined(CARBONATED)
+            if (m_onPause)
+            {
+                // do not use GPU for copying image data while the app is in background
+                return;
+            }
+#endif
+            
             while (!m_notifiedMaterialAssets.empty())
             {
                 auto materialAsset = m_notifiedMaterialAssets.front();

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
@@ -13,7 +13,9 @@
 #include <Atom/RPI.Public/Material/Material.h>
 #include <AtomLyIntegration/CommonFeatures/Material/MaterialComponentBus.h>
 #include <AtomLyIntegration/CommonFeatures/Material/MaterialComponentConfig.h>
-
+#if defined(CARBONATED)
+#include <AzFramework/API/ApplicationAPI.h>
+#endif
 namespace AZ
 {
     namespace Render
@@ -23,6 +25,9 @@ namespace AZ
         class MaterialComponentController final
             : MaterialComponentRequestBus::Handler
             , MaterialConsumerNotificationBus::Handler
+#if defined(CARBONATED)
+            , public AzFramework::ApplicationLifecycleEvents::Bus::Handler
+#endif
             , Data::AssetBus::MultiHandler
             , SystemTickBus::Handler
         {
@@ -82,7 +87,7 @@ namespace AZ
 
             //! MaterialConsumerNotificationBus::Handler overrides...
             void OnMaterialAssignmentSlotsChanged() override;
-
+            
         private:
 
             AZ_DISABLE_COPY(MaterialComponentController);
@@ -95,6 +100,12 @@ namespace AZ
 
             // AZ::SystemTickBus overrides...
             void OnSystemTick() override;
+
+#if defined(CARBONATED)
+            // ApplicationLifecycleEvents::Bus overrides
+            void OnApplicationConstrained(AzFramework::ApplicationLifecycleEvents::Event /*lastEvent*/) override;
+            void OnApplicationUnconstrained(AzFramework::ApplicationLifecycleEvents::Event /*lastEvent*/) override;
+#endif
 
             void LoadMaterials();
             // Typically called from thread context of Data::AssetBus::MultiHandler::OnAssetXXX.
@@ -147,6 +158,10 @@ namespace AZ
             bool m_queuedMaterialsCreatedNotification = false;
             bool m_queuedMaterialsUpdatedNotification = false;
             bool m_queuedLoadMaterials = false;
+            
+#if defined(CARBONATED)
+            bool m_onPause = false;
+#endif
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
@@ -87,7 +87,7 @@ namespace AZ
 
             //! MaterialConsumerNotificationBus::Handler overrides...
             void OnMaterialAssignmentSlotsChanged() override;
-            
+
         private:
 
             AZ_DISABLE_COPY(MaterialComponentController);


### PR DESCRIPTION
## What does this PR do?

Image asset creation involves data copy via GPU. If we use GPU in background then GPU crashes.
The fix is pausing material controller updates, which prevents image data loading to metal buffers.

## How was this PR tested?

Local and Jenkins iOS build tested.
