### PR TITLE
Workaround for Linux to use not standard path with required SFX data files

### DIFF
--- a/Gems/AudioSystem/Code/Source/Engine/AudioSystem.cpp
+++ b/Gems/AudioSystem/Code/Source/Engine/AudioSystem.cpp
@@ -20,11 +20,7 @@
 
 namespace Audio
 {
-#if defined(CARBONATED) && defined(AZ_PLATFORM_LINUX)
-    static constexpr const char AudioControlsBasePath[]{ "libs/gameaudio_linux/" };
-#else
     static constexpr const char AudioControlsBasePath[]{ "libs/gameaudio/" };
-#endif
     // Save off the threadId of the "Main Thread" that was used to connect EBuses.
     AZStd::thread_id g_mainThreadId;
     AZStd::thread_id g_audioThreadId;

--- a/Gems/AudioSystem/Code/Source/Engine/AudioSystem.cpp
+++ b/Gems/AudioSystem/Code/Source/Engine/AudioSystem.cpp
@@ -20,8 +20,11 @@
 
 namespace Audio
 {
+#if defined(CARBONATED) && defined(AZ_PLATFORM_LINUX)
+    static constexpr const char AudioControlsBasePath[]{ "libs/gameaudio_linux/" };
+#else
     static constexpr const char AudioControlsBasePath[]{ "libs/gameaudio/" };
-
+#endif
     // Save off the threadId of the "Main Thread" that was used to connect EBuses.
     AZStd::thread_id g_mainThreadId;
     AZStd::thread_id g_audioThreadId;

--- a/scripts/commit_validation/commit_validation/carbonated_pal_allowedlist.txt
+++ b/scripts/commit_validation/commit_validation/carbonated_pal_allowedlist.txt
@@ -12,6 +12,5 @@
 */Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.h
 */Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandQueue.cpp
 */Gems/Atom/RPI/Code/Source/RPI.Public/WindowContext.cpp
-*/Gems/AudioSystem/Code/Source/Engine/AudioSystem.cpp
 */Code/Framework/AzFramework/AzFramework/Windowing/NativeWindow.cpp
 */Code/Legacy/CrySystem/System.cpp

--- a/scripts/commit_validation/commit_validation/carbonated_pal_allowedlist.txt
+++ b/scripts/commit_validation/commit_validation/carbonated_pal_allowedlist.txt
@@ -12,5 +12,6 @@
 */Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.h
 */Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandQueue.cpp
 */Gems/Atom/RPI/Code/Source/RPI.Public/WindowContext.cpp
+*/Gems/AudioSystem/Code/Source/Engine/AudioSystem.cpp
 */Code/Framework/AzFramework/AzFramework/Windowing/NativeWindow.cpp
 */Code/Legacy/CrySystem/System.cpp


### PR DESCRIPTION
## What does this PR do?

The AssetProcessor on Linux doesn't process "libs/gameaudio" subdirectory, i.e. it doesn't copy it to the Cache.
Due to the time limit the reason of such behavior is not discovered yet. As workaround let's use "libs/gameaudio_linux" subdirectory instead of default one.
AudioSystem is looking the data files in "libs/gameaudio". So this PR forces AudioSystem to use "libs/gameaudio_linux" subdirectory on Linux.

## How was this PR tested?

The client plays SFXs on Linux now.
