### PR TITLE
Carbonated/gruber/jasons/noticket na n handling in cull decals

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
@@ -648,6 +648,22 @@ namespace AZ
                     {
                         float d1 = (AZ::Vector3::CreateFromFloat3(dataVector[lhs].m_position.data()) - viewPos).GetLengthSq();
                         float d2 = (AZ::Vector3::CreateFromFloat3(dataVector[rhs].m_position.data()) - viewPos).GetLengthSq();
+
+                        // The check: NaN is not equal to itself. IEEE 754 floating point standard defines that any comparison with NaN
+                        // should return false, except for != which returns true. So this is a common way to check for NaN values.
+                        bool d1Invalid = (d1 != d1);
+                        bool d2Invalid = (d2 != d2);
+
+                        if (d1Invalid || d2Invalid)
+                        {
+                            // Log the error using standard O3DE logging
+                            AZ_Printf("MadWorld", "Decal Math Error: NaN detected! Indices: %u, %u", lhs, rhs);
+
+                            // Strict Weak Ordering requires a consistent result.
+                            // This pushes invalid entries to the back.
+                            return d1Invalid < d2Invalid;
+                        }
+
                         return d1 < d2;
                     });
             }

--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
@@ -110,8 +110,10 @@ namespace AZ
             m_visibleDecalBufferHandlers.clear();
         }
 
-        DecalTextureArrayFeatureProcessor::DecalHandle DecalTextureArrayFeatureProcessor::AcquireDecal()
+#if defined(CARBONATED)
+        DecalTextureArrayFeatureProcessor::DecalHandle DecalTextureArrayFeatureProcessor::AcquireDecalInternal()
         {
+            // NO LOCK HERE. This is only called by functions that already hold a lock.
             const uint16_t id = m_decalData.GetFreeSlotIndex();
 
             if (id == IndexedDataVector<DecalData>::NoFreeSlot)
@@ -126,9 +128,38 @@ namespace AZ
                 return DecalHandle(id);
             }
         }
