### PR TITLE
CAR-31244: Remove old Carbonated patсh for the level loading under GridMate. It is not needed anymore.

### DIFF
--- a/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
+++ b/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
@@ -348,16 +348,6 @@ namespace LegacyLevelSystem
             AZ::Data::Asset<AzFramework::Spawnable> rootSpawnable(
                 rootSpawnableAssetId, azrtti_typeid<AzFramework::Spawnable>(), levelName);
 
-// Gruber patch begin. // LVB
-#ifdef CARBONATED
-            rootSpawnable.QueueLoad();
-            // when we call AssetBus::QueuedEventCount() immediately after Asset::QueueLoad(), it returns the number of level assets for loading
-            m_queuedAssetsCountMax = static_cast<int>(AZ::Data::AssetBus::QueuedEventCount());
-            m_queuedAssetsCount = -1;
-            rootSpawnable.BlockUntilLoadComplete();
-#endif
-// Gruber patch end. // LVB
-
             m_rootSpawnableId = rootSpawnableAssetId;
             m_rootSpawnableGeneration = AzFramework::RootSpawnableInterface::Get()->AssignRootSpawnable(rootSpawnable);
 


### PR DESCRIPTION
## What does this PR do?

Previously, GridMate network replication required synchronous loading of levels to function correctly.
Now we removed GridMate and switched to O3DE Multiaplyer system. So we don't need this patch anymore. 
It should help to decrease the memory peak when one level is unloaded and new level is loading.

## How was this PR tested?

Tested in the Editor: for small playground_base level and for the big redpoweplant one.
Tested in server <-> client variant.
Tested in client in "offline" mission.

Everything works.