### PR TITLE
Getting light type in AreaLightBus

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/CoreLights/AreaLightBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/CoreLights/AreaLightBus.h
@@ -36,6 +36,9 @@ namespace AZ
 
             //! Gets an area light's visibility
             virtual bool GetVisible() const = 0;
+
+            //! Gets an area light's type
+            virtual AreaLightComponentConfig::LightType GetType() const = 0;
 #endif
 
             //! Gets an area light's color. This value is independent from its intensity.

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/AreaLightComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/AreaLightComponentController.cpp
@@ -204,6 +204,11 @@ namespace AZ::Render
         return m_isVisible;
     }
 
+    AreaLightComponentConfig::LightType AreaLightComponentController::GetType() const
+    {
+        return m_configuration.m_lightType;
+    }
+
 #endif
     
     void AreaLightComponentController::VerifyLightTypeAndShapeComponent()

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/AreaLightComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/AreaLightComponentController.h
@@ -55,6 +55,7 @@ namespace AZ
 #if defined(CARBONATED) && defined(CARBONATED_LIGHT_VIZ)
             void SetVisible(bool isVisible) override;
             bool GetVisible() const override;
+            AreaLightComponentConfig::LightType GetType() const override;
 #endif
             const Color& GetColor() const override;
             void SetColor(const Color& color) override;


### PR DESCRIPTION
What does it do?

The function that returns light type has been added to AreaLightBus

Test Method

The changes are tested on Windows client

Jira Ticket(s)

CAR-31457