### PR TITLE
Attachment Resets

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Animation/AttachmentComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Animation/AttachmentComponent.cpp
@@ -100,6 +100,10 @@ namespace AZ
                 Attach(configuration.m_targetId, configuration.m_targetBoneName.c_str(), configuration.m_targetOffset);
             }
 
+#if defined(CARBONATED)
+            m_initialConfiguration = configuration;
+#endif
+
             LmbrCentral::AttachmentComponentRequestBus::Handler::BusConnect(m_ownerId);
         }
 
@@ -171,6 +175,13 @@ namespace AZ
             // alert others that we've attached
             LmbrCentral::AttachmentComponentNotificationBus::Event(m_targetId, &LmbrCentral::AttachmentComponentNotificationBus::Events::OnAttached, m_ownerId);
         }
+
+#if defined(CARBONATED)
+        void BoneFollower::AttachToDefaults()
+        {
+            Attach(m_initialConfiguration.m_targetId, m_initialConfiguration.m_targetBoneName.c_str(), m_initialConfiguration.m_targetOffset);
+        }
+#endif
 
         void BoneFollower::Detach()
         {

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Animation/AttachmentComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Animation/AttachmentComponent.h
@@ -82,6 +82,10 @@ namespace AZ
             const char* GetJointName() override;
             AZ::EntityId GetTargetEntityId() override;
             AZ::Transform GetOffset() override;
+
+#if defined(CARBONATED)
+            void AttachToDefaults() override;
+#endif
             ////////////////////////////////////////////////////////////////////////
 
         private:
@@ -134,6 +138,10 @@ namespace AZ
             int             m_targetBoneId; //!< negative when bone not found
 
             AttachmentConfiguration::ScaleSource m_scaleSource;
+
+#if defined(CARBONATED)
+            AttachmentConfiguration m_initialConfiguration;
+#endif
         };
 
         /*!

--- a/Gems/LmbrCentral/Code/include/LmbrCentral/Animation/AttachmentComponentBus.h
+++ b/Gems/LmbrCentral/Code/include/LmbrCentral/Animation/AttachmentComponentBus.h
@@ -37,6 +37,11 @@ namespace LmbrCentral
         //! \param offset           Attachment's offset from target.
         virtual void Attach(AZ::EntityId targetId, const char* targetBoneName, const AZ::Transform& offset) = 0;
 
+#if defined(CARBONATED)
+        //Attach to the configuration set on the component
+        virtual void AttachToDefaults() {};
+#endif
+
         //! The entity will detach from its target.
         virtual void Detach() = 0;
 


### PR DESCRIPTION
## What does this PR do?

Attachment components activate with an initial configuration but immediately lose it upon attach or more importantly detach. This change stores that config and exposes an api to reapply the initial config.

## How was this PR tested?

Its been used for months in red 
