### PR TITLE
[Car-31255] Rain: Improve Wet Shader

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/WetPropertyGroup.json
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/WetPropertyGroup.json
@@ -6,14 +6,27 @@
         {
             "name": "useWet",
             "displayName": "Apply Wet",
-            "description": "User Wet properties or not.",
+            "description": "Use Wet properties or not.",
             "type": "Bool",
             "defaultValue": false
         },
         {
+            "name": "wetAmount",
+            "displayName": "Wetness Amount",
+            "description": "Wetting factor, for example rain intensity, [0..1]: 0 is no wetting, 1 is maximal wetting.",
+            "type": "Float",
+            "defaultValue": 0.0,
+            "min": 0.0,
+            "max": 1.0,
+            "connection": {
+                "type": "ShaderInput",
+                "name": "m_wetAmount"
+            }
+        },
+        {
             "name": "wetFactor",
-            "displayName": "WetnessFactor",
-            "description": "WetnessFactor [0..1]. 0 is dry, 1 is completely wet.",
+            "displayName": "Wetness Factor",
+            "description": "Moistening factor of surface material, [0..1]: 0 surface remains waterless, 1 surface is completely soaked.",
             "type": "Float",
             "defaultValue": 0.0,
             "min": 0.0,
@@ -26,14 +39,14 @@
         {
             "name": "useTexture",
             "displayName": "Use Texture",
-            "description": "Whether to use the texture, or just default to the WetFactor value.",
+            "description": "Whether to use the texture, or just default to the wetFactor value.",
             "type": "Bool",
             "defaultValue": false
         },
         {
             "name": "textureMap",
             "displayName": "Texture",
-            "description": "Texture for defining surface wetness.",
+            "description": "Texture defining surface Moistening properties.",
             "type": "Image",
             "connection": {
                 "type": "ShaderInput",
@@ -43,7 +56,7 @@
         {
             "name": "textureMapUv",
             "displayName": "UV",
-            "description": "Specular reflection map UV set",
+            "description": "Moistening properties map UV set",
             "type": "Enum",
             "enumIsUv": true,
             "defaultValue": "Tiled",

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR.azsli
@@ -9,6 +9,7 @@
 #pragma once
 
 #define ENABLE_VERTEX_COLOR 1
+#define CARBONATED_ENABLE_WETNESS 1
 
 //TODO(MaterialPipeline): Inline the MaterialSrg files since they aren't reused.
 //TODO(MaterialPipeline): Try removing different parts of the SRG and see how hard/easy it is to customize the surface function.

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR.materialtype
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR.materialtype
@@ -1,6 +1,6 @@
 {
     "description": "Material Type with properties used to define Standard PBR, a metallic-roughness Physically-Based Rendering (PBR) material shading model.",
-    "version": 6,
+    "version": 7,
     "versionUpdates": [
         {
             "toVersion": 4,
@@ -62,6 +62,9 @@
             },
             {
                 "$import": "MaterialInputs/SilhouetteBlockerPropertyGroup.json"
+            },
+            {
+                "$import": "MaterialInputs/WetPropertyGroup.json"
             }
         ]
     },

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_SurfaceEval.azsli
@@ -114,25 +114,11 @@ Surface EvaluateSurface_BasePBR(
             wetFactor = GetWetInput(MaterialSrg::m_wetMap, MaterialSrg::m_sampler, wetMapUv);
         }
         
-        // The wetFactor is describing Moistening properties of a surface material
-        //float porosity = 0;
-        //float maxDarken = 0;
-        //if (wetFactor < 0.3f) // Metal
-        //{
-        //    porosity = 0.1;
-        //    maxDarken = 0.2;
-        //}
-        //else if (wetFactor < 0.6) // Dielectric
-        //{
-        //    porosity = 0.5;
-        //    maxDarken = 0.5;
-        //}
-        //else // Porous
-        //{
-        //    porosity = 0.9;
-        //    maxDarken = 0.95;
-        //}
-        // Approximation used:
+        // The wetFactor is describing Moistening properties of a surface material.
+        // For Metals:              wetFactor < 0.3         -> porosity <= 0.1; maxDarken <= 0.2;
+        // For Smooth Dielectrics:  0.3 >= wetFactor < 0.6  -> porosity <= 0.5; maxDarken <= 0.5;
+        // For Porous Dielectrics:  0.6 >= wetFactor < 1.0  -> porosity <= 0.9; maxDarken <= 0.95;
+        // Approximation:
         const float porosity = saturate(pow(1.15f, wetFactor) - 0.1f);
         const float maxDarken = pow(1.25f, wetFactor) * 0.95f;
         

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_SurfaceEval.azsli
@@ -85,64 +85,83 @@ Surface EvaluateSurface_BasePBR(
     float2 specularUv = uvs[MaterialSrg::m_specularF0MapUvIndex];
     real specularF0Factor = GetSpecularInput(MaterialSrg::m_specularF0Map, MaterialSrg::m_sampler, specularUv, real(MaterialSrg::m_specularF0Factor), o_specularF0_useTexture, uvDxDy, customDerivatives);
 
+#if !CARBONATED_ENABLE_WETNESS
+    // Wetness, if allowed, affects baseColor, specularF0Factor, surface.roughnessLinear, so final calculation is moved below
+    surface.SetAlbedoAndSpecularF0(baseColor, specularF0Factor, metallic);
+#endif // !CARBONATED_ENABLE_WETNESS
+    
     // ------- Roughness -------
 
     float2 roughnessUv = uvs[MaterialSrg::m_roughnessMapUvIndex];
     surface.roughnessLinear = GetRoughnessInput(MaterialSrg::m_roughnessMap, MaterialSrg::m_sampler, roughnessUv, real(MaterialSrg::m_roughnessFactor),
                                         real(MaterialSrg::m_roughnessLowerBound), real(MaterialSrg::m_roughnessUpperBound), o_roughness_useTexture, uvDxDy, customDerivatives);
 
-    // ------- Wetness -------
+#if !CARBONATED_ENABLE_WETNESS
+    // Wetness, if allowed, affects baseColor, specularF0Factor, surface.roughnessLinear, so final calculation is moved below
+    surface.CalculateRoughnessA();
+#endif // !CARBONATED_ENABLE_WETNESS
+
+    // ------- Wetness ------- affects baseColor, specularF0Factor, surface.roughnessLinear
 #if CARBONATED_ENABLE_WETNESS
     if (o_useWet)
     {
-        float porosity = 0;
-        float maxDarken = 0;
-        float wetFactor = MaterialSrg::m_wetFactor;
+        float wetFactor = saturate(MaterialSrg::m_wetFactor);
+        const float wetAmount = saturate(MaterialSrg::m_wetAmount);
         
         if (o_wet_useTexture)
         {
-            float2 wetMapUv = uvs[MaterialSrg::m_wetMapUvIndex];
+            const float2 wetMapUv = uvs[MaterialSrg::m_wetMapUvIndex];
             wetFactor = GetWetInput(MaterialSrg::m_wetMap, MaterialSrg::m_sampler, wetMapUv);
         }
         
-        if (wetFactor < 0.3) // Metal
-        {
-            porosity = 0.1;
-            maxDarken = 0.2;
-        }
-        else if (wetFactor < 0.6) // Dielectric
-        {
-            porosity = 0.5;
-            maxDarken = 0.5;
-        }
-        else // Porous
-        {
-            porosity = 0.9;
-            maxDarken = 0.95;
-        }
-
-        float effectiveWetness = wetFactor * porosity;
-        float darkening = 1.0 - effectiveWetness * maxDarken;
-        float3 waterTint = float3(0.96, 0.98, 1.0);
-        baseColor = baseColor * darkening * lerp(1.0, waterTint, wetFactor * 0.3);
+        // The wetFactor is describing Moistening properties of a surface material
+        //float porosity = 0;
+        //float maxDarken = 0;
+        //if (wetFactor < 0.3f) // Metal
+        //{
+        //    porosity = 0.1;
+        //    maxDarken = 0.2;
+        //}
+        //else if (wetFactor < 0.6) // Dielectric
+        //{
+        //    porosity = 0.5;
+        //    maxDarken = 0.5;
+        //}
+        //else // Porous
+        //{
+        //    porosity = 0.9;
+        //    maxDarken = 0.95;
+        //}
+        // Approximation used:
+        const float porosity = saturate(pow(1.15f, wetFactor) - 0.1f);
+        const float maxDarken = pow(1.25f, wetFactor) * 0.95f;
         
-        float smoothFactor = lerp(0.7, 0.3, saturate(surface.roughnessLinear * 2.0));
-        surface.roughnessLinear = lerp(surface.roughnessLinear, 0.02, wetFactor * smoothFactor);
+        const float effectiveWetness = saturate(wetFactor + 0.1f) * wetAmount;
+        const float darkening = 1.0f - effectiveWetness * porosity * maxDarken;
+        const float3 waterTint = float3(0.96f, 0.98f, 1.0f);
+        baseColor = baseColor * darkening * lerp(1.0, waterTint, effectiveWetness * 0.3f);
         
-        float waterF0 = 0.02;
-        if (metallic > 0.5)
+        const float smoothFactor = lerp(0.7f, 0.3f, saturate(surface.roughnessLinear * 2.0f));
+        surface.roughnessLinear = lerp(surface.roughnessLinear, 0.02f, effectiveWetness * smoothFactor);
+        
+        const float waterF0 = 0.02f;
+        if (metallic > 0.5f)
         {
-            specularF0Factor = lerp(specularF0Factor, max(specularF0Factor, waterF0), wetFactor * 0.5);
+            specularF0Factor = lerp(specularF0Factor, max(specularF0Factor, waterF0), effectiveWetness * 0.5f);
         }
         else
         {
-            specularF0Factor = lerp(specularF0Factor, waterF0, wetFactor * (1.0 - porosity * 0.5));
+            specularF0Factor = lerp(specularF0Factor, waterF0, effectiveWetness * (1.0f - porosity * 0.5f));
         }
     }
-#endif //CARBONATED_ENABLE_WETNESS
-
+    
+    // Delayed calculations
     surface.SetAlbedoAndSpecularF0(baseColor, specularF0Factor, metallic);
+
     surface.CalculateRoughnessA();
+    
+#endif // CARBONATED_ENABLE_WETNESS
+
 
     return surface;
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/WetInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/WetInput.azsli
@@ -17,6 +17,7 @@
 // You can optionally provide a prefix for the set of inputs which corresponds to a prefix string supplied by the .materialtype file. This is common for multi-layered material types.
 
 #define COMMON_SRG_INPUTS_WET(prefix) \
+float prefix##m_wetAmount;  \
 float prefix##m_wetFactor;  \
 Texture2D prefix##m_wetMap; \
 uint prefix##m_wetMapUvIndex;


### PR DESCRIPTION
### What does this PR do?
Closes : [Car-31255](https://favro.com/organization/ab098f3312254434882b4396/579ee0f4d0168dab8e8d0252?card=Car-31255).

* Updates `Gems\Atom\Feature\Common\Assets\Materials\Types\MaterialInputs\WetPropertyGroup.json` and `Gems\Atom\Feature\Common\Assets\Shaders\Materials\MaterialInputs\WetInput.azsli` :
* * Adds `wet.wetAmount` material shader input;
* * Improves inputs' descriptions.

* Updates  `Gems\Atom\Feature\Common\Assets\Materials\Types\StandardPBR.azsli` and `Gems\Atom\Feature\Common\Assets\Materials\Types\StandardPBR.materialtype` :
* * Adds "Wetness" evaluation.

* Updates `Gems\Atom\Feature\Common\Assets\Shaders\Materials\BasePBR\BasePBR_SurfaceEval.azsli` :
* * Makes use of `wet.wetAmount `material shader input in shader surface evaluation;
* * Approximates '`porosity`' and '`maxDarken`' surface soaking properties' calculations without `if`s,

### How to use "Wetness" properties of  `BasePBR-` and `StandardPBR-`based materials?
* An Entity which is to use "Rain-induced Wetness Effects", should have:
* * Mesh Component and Material Component with at least one `BasePBR-` and `StandardPBR-` based material;
* * Tag component with the `"rain_wetness"` Tag;

* The material in use should have at least one of `wet` shader input values: the `"wet.wetFactor"` parameter, wich defines Moistening properties of the surface material, [0..1]: 0 surface remains waterless, 1 surface is completely soaked.
* * Metals: `"wet.wetFactor" < 0.3`
* * Smooth Dielectrics: `0.3 >= "wet.wetFactor" < 0.6`
* * Porous Dielectrics: `0.6 >= "wet.wetFactor" < 1.0`

* The project should be linked with the `Weather` GEM, to be able to use `{Editor}WeatherComponent`s; 

* The game level should have the `EditorWeatherComponent` in one of its Entities; otherwise "wetness" parameters are not controlled.
* * `{Editor}WeatherComponent` creates  the `WetSurfacesManager`, which collects all Entities with the `"rain_wetness"` Tag and then controlls "wetness" material properties basing on `RainOptions::m_amount` (general amount / intensity of all Rain-induced effects) and `RainOptions::m_m_diffuseDarkening` (specific parameter for "wetness" effcts amount).

### How was this PR tested?
This PR is coupled with PR https://github.com/carbonated-dev/o3de-gems/pull/41 , and is tied with changes made in https://github.com/carbonated-dev/o3de-red-game/tree/build/astarykh/CAR-31247-Implement-WetSurfacesManager, used to check this PR and the above-mentioned PR https://github.com/carbonated-dev/o3de-gems/pull/41 . 

In the above-mentioned game branch:
* Several `BasePBR-` and `StandardPBR-` based materials are updated to have meaningful `"wet.WetFactor"` values corresponding to porous dialectical surfaces;
* Several prefabs using updated materials are updated to have the `"rain_wetness"` Tag, so that "Wetness" properties are applied by the `WetSurfacesManager`.

On PC the correct control of "Wetness" properties of `BasePBR-` and `StandardPBR-`based materials with newly added `WetSurfacesManager` of the `Weather` GEM was checked in Efitor and Editor-GameMode.
Please refer to PR https://github.com/carbonated-dev/o3de-gems/pull/41 for further details.

### Note: Assets Processing takes time, as most of material shaders in a project are to be updated.

https://github.com/user-attachments/assets/7fb793c7-132e-4c44-85f7-12cb56c2f5cd