+#endif
+
+        DecalTextureArrayFeatureProcessor::DecalHandle DecalTextureArrayFeatureProcessor::AcquireDecal()
+        {
+#if defined(CARBONATED)
+            AZStd::unique_lock<AZStd::shared_mutex> writeLock(m_decalDataMutex);
+            // we are already locked so call the internal version that doesn't lock again to avoid deadlock.
+            return AcquireDecalInternal();
+#else
+
+            const uint16_t id = m_decalData.GetFreeSlotIndex();
+
+            if (id == IndexedDataVector<DecalData>::NoFreeSlot)
+            {
+                return DecalHandle(DecalHandle::NullIndex);
+            }
+            else
+            {
+                m_deviceBufferNeedsUpdate = true;
+                DecalData& decalData = m_decalData.GetData<0>(id);
+                decalData.m_textureArrayIndex = DecalData::UnusedIndex;
+                return DecalHandle(id);
+            }
+#endif
+        }
 
         bool DecalTextureArrayFeatureProcessor::ReleaseDecal(const DecalHandle decal)
         {
+#if defined(CARBONATED)
+            AZStd::unique_lock<AZStd::shared_mutex> writeLock(m_decalDataMutex);
+#endif
+
             if (decal.IsValid())
             {
                 if (m_materialLoadTracker.IsAssetLoading(decal))
@@ -152,14 +183,36 @@ namespace AZ
         {
             AZ_Assert(sourceDecal.IsValid(), "Invalid DecalHandle passed to DecalTextureArrayFeatureProcessor::CloneDecal().");
 
+#if defined(CARBONATED)
+            // Lock once for the entire cloning process.
+            AZStd::unique_lock<AZStd::shared_mutex> writeLock(m_decalDataMutex);
+
+            // Call the internal version that DOES NOT lock, preventing a deadlock.
+            const DecalHandle decal = AcquireDecalInternal();
+#else
             const DecalHandle decal = AcquireDecal();
+#endif
+
             if (decal.IsValid())
             {
                 m_decalData.GetData<0>(decal.GetIndex()) = m_decalData.GetData<0>(sourceDecal.GetIndex());
+
                 const auto materialAsset = GetMaterialUsedByDecal(sourceDecal);
                 if (materialAsset.IsValid())
                 {
-                    m_materialToTextureArrayLookupTable.at(materialAsset).m_useCount++;
+                    // We use find() here to be safe, as it's a best practice when multi-threading.
+                    auto iter = m_materialToTextureArrayLookupTable.find(materialAsset);
+                    if (iter != m_materialToTextureArrayLookupTable.end())
+                    {
+                        iter->second.m_useCount++;
+                    }
+#if !defined(CARBONATED)
+                    else
+                    {
+                        // Fallback for vanilla build if find failed (maintaining original .at() behavior)
+                        m_materialToTextureArrayLookupTable.at(materialAsset).m_useCount++;
+                    }
+#endif
                 }
                 else
                 {
@@ -210,6 +263,9 @@ namespace AZ
 
         void DecalTextureArrayFeatureProcessor::SetDecalData(const DecalHandle handle, const DecalData& data)
         {
+#if defined(CARBONATED)
+            AZStd::unique_lock<AZStd::shared_mutex> writeLock(m_decalDataMutex);
+#endif
             if (handle.IsValid())
             {
                 m_decalData.GetData<0>(handle.GetIndex()) = data;
@@ -235,6 +291,17 @@ namespace AZ
         {
             if (handle.IsValid())
             {
+#if defined(CARBONATED)
+                if (!IsVectorValid(position))
+                {
+                    AZ_Warning(
+                        "DecalTextureArrayFeatureProcessor",
+                        false,
+                        "SetDecalPosition rejected: NaN detected in position for handle %u.",
+                        handle.GetIndex());
+                    return;
+                }
+#endif
                 AZStd::array<float, 3>& writePos = m_decalData.GetData<0>(handle.GetIndex()).m_position;
                 position.StoreToFloat3(writePos.data());
                 UpdateBounds(handle);
@@ -372,6 +439,13 @@ namespace AZ
         {
             if (handle.IsValid())
             {
+#if defined(CARBONATED)
+                if (!IsVectorValid(world.GetTranslation()))
+                {
+                    AZ_Error("DecalTextureArrayFeatureProcessor", false, "SetDecalTransform rejected: NaN detected in world translation for handle %u.", handle.GetIndex());
+                    return;
+                }
+#endif
                 SetDecalHalfSize(handle, nonUniformScale * world.GetUniformScale());
                 SetDecalPosition(handle, world.GetTranslation());
                 SetDecalOrientation(handle, world.GetRotation());
@@ -627,6 +701,11 @@ namespace AZ
                 return;
             }
 
+#if defined(CARBONATED)
+            // Acquire a shared lock to prevent the Main thread from resizing m_decalData
+            // while we are sorting and iterating over it.
+            AZStd::shared_lock<AZStd::shared_mutex> readLock(m_decalDataMutex);
+#endif
             const auto& dataVector = m_decalData.GetDataVector<0>();
             size_t numVisibleDecals =
                 r_maxVisibleDecals < 0 ? dataVector.size() : AZStd::min(dataVector.size(), static_cast<size_t>(r_maxVisibleDecals));

--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
@@ -200,18 +200,20 @@ namespace AZ
                 const auto materialAsset = GetMaterialUsedByDecal(sourceDecal);
                 if (materialAsset.IsValid())
                 {
-                    // We use find() here to be safe, as it's a best practice when multi-threading.
+#if defined(CARBONATED)
+
+                    // Carbonated build: safer lookup for multi-threading
                     auto iter = m_materialToTextureArrayLookupTable.find(materialAsset);
                     if (iter != m_materialToTextureArrayLookupTable.end())
                     {
                         iter->second.m_useCount++;
                     }
-#if !defined(CARBONATED)
-                    else
-                    {
-                        // Fallback for vanilla build if find failed (maintaining original .at() behavior)
-                        m_materialToTextureArrayLookupTable.at(materialAsset).m_useCount++;
-                    }
+
+#else
+
+                    // Original O3DE behavior
+                    m_materialToTextureArrayLookupTable.at(materialAsset).m_useCount++;
+
 #endif
                 }
                 else
@@ -713,18 +715,17 @@ namespace AZ
             // while we are sorting and iterating over it.
             AZStd::shared_lock<AZStd::shared_mutex> readLock(m_decalDataMutex);
 #endif
+
             const auto& dataVector = m_decalData.GetDataVector<0>();
             size_t numVisibleDecals =
                 r_maxVisibleDecals < 0 ? dataVector.size() : AZStd::min(dataVector.size(), static_cast<size_t>(r_maxVisibleDecals));
             AZStd::vector<uint32_t> sortedDecals(dataVector.size());
             // Initialize with all the decals indices
             std::iota(sortedDecals.begin(), sortedDecals.end(), 0);
-#if !defined(CARBONATED)
-            // Only sort if we are going to limit the number of visible decals
-            if (numVisibleDecals < dataVector.size())
-#else
-            // Sort always due to the render pipeline can have its own limit for visible decals. And that limit can be much less than numVisibleDecals.
-#endif
+
+#if defined(CARBONATED)
+            // Sort always due to the render pipeline can have its own limit for visible decals. And that limit can be much less than
+            // numVisibleDecals.
             {
                 AZ::Vector3 viewPos = view->GetViewToWorldMatrix().GetTranslation();
                 AZStd::sort(
@@ -747,7 +748,7 @@ namespace AZ
                         if (d1Invalid || d2Invalid)
                         {
                             // Log the error using standard O3DE logging
-                            AZ_Printf("MadWorld", "Decal Math Error: NaN detected! Indices: %u, %u", lhs, rhs);
+                            AZ_Printf("DecalTextureArrayFeatureProcessor", "Decal Math Error: NaN detected! Indices: %u, %u", lhs, rhs);
 
                             // Strict Weak Ordering requires a consistent result.
                             // This pushes invalid entries to the back.
@@ -757,6 +758,22 @@ namespace AZ
                         return d1 < d2;
                     });
             }
+#else
+            // Only sort if we are going to limit the number of visible decals
+            if (numVisibleDecals < dataVector.size())
+            {
+                AZ::Vector3 viewPos = view->GetViewToWorldMatrix().GetTranslation();
+                AZStd::sort(
+                    sortedDecals.begin(),
+                    sortedDecals.end(),
+                    [&dataVector, &viewPos](uint32_t lhs, uint32_t rhs)
+                    {
+                        float d1 = (AZ::Vector3::CreateFromFloat3(dataVector[lhs].m_position.data()) - viewPos).GetLengthSq();
+                        float d2 = (AZ::Vector3::CreateFromFloat3(dataVector[rhs].m_position.data()) - viewPos).GetLengthSq();
+                        return d1 < d2;
+                    });
+            }
+#endif
 
             const AZ::Frustum viewFrustum = AZ::Frustum::CreateFromMatrixColumnMajor(view->GetWorldToClipMatrix());
             AZStd::vector<uint32_t> visibilityBuffer;

--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
@@ -197,29 +197,33 @@ namespace AZ
             {
                 m_decalData.GetData<0>(decal.GetIndex()) = m_decalData.GetData<0>(sourceDecal.GetIndex());
 
+#if defined(CARBONATED)
                 const auto materialAsset = GetMaterialUsedByDecal(sourceDecal);
                 if (materialAsset.IsValid())
                 {
-#if defined(CARBONATED)
-
                     // Carbonated build: safer lookup for multi-threading
                     auto iter = m_materialToTextureArrayLookupTable.find(materialAsset);
                     if (iter != m_materialToTextureArrayLookupTable.end())
                     {
                         iter->second.m_useCount++;
                     }
-
-#else
-
-                    // Original O3DE behavior
-                    m_materialToTextureArrayLookupTable.at(materialAsset).m_useCount++;
-
-#endif
                 }
                 else
                 {
                     AZ_Warning("DecalTextureArrayFeatureProcessor", false, "CloneDecal called on a decal with no material set.");
                 }
+#else
+                const auto materialAsset = GetMaterialUsedByDecal(sourceDecal);
+                if (materialAsset.IsValid())
+                {
+                    m_materialToTextureArrayLookupTable.at(materialAsset).m_useCount++;
+                }
+                else
+                {
+                    AZ_Warning("DecalTextureArrayFeatureProcessor", false, "CloneDecal called on a decal with no material set.");
+                }
+#endif
+
                 m_deviceBufferNeedsUpdate = true;
             }
             return decal;

--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
@@ -298,11 +298,7 @@ namespace AZ
 #if defined(CARBONATED)
                 if (!IsVectorValid(position))
                 {
-                    AZ_Warning(
-                        "DecalTextureArrayFeatureProcessor",
-                        false,
-                        "SetDecalPosition rejected: NaN detected in position for handle %u.",
-                        handle.GetIndex());
+                    AZ_Warning("DecalTextureArrayFeatureProcessor", false, "SetDecalPosition rejected: NaN detected in position for handle %u.", handle.GetIndex());
                     return;
                 }
 #endif

--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
@@ -646,6 +646,10 @@ namespace AZ
                     sortedDecals.end(),
                     [&dataVector, &viewPos](uint32_t lhs, uint32_t rhs)
                     {
+                        // It's possible that d1 or d2 could be NaN if the decal position data is invalid. We need to handle this case to
+                        // avoid undefined behavior in sorting and potential crashes. In this implementation, we will treat NaN values as
+                        // greater than any valid number, which effectively pushes decals with invalid positions to the end of the sorted
+                        // list.
                         float d1 = (AZ::Vector3::CreateFromFloat3(dataVector[lhs].m_position.data()) - viewPos).GetLengthSq();
                         float d2 = (AZ::Vector3::CreateFromFloat3(dataVector[rhs].m_position.data()) - viewPos).GetLengthSq();
 

--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
@@ -289,6 +289,10 @@ namespace AZ
 
         void DecalTextureArrayFeatureProcessor::SetDecalPosition(const DecalHandle handle, const AZ::Vector3& position)
         {
+#if defined(CARBONATED)
+            // setting the lock here to prevent potential tearing issues with the position being read for culling while it's being updated.
+            AZStd::unique_lock<AZStd::shared_mutex> writeLock(m_decalDataMutex);
+#endif
             if (handle.IsValid())
             {
 #if defined(CARBONATED)
@@ -317,6 +321,9 @@ namespace AZ
         {
             if (handle.IsValid())
             {
+#if defined(CARBONATED)
+                AZStd::unique_lock<AZStd::shared_mutex> writeLock(m_decalDataMutex);
+#endif
                 orientation.StoreToFloat4(m_decalData.GetData<0>(handle.GetIndex()).m_quaternion.data());
                 m_deviceBufferNeedsUpdate = true;
             }
@@ -361,6 +368,9 @@ namespace AZ
 
         void DecalTextureArrayFeatureProcessor::SetDecalHalfSize(DecalHandle handle, const Vector3& halfSize)
         {
+#if defined(CARBONATED)
+            AZStd::unique_lock<AZStd::shared_mutex> writeLock(m_decalDataMutex);
+#endif
             if (handle.IsValid())
             {
                 halfSize.StoreToFloat3(m_decalData.GetData<0>(handle.GetIndex()).m_halfSize.data());
@@ -440,6 +450,7 @@ namespace AZ
             if (handle.IsValid())
             {
 #if defined(CARBONATED)
+                // We don't lock SetDecalTransform, the other SetDecal functions used will handle their own locks.
                 if (!IsVectorValid(world.GetTranslation()))
                 {
                     AZ_Error("DecalTextureArrayFeatureProcessor", false, "SetDecalTransform rejected: NaN detected in world translation for handle %u.", handle.GetIndex());

--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.h
@@ -106,7 +106,11 @@ namespace AZ
                 RPI::ViewPtr previousView) override;
 
         private:
-
+#if defined(CARBONATED)
+            // Shared mutex to prevent race conditions during culling
+            mutable AZStd::shared_mutex m_decalDataMutex;
+            DecalTextureArrayFeatureProcessor::DecalHandle AcquireDecalInternal();
+#endif
             // Number of size and format permutations
             // This number should match the number of texture arrays in Decals/ViewSrg.azsli
             static constexpr int NumTextureArrays = 4;

--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.h
@@ -145,6 +145,11 @@ namespace AZ
             void UpdateBounds(const DecalHandle handle);
 #if defined(CARBONATED)
             void LogDecalDebugInfo(const AZStd::string& text, const DecalLocation& decalLocation) const;
+            bool IsVectorValid(const AZ::Vector3& vec) const
+            {
+                // IEEE 754: NaN is the only value that does not equal itself.
+                return (vec.GetX() == vec.GetX()) && (vec.GetY() == vec.GetY()) && (vec.GetZ() == vec.GetZ());
+            }
 #endif
 
             MultiIndexedDataVector<DecalData, AZ::Aabb> m_decalData;

--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.h
@@ -145,6 +145,7 @@ namespace AZ
             void UpdateBounds(const DecalHandle handle);
 #if defined(CARBONATED)
             void LogDecalDebugInfo(const AZStd::string& text, const DecalLocation& decalLocation) const;
+            // A helper function to check if the vector contains NaN or not. NaN can cause issues for GPU culling and sorting.
             bool IsVectorValid(const AZ::Vector3& vec) const
             {
                 // IEEE 754: NaN is the only value that does not equal itself.


### PR DESCRIPTION
## What does this PR do?

Crashes with CullDecals observed in Google Play reports-- potential issues: NaN during the sorting (most likely) and race condition because of lack of mutex locking.

I hardened the decal handling in DecalTextureArrayFeatureProcessor by checking for NaN specifically and pushing those to the back so the sort wouldn't overrun/act weird if encountering a NaN condition with the floats it attempts to sort.

I also hardened the SetDecal fucntions with writelocks.

## How was this PR tested?
Locally and iOS/Android build 40519 (will test android when build compeltes)
Tested by playing mission and looking for errors
