### PR TITLE
[NOTICKET] Add missing include

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceSerializer.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceSerializer.cpp
@@ -17,6 +17,10 @@
 #include <AzToolsFramework/Prefab/PrefabSystemComponentInterface.h>
 #include <Prefab/PrefabDomUtils.h>
 
+#if defined CARBONATED
+#include <AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h>
+#endif
+
 namespace AzToolsFramework
 {
     namespace Prefab


### PR DESCRIPTION
## What does this PR do?

Fixes compilation errors encountered when compiling a non-unity build.

## How was this PR tested?

PC: all Red targets built, Editor and Server+Client run, with changes of
PR https://github.com/carbonated-dev/o3de-red-game/pull/144. 

