### PR TITLE
[CAR-31059] Make more readable warnings in prefab patches serialization

### DIFF
--- a/Code/Framework/AzCore/AzCore/Serialization/Json/JsonMerger.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/Json/JsonMerger.cpp
@@ -283,10 +283,10 @@ namespace AZ
 #if defined(CARBONATED) // More readable warnings in prefab patches serialization
             rapidjson::StringBuffer pointerPathString;
             path.Stringify(pointerPathString);
-            const auto message = R"(The required field "value" for "add" operation is missing at path:)";
+            constexpr const auto message = R"(The required field "value" for "add" operation is missing at path:)";
             return settings.m_reporting(AZStd::string::format("%s\n   '%s'.", message, pointerPathString.GetString()),
                 ResultCode(Tasks::Merge, Outcomes::Missing), element);
-#elif
+#else
             return settings.m_reporting(R"(The required field "value" for "add" operation is missing.)",
                 ResultCode(Tasks::Merge, Outcomes::Missing), element);
 #endif // defined(CARBONATED)
@@ -325,10 +325,10 @@ namespace AZ
         if (!parentValue)
         {
 #if defined(CARBONATED) // More readable warnings in prefab patches serialization
-            const auto message = R"(The target path for "add" operation does not exist at path:)";
+            constexpr const auto message = R"(The target path for "add" operation does not exist at path:)";
             return settings.m_reporting(AZStd::string::format("%s\n   '%s'.", message, pointerPathString.GetString()),
                 ResultCode(Tasks::Merge, Outcomes::Missing), element);
-#elif
+#else
             return settings.m_reporting(R"(The target path for "add" operation does not exist.)",
                 ResultCode(Tasks::Merge, Outcomes::Invalid), element);
 #endif // defined(CARBONATED)
@@ -365,7 +365,7 @@ namespace AZ
                     const auto message = R"(The target path for "add" operation is not an index value at path:)";
                     return settings.m_reporting(AZStd::string::format("%s\n   '%s'.", message, pointerPathString.GetString()),
                         ResultCode(Tasks::Merge, Outcomes::Missing), element);
-#elif
+#else
                     return settings.m_reporting(R"(The target path for "add" operation is not an index value.)",
                         ResultCode(Tasks::Merge, Outcomes::Invalid), element);
 #endif // defined(CARBONATED)
@@ -391,10 +391,10 @@ namespace AZ
                 else
                 {
 #if defined(CARBONATED) // More readable warnings in prefab patches serialization
-                    const auto message = R"(The target path for "add" operation is not a valid index at path:)";
+                    constexpr const auto message = R"(The target path for "add" operation is not a valid index at path:)";
                     return settings.m_reporting(AZStd::string::format("%s\n   '%s'.", message, pointerPathString.GetString()),
                         ResultCode(Tasks::Merge, Outcomes::Missing), element);
-#elif
+#else
                     return settings.m_reporting(R"(The target path for "add" operation is not a valid index.)",
                         ResultCode(Tasks::Merge, Outcomes::Invalid), element);
 #endif // defined(CARBONATED)
@@ -404,10 +404,10 @@ namespace AZ
         else
         {
 #if defined(CARBONATED) // More readable warnings in prefab patches serialization
-            const auto message = R"(The target for "add" operation is not an object or array at path:)";
+            constexpr const auto message = R"(The target for "add" operation is not an object or array at path:)";
             return settings.m_reporting(AZStd::string::format("%s\n   '%s'.", message, pointerPathString.GetString()),
                 ResultCode(Tasks::Merge, Outcomes::Missing), element);
-#elif
+#else
             return settings.m_reporting(R"(The target for "add" operation is not an object or array.)",
                 ResultCode(Tasks::Merge, Outcomes::TypeMismatch), element);
 #endif // defined(CARBONATED)
@@ -443,10 +443,10 @@ namespace AZ
         if (!parentValue)
         {
 #if defined(CARBONATED) // More readable warnings in prefab patches serialization
-            const auto message = R"(The target path for "remove" operation does not exist at path:)";
+            constexpr const auto message = R"(The target path for "remove" operation does not exist at path:)";
             return settings.m_reporting(AZStd::string::format("%s\n   '%s'.", message, pointerPathString.GetString()),
                 ResultCode(Tasks::Merge, Outcomes::Missing), element);
-#elif
+#else
             return settings.m_reporting(R"(The target path for "remove" operation does not exist.)",
                 ResultCode(Tasks::Merge, Outcomes::Invalid), element);
 #endif // defined(CARBONATED)
@@ -457,10 +457,10 @@ namespace AZ
             if (!parentValue->EraseMember(tokens[path.GetTokenCount() - 1].name))
             {
 #if defined(CARBONATED) // More readable warnings in prefab patches serialization
-            const auto message = R"(The "remove" operation failed to remove the member from object at path:)";
+            constexpr const auto message = R"(The "remove" operation failed to remove the member from object at path:)";
             return settings.m_reporting(AZStd::string::format("%s\n   '%s'.", message, pointerPathString.GetString()),
                 ResultCode(Tasks::Merge, Outcomes::Missing), element);
-#elif
+#else
                 rapidjson::StringBuffer pathString;
                 path.Stringify(pathString);
                 return settings.m_reporting(
@@ -481,10 +481,10 @@ namespace AZ
             else
             {
 #if defined(CARBONATED) // More readable warnings in prefab patches serialization
-            const auto message = R"(The target path for "remove" operation has an invalid index at path:)";
+            constexpr const auto message = R"(The target path for "remove" operation has an invalid index at path:)";
             return settings.m_reporting(AZStd::string::format("%s\n   '%s'.", message, pointerPathString.GetString()),
                 ResultCode(Tasks::Merge, Outcomes::Missing), element);
-#elif
+#else
                 return settings.m_reporting(R"(The target path for "remove" operation has an invalid index.)",
                     ResultCode(Tasks::Merge, Outcomes::Invalid), element);
 #endif // defined(CARBONATED)
@@ -493,10 +493,10 @@ namespace AZ
         else
         {
 #if defined(CARBONATED) // More readable warnings in prefab patches serialization
-            const auto message = R"(The target for "remove" operation is not an object or array at path:)";
+            constexpr const auto message = R"(The target for "remove" operation is not an object or array at path:)";
             return settings.m_reporting(AZStd::string::format("%s\n   '%s'.", message, pointerPathString.GetString()),
                 ResultCode(Tasks::Merge, Outcomes::Missing), element);
-#elif
+#else
             return settings.m_reporting(R"(The target for "remove" operation is not an object or array.)",
                 ResultCode(Tasks::Merge, Outcomes::TypeMismatch), element);
 #endif // defined(CARBONATED)
@@ -526,10 +526,10 @@ namespace AZ
         {
             ScopedStackedString valueName(element, "value");
 #if defined(CARBONATED) // More readable warnings in prefab patches serialization
-            const auto message = R"(The required field "value" for "replace" operation is missing at path:)";
+            constexpr const auto message = R"(The required field "value" for "replace" operation is missing at path:)";
             return settings.m_reporting(AZStd::string::format("%s\n   '%s'.", message, pointerPathString.GetString()),
                 ResultCode(Tasks::Merge, Outcomes::Missing), element);
-#elif
+#else
             return settings.m_reporting(R"(The required field "value" for "replace" operation is missing.)",
                 ResultCode(Tasks::Merge, Outcomes::Missing), element);
 #endif // defined(CARBONATED)
@@ -539,10 +539,10 @@ namespace AZ
         if (!memberValue)
         {
 #if defined(CARBONATED) // More readable warnings in prefab patches serialization
-            const auto message = R"(The target for "replace" operation doesn't exist at path:)";
+            constexpr const auto message = R"(The target for "replace" operation doesn't exist at path:)";
             return settings.m_reporting(AZStd::string::format("%s\n   '%s'.", message, pointerPathString.GetString()),
                 ResultCode(Tasks::Merge, Outcomes::Missing), element);
-#elif
+#else
             return settings.m_reporting(R"(The target for "replace" operation doesn't exist.)",
                 ResultCode(Tasks::Merge, Outcomes::Invalid), element);
 #endif // defined(CARBONATED)

--- a/Code/Framework/AzCore/AzCore/Serialization/Json/JsonMerger.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/Json/JsonMerger.cpp
@@ -24,6 +24,9 @@ namespace AZ
         StackedString element(StackedString::Format::JsonPointer);
         if (!patch.IsArray())
         {
+#if defined(CARBONATED) // More readable warnings in prefab patches serialization
+            ScopedStackedString entryOp(element, "patches");
+#endif // defined(CARBONATED)
             return settings.m_reporting("JSON Patch only supports arrays at the root.",
                 ResultCode(Tasks::Merge, Outcomes::TypeMismatch), element);
         }
@@ -277,8 +280,16 @@ namespace AZ
         if (value == entry.MemberEnd())
         {
             ScopedStackedString valueName(element, "value");
+#if defined(CARBONATED) // More readable warnings in prefab patches serialization
+            rapidjson::StringBuffer pointerPathString;
+            path.Stringify(pointerPathString);
+            const auto message = R"(The required field "value" for "add" operation is missing at path:)";
+            return settings.m_reporting(AZStd::string::format("%s\n   '%s'.", message, pointerPathString.GetString()),
+                ResultCode(Tasks::Merge, Outcomes::Missing), element);
+#elif
             return settings.m_reporting(R"(The required field "value" for "add" operation is missing.)",
                 ResultCode(Tasks::Merge, Outcomes::Missing), element);
+#endif // defined(CARBONATED)
         }
 
         rapidjson::Value newValue;
@@ -292,11 +303,18 @@ namespace AZ
     {
         using namespace JsonSerializationResult;
 
+#if defined(CARBONATED) // More readable warnings in prefab patches serialization : moved up for shared usage
+        rapidjson::StringBuffer pointerPathString;
+        path.Stringify(pointerPathString);
+#endif // defined(CARBONATED)
+
         const rapidjson::Pointer::Token* const tokens = path.GetTokens();
         if (path.GetTokenCount() == 0)
         {
+#if !defined(CARBONATED) // More readable warnings in prefab patches serialization : moved up for shared usage
             rapidjson::StringBuffer pointerPathString;
             path.Stringify(pointerPathString);
+#endif // !defined(CARBONATED)
             target = AZStd::move(newValue);
             return settings.m_reporting(R"(Successfully applied "add" operation.)",
                 ResultCode(Tasks::Merge, Outcomes::Success), pointerPathString.GetString());
@@ -306,8 +324,14 @@ namespace AZ
         rapidjson::Value* parentValue = parent.Get(target);
         if (!parentValue)
         {
+#if defined(CARBONATED) // More readable warnings in prefab patches serialization
+            const auto message = R"(The target path for "add" operation does not exist at path:)";
+            return settings.m_reporting(AZStd::string::format("%s\n   '%s'.", message, pointerPathString.GetString()),
+                ResultCode(Tasks::Merge, Outcomes::Missing), element);
+#elif
             return settings.m_reporting(R"(The target path for "add" operation does not exist.)",
                 ResultCode(Tasks::Merge, Outcomes::Invalid), element);
+#endif // defined(CARBONATED)
         }
 
         if (parentValue->IsObject())
@@ -337,8 +361,14 @@ namespace AZ
                 }
                 else
                 {
+#if defined(CARBONATED) // More readable warnings in prefab patches serialization
+                    const auto message = R"(The target path for "add" operation is not an index value at path:)";
+                    return settings.m_reporting(AZStd::string::format("%s\n   '%s'.", message, pointerPathString.GetString()),
+                        ResultCode(Tasks::Merge, Outcomes::Missing), element);
+#elif
                     return settings.m_reporting(R"(The target path for "add" operation is not an index value.)",
                         ResultCode(Tasks::Merge, Outcomes::Invalid), element);
+#endif // defined(CARBONATED)
                 }
             }
             else
@@ -360,19 +390,33 @@ namespace AZ
                 }
                 else
                 {
+#if defined(CARBONATED) // More readable warnings in prefab patches serialization
+                    const auto message = R"(The target path for "add" operation is not a valid index at path:)";
+                    return settings.m_reporting(AZStd::string::format("%s\n   '%s'.", message, pointerPathString.GetString()),
+                        ResultCode(Tasks::Merge, Outcomes::Missing), element);
+#elif
                     return settings.m_reporting(R"(The target path for "add" operation is not a valid index.)",
                         ResultCode(Tasks::Merge, Outcomes::Invalid), element);
+#endif // defined(CARBONATED)
                 }
             }
         }
         else
         {
+#if defined(CARBONATED) // More readable warnings in prefab patches serialization
+            const auto message = R"(The target for "add" operation is not an object or array at path:)";
+            return settings.m_reporting(AZStd::string::format("%s\n   '%s'.", message, pointerPathString.GetString()),
+                ResultCode(Tasks::Merge, Outcomes::Missing), element);
+#elif
             return settings.m_reporting(R"(The target for "add" operation is not an object or array.)",
                 ResultCode(Tasks::Merge, Outcomes::TypeMismatch), element);
+#endif // defined(CARBONATED)
         }
 
+#if !defined(CARBONATED) // More readable warnings in prefab patches serialization : moved up for shared usage
         rapidjson::StringBuffer pointerPathString;
         path.Stringify(pointerPathString);
+#endif // !defined(CARBONATED)
         return settings.m_reporting(R"(Successfully applied "add" operation.)",
             ResultCode(Tasks::Merge, Outcomes::Success), pointerPathString.GetString());
     }
@@ -381,6 +425,11 @@ namespace AZ
         StackedString& element, JsonApplyPatchSettings& settings)
     {
         using namespace JsonSerializationResult;
+
+#if defined(CARBONATED) // More readable warnings in prefab patches serialization : moved up for shared usage
+        rapidjson::StringBuffer pointerPathString;
+        path.Stringify(pointerPathString);
+#endif // defined(CARBONATED)
 
         const rapidjson::Pointer::Token* const tokens = path.GetTokens();
         if (path.GetTokenCount() == 0)
@@ -393,14 +442,25 @@ namespace AZ
         rapidjson::Value* parentValue = parent.Get(target);
         if (!parentValue)
         {
+#if defined(CARBONATED) // More readable warnings in prefab patches serialization
+            const auto message = R"(The target path for "remove" operation does not exist at path:)";
+            return settings.m_reporting(AZStd::string::format("%s\n   '%s'.", message, pointerPathString.GetString()),
+                ResultCode(Tasks::Merge, Outcomes::Missing), element);
+#elif
             return settings.m_reporting(R"(The target path for "remove" operation does not exist.)",
                 ResultCode(Tasks::Merge, Outcomes::Invalid), element);
+#endif // defined(CARBONATED)
         }
 
         if (parentValue->IsObject())
         {
             if (!parentValue->EraseMember(tokens[path.GetTokenCount() - 1].name))
             {
+#if defined(CARBONATED) // More readable warnings in prefab patches serialization
+            const auto message = R"(The "remove" operation failed to remove the member from object at path:)";
+            return settings.m_reporting(AZStd::string::format("%s\n   '%s'.", message, pointerPathString.GetString()),
+                ResultCode(Tasks::Merge, Outcomes::Missing), element);
+#elif
                 rapidjson::StringBuffer pathString;
                 path.Stringify(pathString);
                 return settings.m_reporting(
@@ -408,6 +468,7 @@ namespace AZ
                         R"(The "remove" operation failed to remove member '%s' from object at path '%s'.)",
                         tokens[path.GetTokenCount() - 1].name, pathString.GetString()),
                     ResultCode(Tasks::Merge, Outcomes::Invalid), element);
+#endif // defined(CARBONATED)
             }
         }
         else if (parentValue->IsArray())
@@ -419,18 +480,32 @@ namespace AZ
             }
             else
             {
+#if defined(CARBONATED) // More readable warnings in prefab patches serialization
+            const auto message = R"(The target path for "remove" operation has an invalid index at path:)";
+            return settings.m_reporting(AZStd::string::format("%s\n   '%s'.", message, pointerPathString.GetString()),
+                ResultCode(Tasks::Merge, Outcomes::Missing), element);
+#elif
                 return settings.m_reporting(R"(The target path for "remove" operation has an invalid index.)",
                     ResultCode(Tasks::Merge, Outcomes::Invalid), element);
+#endif // defined(CARBONATED)
             }
         }
         else
         {
+#if defined(CARBONATED) // More readable warnings in prefab patches serialization
+            const auto message = R"(The target for "remove" operation is not an object or array at path:)";
+            return settings.m_reporting(AZStd::string::format("%s\n   '%s'.", message, pointerPathString.GetString()),
+                ResultCode(Tasks::Merge, Outcomes::Missing), element);
+#elif
             return settings.m_reporting(R"(The target for "remove" operation is not an object or array.)",
                 ResultCode(Tasks::Merge, Outcomes::TypeMismatch), element);
+#endif // defined(CARBONATED)
         }
 
+#if !defined(CARBONATED) // More readable warnings in prefab patches serialization : moved up for shared usage
         rapidjson::StringBuffer pointerPathString;
         path.Stringify(pointerPathString);
+#endif // !defined(CARBONATED)
         return settings.m_reporting(R"(Successfully applied "remove" operation.)",
             ResultCode(Tasks::Merge, Outcomes::Success), pointerPathString.GetString());
     }
@@ -441,25 +516,44 @@ namespace AZ
     {
         using namespace JsonSerializationResult;
 
+#if defined(CARBONATED) // More readable warnings in prefab patches serialization : moved up for shared usage
+        rapidjson::StringBuffer pointerPathString;
+        path.Stringify(pointerPathString);
+#endif // defined(CARBONATED)
+
         auto value = entry.FindMember("value");
         if (value == entry.MemberEnd())
         {
             ScopedStackedString valueName(element, "value");
+#if defined(CARBONATED) // More readable warnings in prefab patches serialization
+            const auto message = R"(The required field "value" for "replace" operation is missing at path:)";
+            return settings.m_reporting(AZStd::string::format("%s\n   '%s'.", message, pointerPathString.GetString()),
+                ResultCode(Tasks::Merge, Outcomes::Missing), element);
+#elif
             return settings.m_reporting(R"(The required field "value" for "replace" operation is missing.)",
                 ResultCode(Tasks::Merge, Outcomes::Missing), element);
+#endif // defined(CARBONATED)
         }
 
         rapidjson::Value* memberValue = path.Get(target);
         if (!memberValue)
         {
+#if defined(CARBONATED) // More readable warnings in prefab patches serialization
+            const auto message = R"(The target for "replace" operation doesn't exist at path:)";
+            return settings.m_reporting(AZStd::string::format("%s\n   '%s'.", message, pointerPathString.GetString()),
+                ResultCode(Tasks::Merge, Outcomes::Missing), element);
+#elif
             return settings.m_reporting(R"(The target for "replace" operation doesn't exist.)",
                 ResultCode(Tasks::Merge, Outcomes::Invalid), element);
+#endif // defined(CARBONATED)
         }
 
         memberValue->CopyFrom(value->value, allocator, true);
 
+#if !defined(CARBONATED) // More readable warnings in prefab patches serialization : moved up for shared usage
         rapidjson::StringBuffer pointerPathString;
         path.Stringify(pointerPathString);
+#endif // !defined(CARBONATED)
         return settings.m_reporting(R"(Successfully applied "replace" operation.)",
             ResultCode(Tasks::Merge, Outcomes::Success), pointerPathString.GetString());
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Link/Link.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Link/Link.cpp
@@ -218,11 +218,21 @@ namespace AzToolsFramework
                 if (applyPatchResult.GetOutcome() == AZ::JsonSerializationResult::Outcomes::PartialSkip ||
                     applyPatchResult.GetOutcome() == AZ::JsonSerializationResult::Outcomes::Skipped)
                 {
+#if defined(CARBONATED) // More readable warnings in prefab patches serialization
+                    AZ_Warning(
+                        "Prefab",
+                        false,
+                        "Link::UpdateTarget - Some of the patches couldn't be applied on the Source Template:"
+                        "\n   '%s',\npresent under the Target Template:\n    '%s'.",
+                        sourceTemplateName->get().GetString(), targetTemplateName->get().GetString());
+                    // TODO : possibly mark target DOM with failed patches as Dirty, filter out failed patches and propose to re-save
+#elif
                     AZ_Warning(
                         "Prefab", false,
                         "Link::UpdateTarget - Some of the patches couldn't be applied on the source template '%s' present under the  "
                         "target Template '%s'.",
                         sourceTemplateName->get().GetString(), targetTemplateName->get().GetString());
+#endif // defined(CARBONATED)
                 }
             }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Link/Link.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Link/Link.cpp
@@ -226,7 +226,7 @@ namespace AzToolsFramework
                         "\n   '%s',\npresent under the Target Template:\n    '%s'.",
                         sourceTemplateName->get().GetString(), targetTemplateName->get().GetString());
                     // TODO : possibly mark target DOM with failed patches as Dirty, filter out failed patches and propose to re-save
-#elif
+#else
                     AZ_Warning(
                         "Prefab", false,
                         "Link::UpdateTarget - Some of the patches couldn't be applied on the source template '%s' present under the  "


### PR DESCRIPTION
#### Introduction:
When a prefab instantiated into the Level. i.e. an `Object01.prefab`, is changed after being inserted and patched, - some prefab properties' patches in unchanged Level instance may become illegal.

Usual way to generate wrong patches is:
* A prefab instantiated into the Level. i.e. an `Object02.prefab`, is based on using  instance of an `Object01.prefab`;
* And then `Object01.prefab` is updated, - components or other properties are changed;
* And hence some prefab properties' patches in unchanged `Object02.prefab` become illegal.

If such `Object02.prefab` is instantiated several times in the Level, number of warnings multiples accordingly.

The situation becomes worse (more illegal patches are supposed to occur), when an `Object03.prefab`, is based on using instance of an `Object02.prefab`, which is based on using instance of an `Object01.prefab`.

For example, some game prefabs were updated:
* In a legacy Entity, e.g. `Entity_[3737749186924]` in a `base.prefab`, an obsolete `OldComponent` was replaced by an updated `NewFunctionalityComponent`. 
* In `base.prefab` it was made explicitly, `Component_[7339026914538983381]` was deleted, and `NewFunctionalityComponent` was added;
* Yet in a number of derivative prefabs, based on instantiated `base.prefab`,  - this obsolete `Component_[7339026914538983381]` had been previously just deleted with patch
```
{
  "op": "remove",
  "path": "/Entities/Entity_[3737749186924]/Components/Component_[7339026914538983381]"
}
```

So, at the moment the `base.prefab` was changed,  the above patch in all the derived prefabs became invalid, producing (with code updated in this PR)
```
 [Warning] (Prefab Serialization) - The "remove" operation failed to remove the member from object at path:
 '/Entities/Entity_[3737749186924]/Components/Component_[7339026914538983381] ...'.
```
And all other prefabs based on these when being processed and  / or loaded, also produce this serialization warning.


### What does this PR do?
Refactors Prefab Serialization Warnings to be more readable,
Original warnings mainly contain only number of a failed patch in array, in the form of '/n' output, one other warning has repetitive output of a last target path member and then this path. All these deficiencies and inconsitencies made analysis difficult.
With this PR the second line of each warning contains full target path for each failed patch.

### How was this PR tested?
In Red project:
* Assets re-processed in AssetProcessor;
* Editor run on PC in several Levels in Editor.
* Extended warnings noted 
[Android and iOS builds](http://10.0.1.100:8080/job/Extraction/job/Client/job/build%252Fastarykh%252FCAR-31059-patches-detailed-warnings-test/) succeded.