### PR TITLE
translucent ui implementation

### DIFF
--- a/Gems/LyShine/Assets/LyShine/Shaders/LyShineUI.azsl
+++ b/Gems/LyShine/Assets/LyShine/Shaders/LyShineUI.azsl
@@ -27,6 +27,7 @@ ShaderResourceGroup InstanceSrg : SRG_PerDraw
     row_major float4x4 m_worldToProj;
     uint m_isClamp;
     float m_backdropBlurRadius;
+    float2 m_backdropInvTextureSize;
     Texture2D m_texture[16];
 
     Sampler m_wrapSampler
@@ -96,6 +97,19 @@ float4 SampleTriangleTexture(uint texIndex, float2 uv)
     }
 }
 
+static const float kBackdropDiagonalOffset = 0.70710678f;
+static const float2 kBackdropBlurOffsets[8] =
+{
+    float2(1.0f, 0.0f),
+    float2(kBackdropDiagonalOffset, kBackdropDiagonalOffset),
+    float2(0.0f, 1.0f),
+    float2(-kBackdropDiagonalOffset, kBackdropDiagonalOffset),
+    float2(-1.0f, 0.0f),
+    float2(-kBackdropDiagonalOffset, -kBackdropDiagonalOffset),
+    float2(0.0f, -1.0f),
+    float2(kBackdropDiagonalOffset, -kBackdropDiagonalOffset)
+};
+
 float4 SampleBlurredTexture(uint texIndex, float2 uv, float blurRadius)
 {
     if (blurRadius <= 0.0f)
@@ -103,46 +117,21 @@ float4 SampleBlurredTexture(uint texIndex, float2 uv, float blurRadius)
         return SampleTriangleTexture(texIndex, uv);
     }
 
-    uint width;
-    uint height;
-    InstanceSrg::m_texture[texIndex].GetDimensions(width, height);
-    if (width == 0 || height == 0)
+    float2 blurOffsetUv = blurRadius * InstanceSrg::m_backdropInvTextureSize;
+    if (blurOffsetUv.x <= 0.0f || blurOffsetUv.y <= 0.0f)
     {
         return SampleTriangleTexture(texIndex, uv);
     }
 
-    float2 texelSize = blurRadius / float2(width, height);
-    float2 texelSize2 = texelSize * 2.0f;
+    float4 color = SampleTriangleTexture(texIndex, uv) * 2.0f;
+    float totalWeight = 2.0f;
 
-    float totalWeight = 0.0f;
-    float4 color = float4(0.0f, 0.0f, 0.0f, 0.0f);
-
-    color += SampleTriangleTexture(texIndex, uv) * 2.0f;
-    totalWeight += 2.0f;
-
-    color += SampleTriangleTexture(texIndex, uv + float2(texelSize.x, 0.0f)) * 1.75f;
-    color += SampleTriangleTexture(texIndex, uv - float2(texelSize.x, 0.0f)) * 1.75f;
-    color += SampleTriangleTexture(texIndex, uv + float2(0.0f, texelSize.y)) * 1.75f;
-    color += SampleTriangleTexture(texIndex, uv - float2(0.0f, texelSize.y)) * 1.75f;
-    totalWeight += 7.0f;
-
-    color += SampleTriangleTexture(texIndex, uv + texelSize) * 1.25f;
-    color += SampleTriangleTexture(texIndex, uv + float2(texelSize.x, -texelSize.y)) * 1.25f;
-    color += SampleTriangleTexture(texIndex, uv + float2(-texelSize.x, texelSize.y)) * 1.25f;
-    color += SampleTriangleTexture(texIndex, uv - texelSize) * 1.25f;
-    totalWeight += 5.0f;
-
-    color += SampleTriangleTexture(texIndex, uv + float2(texelSize2.x, 0.0f)) * 1.0f;
-    color += SampleTriangleTexture(texIndex, uv - float2(texelSize2.x, 0.0f)) * 1.0f;
-    color += SampleTriangleTexture(texIndex, uv + float2(0.0f, texelSize2.y)) * 1.0f;
-    color += SampleTriangleTexture(texIndex, uv - float2(0.0f, texelSize2.y)) * 1.0f;
-    totalWeight += 4.0f;
-
-    color += SampleTriangleTexture(texIndex, uv + texelSize2) * 0.75f;
-    color += SampleTriangleTexture(texIndex, uv + float2(texelSize2.x, -texelSize2.y)) * 0.75f;
-    color += SampleTriangleTexture(texIndex, uv + float2(-texelSize2.x, texelSize2.y)) * 0.75f;
-    color += SampleTriangleTexture(texIndex, uv - texelSize2) * 0.75f;
-    totalWeight += 3.0f;
+    [unroll]
+    for (uint i = 0; i < 8; ++i)
+    {
+        color += SampleTriangleTexture(texIndex, uv + (kBackdropBlurOffsets[i] * blurOffsetUv));
+        totalWeight += 1.0f;
+    }
 
     return color / totalWeight;
 }

--- a/Gems/LyShine/Assets/LyShine/Shaders/LyShineUI.azsl
+++ b/Gems/LyShine/Assets/LyShine/Shaders/LyShineUI.azsl
@@ -26,6 +26,7 @@ ShaderResourceGroup InstanceSrg : SRG_PerDraw
 {
     row_major float4x4 m_worldToProj;
     uint m_isClamp;
+    float m_backdropBlurRadius;
     Texture2D m_texture[16];
 
     Sampler m_wrapSampler
@@ -95,11 +96,62 @@ float4 SampleTriangleTexture(uint texIndex, float2 uv)
     }
 }
 
+float4 SampleBlurredTexture(uint texIndex, float2 uv, float blurRadius)
+{
+    if (blurRadius <= 0.0f)
+    {
+        return SampleTriangleTexture(texIndex, uv);
+    }
+
+    uint width;
+    uint height;
+    InstanceSrg::m_texture[texIndex].GetDimensions(width, height);
+    if (width == 0 || height == 0)
+    {
+        return SampleTriangleTexture(texIndex, uv);
+    }
+
+    float2 texelSize = blurRadius / float2(width, height);
+    float2 texelSize2 = texelSize * 2.0f;
+
+    float totalWeight = 0.0f;
+    float4 color = float4(0.0f, 0.0f, 0.0f, 0.0f);
+
+    color += SampleTriangleTexture(texIndex, uv) * 2.0f;
+    totalWeight += 2.0f;
+
+    color += SampleTriangleTexture(texIndex, uv + float2(texelSize.x, 0.0f)) * 1.75f;
+    color += SampleTriangleTexture(texIndex, uv - float2(texelSize.x, 0.0f)) * 1.75f;
+    color += SampleTriangleTexture(texIndex, uv + float2(0.0f, texelSize.y)) * 1.75f;
+    color += SampleTriangleTexture(texIndex, uv - float2(0.0f, texelSize.y)) * 1.75f;
+    totalWeight += 7.0f;
+
+    color += SampleTriangleTexture(texIndex, uv + texelSize) * 1.25f;
+    color += SampleTriangleTexture(texIndex, uv + float2(texelSize.x, -texelSize.y)) * 1.25f;
+    color += SampleTriangleTexture(texIndex, uv + float2(-texelSize.x, texelSize.y)) * 1.25f;
+    color += SampleTriangleTexture(texIndex, uv - texelSize) * 1.25f;
+    totalWeight += 5.0f;
+
+    color += SampleTriangleTexture(texIndex, uv + float2(texelSize2.x, 0.0f)) * 1.0f;
+    color += SampleTriangleTexture(texIndex, uv - float2(texelSize2.x, 0.0f)) * 1.0f;
+    color += SampleTriangleTexture(texIndex, uv + float2(0.0f, texelSize2.y)) * 1.0f;
+    color += SampleTriangleTexture(texIndex, uv - float2(0.0f, texelSize2.y)) * 1.0f;
+    totalWeight += 4.0f;
+
+    color += SampleTriangleTexture(texIndex, uv + texelSize2) * 0.75f;
+    color += SampleTriangleTexture(texIndex, uv + float2(texelSize2.x, -texelSize2.y)) * 0.75f;
+    color += SampleTriangleTexture(texIndex, uv + float2(-texelSize2.x, texelSize2.y)) * 0.75f;
+    color += SampleTriangleTexture(texIndex, uv - texelSize2) * 0.75f;
+    totalWeight += 3.0f;
+
+    return color / totalWeight;
+}
+
 PSOutput MainPS(VSOutput IN)
 {
     PSOutput OUT;
 
-    float4 baseTex = SampleTriangleTexture(IN.m_texIndex, IN.m_uv.xy);
+    float4 baseTex = SampleBlurredTexture(IN.m_texIndex, IN.m_uv.xy, InstanceSrg::m_backdropBlurRadius);
     float4 inDiffuse = IN.m_color;
 
     // If the texture does not have a color channel then the alpha channel will be in the R channel of the R8 texture

--- a/Gems/LyShine/Assets/Passes/LyShineChildPass.pass
+++ b/Gems/LyShine/Assets/Passes/LyShineChildPass.pass
@@ -13,6 +13,11 @@
                     "ScopeAttachmentUsage": "RenderTarget"
                 },
                 {
+                    "Name": "BackdropInput",
+                    "SlotType": "Input",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                {
                     "Name": "DepthInputOutput",
                     "SlotType": "InputOutput",
                     "ScopeAttachmentUsage": "DepthStencil",
@@ -30,6 +35,13 @@
                     "AttachmentRef": {
                         "Pass": "Parent",
                         "Attachment": "ColorInputOutput"
+                    }
+                },
+                {
+                    "LocalSlot": "BackdropInput",
+                    "AttachmentRef": {
+                        "Pass": "Parent",
+                        "Attachment": "BackdropCaptureOutput"
                     }
                 },
                 {

--- a/Gems/LyShine/Assets/Passes/LyShineParent.pass
+++ b/Gems/LyShine/Assets/Passes/LyShineParent.pass
@@ -8,14 +8,71 @@
             "PassClass": "LyShinePass",
             "Slots": [
                 {
+                    "Name": "ColorInput",
+                    "SlotType": "Input",
+                    "ScopeAttachmentUsage": "Copy"
+                },
+                {
                     "Name": "ColorInputOutput",
-                    "SlotType": "InputOutput"
+                    "SlotType": "InputOutput",
+                    "ScopeAttachmentUsage": "RenderTarget"
+                },
+                {
+                    "Name": "BackdropCaptureOutput",
+                    "SlotType": "Output",
+                    "ScopeAttachmentUsage": "Copy"
                 },
                 {
                     "Name": "DepthInputOutput",
                     "SlotType": "InputOutput",
                     "ScopeAttachmentUsage": "DepthStencil"
-                }            
+                }
+            ],
+            "ImageAttachments": [
+                {
+                    "Name": "BackdropCaptureImage",
+                    "SizeSource": {
+                        "Source": {
+                            "Pass": "This",
+                            "Attachment": "ColorInputOutput"
+                        }
+                    },
+                    "FormatSource": {
+                        "Pass": "This",
+                        "Attachment": "ColorInputOutput"
+                    }
+                }
+            ],
+            "Connections": [
+                {
+                    "LocalSlot": "BackdropCaptureOutput",
+                    "AttachmentRef": {
+                        "Pass": "This",
+                        "Attachment": "BackdropCaptureImage"
+                    }
+                }
+            ],
+            "PassRequests": [
+                {
+                    "Name": "BackdropCapturePass",
+                    "TemplateName": "CopyPassTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "Input",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "ColorInput"
+                            }
+                        },
+                        {
+                            "LocalSlot": "Output",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "BackdropCaptureOutput"
+                            }
+                        }
+                    ]
+                }
             ]
         }
     }

--- a/Gems/LyShine/Assets/Passes/LyShinePassRequest.azasset
+++ b/Gems/LyShine/Assets/Passes/LyShinePassRequest.azasset
@@ -7,6 +7,13 @@
         "TemplateName": "LyShineParentTemplate",
         "Connections": [
             {
+                "LocalSlot": "ColorInput",
+                "AttachmentRef": {
+                    "Pass": "AuxGeomPass",
+                    "Attachment": "ColorInputOutput"
+                }
+            },
+            {
                 "LocalSlot": "ColorInputOutput",
                 "AttachmentRef": {
                     "Pass": "AuxGeomPass",

--- a/Gems/LyShine/Assets/Passes/RttChildPass.pass
+++ b/Gems/LyShine/Assets/Passes/RttChildPass.pass
@@ -24,6 +24,11 @@
                     }
                 },
                 {
+                    "Name": "BackdropInput",
+                    "SlotType": "Input",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                {
                     "Name": "DepthInputOutput",
                     "SlotType": "InputOutput",
                     "ScopeAttachmentUsage": "DepthStencil",
@@ -55,6 +60,13 @@
                 }
             ],
             "Connections": [
+                {
+                    "LocalSlot": "BackdropInput",
+                    "AttachmentRef": {
+                        "Pass": "Parent",
+                        "Attachment": "BackdropCaptureOutput"
+                    }
+                },
                 {
                     "LocalSlot": "DepthInputOutput",
                     "AttachmentRef": {

--- a/Gems/LyShine/Code/Include/LyShine/Bus/UiCanvasBus.h
+++ b/Gems/LyShine/Code/Include/LyShine/Bus/UiCanvasBus.h
@@ -12,11 +12,16 @@
 #include <AzCore/Math/Matrix4x4.h>
 #include <AzFramework/Input/Channels/InputChannelDigitalWithSharedModifierKeyStates.h>
 #include <AzFramework/Input/User/LocalUserId.h>
+#include <AtomCore/Instance/InstanceData.h>
 #include <LyShine/UiBase.h>
 #include <Atom/RPI.Reflect/Image/AttachmentImageAsset.h>
 
 // Forward declarations
 struct IUiAnimationSystem;
+namespace AZ::RPI
+{
+    class Image;
+}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 class UiCanvasInterface
@@ -227,6 +232,12 @@ public: // member functions
 
     //! Set the attachment image that this canvas will render to
     virtual void SetAttachmentImageAsset(const AZ::Data::Asset<AZ::RPI::AttachmentImageAsset>& attachmentImageAsset) = 0;
+
+    //! Get the captured scene color that can be sampled by backdrop UI
+    virtual AZ::Data::Instance<AZ::RPI::Image> GetBackdropCaptureImage() = 0;
+
+    //! Get the size of the captured scene color in pixels
+    virtual AZ::Vector2 GetBackdropCaptureSize() = 0;
 
     //! Get flag that controls whether this canvas automatically handles positional input (mouse/touch)
     virtual bool GetIsPositionalInputSupported() = 0;

--- a/Gems/LyShine/Code/Include/LyShine/Bus/UiImageBus.h
+++ b/Gems/LyShine/Code/Include/LyShine/Bus/UiImageBus.h
@@ -38,6 +38,7 @@ public: // types
     {
         SpriteAsset,
         RenderTarget,
+        Backdrop,
     };
 
     enum class FillType : int32_t

--- a/Gems/LyShine/Code/Include/LyShine/IRenderGraph.h
+++ b/Gems/LyShine/Code/Include/LyShine/IRenderGraph.h
@@ -56,6 +56,10 @@ namespace LyShine
         virtual void AddPrimitive(LyShine::UiPrimitive* primitive, const AZ::Data::Instance<AZ::RPI::Image>& texture,
             bool isClampTextureMode, bool isTextureSRGB, bool isTexturePremultipliedAlpha, BlendMode blendMode) = 0;
 
+        //! Add an indexed triangle list primitive that samples the captured backdrop behind the UI with an optional blur
+        virtual void AddBackdropPrimitive(LyShine::UiPrimitive* primitive, const AZ::Data::Instance<AZ::RPI::Image>& texture,
+            bool isClampTextureMode, bool isTextureSRGB, bool isTexturePremultipliedAlpha, BlendMode blendMode, float blurRadius) = 0;
+
         //! Add an indexed triangle list primitive to the render graph which will use maskTexture as an alpha (gradient) mask
         virtual void AddAlphaMaskPrimitive(LyShine::UiPrimitive* primitive,
             AZ::Data::Instance<AZ::RPI::AttachmentImage> contentAttachmentImage,

--- a/Gems/LyShine/Code/Source/LyShinePass.cpp
+++ b/Gems/LyShine/Code/Source/LyShinePass.cpp
@@ -36,6 +36,7 @@ namespace LyShine
     void LyShinePass::ResetInternal()
     {
         LyShinePassRequestBus::Handler::BusDisconnect();
+        m_backdropCaptureImage = nullptr;
 
         Base::ResetInternal();
     }
@@ -60,6 +61,29 @@ namespace LyShine
             LyShinePassRequestBus::Handler::BusConnect(scene->GetId());
         }
 
+        if (!m_ownedAttachments.empty())
+        {
+            AZ::Data::Instance<AZ::RPI::AttachmentImagePool> pool = AZ::RPI::ImageSystemInterface::Get()->GetSystemAttachmentPool();
+            AZ::RPI::Ptr<AZ::RPI::PassAttachment> backdropCaptureAttachment = m_ownedAttachments.front();
+
+            backdropCaptureAttachment->Update();
+            backdropCaptureAttachment->m_lifetime = AZ::RHI::AttachmentLifetimeType::Imported;
+
+            AZ::RHI::ImageDescriptor& imageDesc = backdropCaptureAttachment->m_descriptor.m_image;
+            imageDesc.m_bindFlags |= AZ::RHI::ImageBindFlags::CopyWrite | AZ::RHI::ImageBindFlags::ShaderRead;
+
+            AZ::RHI::ClearValue clearValue = AZ::RHI::ClearValue::CreateVector4Float(0.0f, 0.0f, 0.0f, 0.0f);
+            m_backdropCaptureImage = AZ::RPI::AttachmentImage::Create(
+                *pool.get(),
+                imageDesc,
+                AZ::Name(backdropCaptureAttachment->m_path.GetCStr()),
+                &clearValue,
+                nullptr);
+
+            backdropCaptureAttachment->m_path = m_backdropCaptureImage->GetAttachmentId();
+            backdropCaptureAttachment->m_importedResource = m_backdropCaptureImage;
+        }
+
         // Always recreate children when rebuild the pass
         m_flags.m_createChildren = true;
 
@@ -68,6 +92,8 @@ namespace LyShine
 
     void LyShinePass::CreateChildPassesInternal()
     {
+        Base::CreateChildPassesInternal();
+
         AZ::RPI::Scene* scene = GetScene();
         if (scene)
         {
@@ -104,6 +130,11 @@ namespace LyShine
     AZ::RPI::RasterPass* LyShinePass::GetUiCanvasPass()
     {
         return m_uiCanvasChildPass.get();
+    }
+
+    AZ::Data::Instance<AZ::RPI::AttachmentImage> LyShinePass::GetBackdropCaptureImage()
+    {
+        return m_backdropCaptureImage;
     }
 
     void LyShinePass::AddRttChildPasses(LyShine::AttachmentImagesAndDependencies attachmentImagesAndDependencies)

--- a/Gems/LyShine/Code/Source/LyShinePass.h
+++ b/Gems/LyShine/Code/Source/LyShinePass.h
@@ -43,6 +43,7 @@ namespace LyShine
         void RebuildRttChildren() override;
         AZ::RPI::RasterPass* GetRttPass(const AZStd::string& name) override;
         AZ::RPI::RasterPass* GetUiCanvasPass() override;
+        AZ::Data::Instance<AZ::RPI::AttachmentImage> GetBackdropCaptureImage() override;
 
     private:
         LyShinePass() = delete;
@@ -59,6 +60,9 @@ namespace LyShine
 
         // Pass that renders the UI Canvas elements to the screen
         AZ::RPI::Ptr<LyShineChildPass> m_uiCanvasChildPass;
+
+        // Scene color copy captured before UI rendering for backdrop panels
+        AZ::Data::Instance<AZ::RPI::AttachmentImage> m_backdropCaptureImage;
     };
 
     // Child pass with potential attachment dependencies

--- a/Gems/LyShine/Code/Source/LyShinePassDataBus.h
+++ b/Gems/LyShine/Code/Source/LyShinePassDataBus.h
@@ -10,6 +10,7 @@
 #include <AzCore/std/containers/vector.h>
 #include <AtomCore/Instance/Instance.h>
 #include <Atom/RPI.Public/Base.h>
+#include <Atom/RPI.Public/Image/AttachmentImage.h>
 
 namespace AZ
 {
@@ -43,6 +44,9 @@ public:
 
     //! Returns the final pass that renders the UI canvas contents
     virtual AZ::RPI::RasterPass* GetUiCanvasPass() = 0;
+
+    //! Returns the captured scene color that can be sampled by UI backdrop panels
+    virtual AZ::Data::Instance<AZ::RPI::AttachmentImage> GetBackdropCaptureImage() = 0;
 };
 using LyShinePassRequestBus = AZ::EBus<LyShinePassRequests>;
 

--- a/Gems/LyShine/Code/Source/RenderGraph.cpp
+++ b/Gems/LyShine/Code/Source/RenderGraph.cpp
@@ -55,13 +55,21 @@ namespace LyShine
     };
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////
-    PrimitiveListRenderNode::PrimitiveListRenderNode(const AZ::Data::Instance<AZ::RPI::Image>& texture,
-        bool isClampTextureMode, bool isTextureSRGB, bool preMultiplyAlpha, const AZ::RHI::TargetBlendState& blendModeState)
+    PrimitiveListRenderNode::PrimitiveListRenderNode(
+        const AZ::Data::Instance<AZ::RPI::Image>& texture,
+        bool isClampTextureMode,
+        bool isTextureSRGB,
+        bool preMultiplyAlpha,
+        const AZ::RHI::TargetBlendState& blendModeState,
+        bool isBackdrop,
+        float backdropBlurRadius)
         : RenderNode(RenderNodeType::PrimitiveList)
         , m_numTextures(1)
         , m_isTextureSRGB(isTextureSRGB)
         , m_preMultiplyAlpha(preMultiplyAlpha)
         , m_alphaMaskType(AlphaMaskType::None)
+        , m_isBackdrop(isBackdrop)
+        , m_backdropBlurRadius(backdropBlurRadius)
         , m_blendModeState(blendModeState)
         , m_totalNumVertices(0)
         , m_totalNumIndices(0)
@@ -79,12 +87,14 @@ namespace LyShine
     ////////////////////////////////////////////////////////////////////////////////////////////////////
     PrimitiveListRenderNode::PrimitiveListRenderNode(const AZ::Data::Instance<AZ::RPI::Image>& texture,
         const AZ::Data::Instance<AZ::RPI::Image>& maskTexture, bool isClampTextureMode, bool isTextureSRGB,
-        bool preMultiplyAlpha, AlphaMaskType alphaMaskType, const AZ::RHI::TargetBlendState& blendModeState)
+        bool preMultiplyAlpha, AlphaMaskType alphaMaskType, const AZ::RHI::TargetBlendState& blendModeState, float backdropBlurRadius)
         : RenderNode(RenderNodeType::PrimitiveList)
         , m_numTextures(2)
         , m_isTextureSRGB(isTextureSRGB)
         , m_preMultiplyAlpha(preMultiplyAlpha)
         , m_alphaMaskType(alphaMaskType)
+        , m_isBackdrop(false)
+        , m_backdropBlurRadius(backdropBlurRadius)
         , m_blendModeState(blendModeState)
         , m_totalNumVertices(0)
         , m_totalNumIndices(0)
@@ -183,6 +193,7 @@ namespace LyShine
 
         // Set projection matrix
         drawSrg->SetConstant(uiShaderData.m_viewProjInputIndex, modelViewProjMat);
+        drawSrg->SetConstant(uiShaderData.m_backdropBlurRadiusInputIndex, m_backdropBlurRadius);
 
         drawSrg->Compile();
 
@@ -248,7 +259,6 @@ namespace LyShine
         uiRenderer->SetBaseState(prevBaseState);
     }
 
-    ////////////////////////////////////////////////////////////////////////////////////////////////////
     void PrimitiveListRenderNode::AddPrimitive(LyShine::UiPrimitive* primitive)
     {
 #if defined(CARBONATED)
@@ -1010,6 +1020,8 @@ namespace LyShine
                         primListRenderNode->GetBlendModeState() == blendModeState &&
                         primListRenderNode->GetIsPremultiplyAlpha() == isPreMultiplyAlpha &&
                         primListRenderNode->GetAlphaMaskType() ==  AlphaMaskType::None &&
+                        !primListRenderNode->IsBackdrop() &&
+                        primListRenderNode->GetBackdropBlurRadius() == 0.0f &&
                         primListRenderNode->HasSpaceToAddPrimitive(primitive))
                     {
                         // render state is the same - we can add the primitive to this list if the texture is in
@@ -1046,6 +1058,78 @@ namespace LyShine
             }
 
             // add this primitive to the render node
+            renderNodeToAddTo->AddPrimitive(primitive);
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////
+    void RenderGraph::AddBackdropPrimitive(LyShine::UiPrimitive* primitive, const AZ::Data::Instance<AZ::RPI::Image>& texture,
+        bool isClampTextureMode, bool isTextureSRGB, bool isTexturePremultipliedAlpha, BlendMode blendMode, float blurRadius)
+    {
+        if (blurRadius <= 0.0f)
+        {
+            AddPrimitive(primitive, texture, isClampTextureMode, isTextureSRGB, isTexturePremultipliedAlpha, blendMode);
+            return;
+        }
+
+        AZStd::vector<RenderNode*>* renderNodeList = m_renderNodeListStack.top();
+
+        int texUnit = -1;
+        if (renderNodeList)
+        {
+            bool isPreMultiplyAlpha = m_renderTargetNestLevel > 0 && !isTexturePremultipliedAlpha;
+            bool isShaderOutputPremultAlpha = isPreMultiplyAlpha || isTexturePremultipliedAlpha;
+            AZ::RHI::TargetBlendState blendModeState = GetBlendModeState(blendMode, isShaderOutputPremultAlpha);
+
+            PrimitiveListRenderNode* renderNodeToAddTo = nullptr;
+            if (!renderNodeList->empty())
+            {
+                RenderNode* lastRenderNode = renderNodeList->back();
+
+                if (lastRenderNode && lastRenderNode->GetType() == RenderNodeType::PrimitiveList)
+                {
+                    PrimitiveListRenderNode* primListRenderNode = static_cast<PrimitiveListRenderNode*>(lastRenderNode);
+
+                    if (primListRenderNode->GetIsTextureSRGB() == isTextureSRGB &&
+                        primListRenderNode->GetBlendModeState() == blendModeState &&
+                        primListRenderNode->GetIsPremultiplyAlpha() == isPreMultiplyAlpha &&
+                        primListRenderNode->GetAlphaMaskType() == AlphaMaskType::None &&
+                        primListRenderNode->IsBackdrop() &&
+                        primListRenderNode->GetBackdropBlurRadius() == blurRadius &&
+                        primListRenderNode->HasSpaceToAddPrimitive(primitive))
+                    {
+                        texUnit = primListRenderNode->GetOrAddTexture(texture, isClampTextureMode);
+
+                        if (texUnit != -1)
+                        {
+                            renderNodeToAddTo = primListRenderNode;
+                        }
+                    }
+                }
+            }
+
+            if (!renderNodeToAddTo)
+            {
+                renderNodeToAddTo = new PrimitiveListRenderNode(
+                    texture,
+                    isClampTextureMode,
+                    isTextureSRGB,
+                    isPreMultiplyAlpha,
+                    blendModeState,
+                    true,
+                    blurRadius);
+                renderNodeList->push_back(renderNodeToAddTo);
+                texUnit = 0;
+            }
+
+            if (primitive->m_vertices[0].texIndex != texUnit)
+            {
+                for (int i = 0; i < primitive->m_numVertices; ++i)
+                {
+                    primitive->m_vertices[i].texIndex = static_cast<uint8>(texUnit);
+                }
+            }
+
             renderNodeToAddTo->AddPrimitive(primitive);
         }
     }
@@ -1133,7 +1217,6 @@ namespace LyShine
         }
     }
 
-    ////////////////////////////////////////////////////////////////////////////////////////////////////
     LyShine::UiPrimitive* RenderGraph::GetDynamicQuadPrimitive(const AZ::Vector2* positions, uint32 packedColor)
     {
         const int numVertsInQuad = 4;
@@ -1166,7 +1249,6 @@ namespace LyShine
         return &quad->m_primitive;
     }
 
-    ////////////////////////////////////////////////////////////////////////////////////////////////////
     bool RenderGraph::IsRenderingToMask() const
     {
         return m_isRenderingToMask;
@@ -1258,7 +1340,6 @@ namespace LyShine
         }
     }
 
-    ////////////////////////////////////////////////////////////////////////////////////////////////////
     void RenderGraph::SetDirtyFlag(bool isDirty)
     {
         if (m_isDirty != isDirty)
@@ -1784,4 +1865,5 @@ namespace LyShine
             }
         }
     }
+
 }

--- a/Gems/LyShine/Code/Source/RenderGraph.cpp
+++ b/Gems/LyShine/Code/Source/RenderGraph.cpp
@@ -192,8 +192,21 @@ namespace LyShine
         drawSrg->SetConstant(uiShaderData.m_isClampInputIndex, isClampTextureMode);
 
         // Set projection matrix
+        AZ::Vector2 backdropInvTextureSize = AZ::Vector2::CreateZero();
+        if (m_isBackdrop && m_numTextures > 0 && m_textures[0].m_texture)
+        {
+            const AZ::RHI::Size imageSize = m_textures[0].m_texture->GetDescriptor().m_size;
+            if (imageSize.m_width > 0 && imageSize.m_height > 0)
+            {
+                backdropInvTextureSize = AZ::Vector2(
+                    1.0f / static_cast<float>(imageSize.m_width),
+                    1.0f / static_cast<float>(imageSize.m_height));
+            }
+        }
+
         drawSrg->SetConstant(uiShaderData.m_viewProjInputIndex, modelViewProjMat);
         drawSrg->SetConstant(uiShaderData.m_backdropBlurRadiusInputIndex, m_backdropBlurRadius);
+        drawSrg->SetConstant(uiShaderData.m_backdropInvTextureSizeInputIndex, backdropInvTextureSize);
 
         drawSrg->Compile();
 

--- a/Gems/LyShine/Code/Source/RenderGraph.h
+++ b/Gems/LyShine/Code/Source/RenderGraph.h
@@ -80,9 +80,16 @@ namespace LyShine
         // We use a pool allocator to keep these allocations fast.
         AZ_CLASS_ALLOCATOR(PrimitiveListRenderNode, LyShinePoolAllocator);
 
-        PrimitiveListRenderNode(const AZ::Data::Instance<AZ::RPI::Image>& texture, bool isClampTextureMode, bool isTextureSRGB, bool preMultiplyAlpha, const AZ::RHI::TargetBlendState& blendModeState);
+        PrimitiveListRenderNode(
+            const AZ::Data::Instance<AZ::RPI::Image>& texture,
+            bool isClampTextureMode,
+            bool isTextureSRGB,
+            bool preMultiplyAlpha,
+            const AZ::RHI::TargetBlendState& blendModeState,
+            bool isBackdrop = false,
+            float backdropBlurRadius = 0.0f);
         PrimitiveListRenderNode(const AZ::Data::Instance<AZ::RPI::Image>& texture, const AZ::Data::Instance<AZ::RPI::Image>& maskTexture,
-            bool isClampTextureMode, bool isTextureSRGB, bool preMultiplyAlpha, AlphaMaskType alphaMaskType, const AZ::RHI::TargetBlendState& blendModeState);
+            bool isClampTextureMode, bool isTextureSRGB, bool preMultiplyAlpha, AlphaMaskType alphaMaskType, const AZ::RHI::TargetBlendState& blendModeState, float backdropBlurRadius = 0.0f);
         ~PrimitiveListRenderNode() override;
         void Render(UiRenderer* uiRenderer
             , const AZ::Matrix4x4& modelViewProjMat
@@ -100,6 +107,8 @@ namespace LyShine
         AZ::RHI::TargetBlendState GetBlendModeState() const { return m_blendModeState; }
         bool GetIsPremultiplyAlpha() const { return m_preMultiplyAlpha; }
         AlphaMaskType GetAlphaMaskType() const { return m_alphaMaskType; }
+        bool IsBackdrop() const { return m_isBackdrop; }
+        float GetBackdropBlurRadius() const { return m_backdropBlurRadius; }
 
         bool HasSpaceToAddPrimitive(LyShine::UiPrimitive* primitive) const;
 
@@ -127,6 +136,8 @@ namespace LyShine
         bool            m_isTextureSRGB;
         bool            m_preMultiplyAlpha;
         AlphaMaskType   m_alphaMaskType;
+        bool            m_isBackdrop;
+        float           m_backdropBlurRadius;
         AZ::RHI::TargetBlendState m_blendModeState;
         int             m_totalNumVertices;
         int             m_totalNumIndices;
@@ -310,6 +321,8 @@ namespace LyShine
 
         void AddPrimitive(LyShine::UiPrimitive* primitive, const AZ::Data::Instance<AZ::RPI::Image>& texture,
             bool isClampTextureMode, bool isTextureSRGB, bool isTexturePremultipliedAlpha, BlendMode blendMode) override;
+        void AddBackdropPrimitive(LyShine::UiPrimitive* primitive, const AZ::Data::Instance<AZ::RPI::Image>& texture,
+            bool isClampTextureMode, bool isTextureSRGB, bool isTexturePremultipliedAlpha, BlendMode blendMode, float blurRadius) override;
         // ~IRenderGraph
 
         //! Add an indexed triangle list primitive to the render graph which will use maskTexture as an alpha (gradient) mask

--- a/Gems/LyShine/Code/Source/UiCanvasComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiCanvasComponent.cpp
@@ -1045,6 +1045,46 @@ void UiCanvasComponent::SetAttachmentImageAsset(const AZ::Data::Asset<AZ::RPI::A
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+AZ::Data::Instance<AZ::RPI::Image> UiCanvasComponent::GetBackdropCaptureImage()
+{
+    UiRenderer* uiRenderer = m_renderInEditor ? GetUiRendererForEditor() : GetUiRendererForGame();
+    if (!uiRenderer || !uiRenderer->GetViewportContext())
+    {
+        return nullptr;
+    }
+
+    if (const AZ::RPI::ScenePtr& scene = uiRenderer->GetViewportContext()->GetRenderScene())
+    {
+        AZ::Data::Instance<AZ::RPI::AttachmentImage> backdropCaptureImage;
+        LyShinePassRequestBus::EventResult(
+            backdropCaptureImage,
+            scene->GetId(),
+            &LyShinePassRequestBus::Events::GetBackdropCaptureImage);
+        return backdropCaptureImage;
+    }
+
+    return nullptr;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+AZ::Vector2 UiCanvasComponent::GetBackdropCaptureSize()
+{
+    if (AZ::Data::Instance<AZ::RPI::Image> backdropCaptureImage = GetBackdropCaptureImage())
+    {
+        const AZ::RHI::Size size = backdropCaptureImage->GetDescriptor().m_size;
+        return AZ::Vector2(aznumeric_cast<float>(size.m_width), aznumeric_cast<float>(size.m_height));
+    }
+
+    UiRenderer* uiRenderer = m_renderInEditor ? GetUiRendererForEditor() : GetUiRendererForGame();
+    if (uiRenderer)
+    {
+        return uiRenderer->GetViewportSize();
+    }
+
+    return GetCanvasSize();
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
 bool UiCanvasComponent::GetIsPositionalInputSupported()
 {
     return m_isPositionalInputSupported;
@@ -2064,12 +2104,12 @@ void UiCanvasComponent::RenderCanvas(bool isInGame, AZ::Vector2 viewportSize, Ui
     }
 
     m_isRendering = true;
+    const bool renderToTexture = !m_renderInEditor && GetIsRenderToTexture();
 
     if (m_renderGraph.GetDirtyFlag())
     {
         m_renderGraph.ResetGraph();
 
-        bool renderToTexture = !m_renderInEditor && GetIsRenderToTexture();
         if (renderToTexture)
         {
             if (m_attachmentImageId.IsEmpty())
@@ -3843,7 +3883,6 @@ void UiCanvasComponent::DestroyRenderTarget()
     }
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
 bool UiCanvasComponent::SaveCanvasToFile(const AZStd::string& pathname, AZ::DataStream::StreamType streamType)
 {
     // Note: This is ok for saving in tools, but we should use the streamer to write objects directly (no memory store)

--- a/Gems/LyShine/Code/Source/UiCanvasComponent.h
+++ b/Gems/LyShine/Code/Source/UiCanvasComponent.h
@@ -130,6 +130,8 @@ public: // member functions
     void SetIsRenderToTexture(bool isRenderToTexture) override;
     const AZ::Data::Asset<AZ::RPI::AttachmentImageAsset>& GetAttachmentImageAsset() override;
     void SetAttachmentImageAsset(const AZ::Data::Asset<AZ::RPI::AttachmentImageAsset>& attachmentImageAsset) override;
+    AZ::Data::Instance<AZ::RPI::Image> GetBackdropCaptureImage() override;
+    AZ::Vector2 GetBackdropCaptureSize() override;
 
     bool GetIsPositionalInputSupported() override;
     void SetIsPositionalInputSupported(bool isSupported) override;

--- a/Gems/LyShine/Code/Source/UiImageComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiImageComponent.cpp
@@ -362,12 +362,19 @@ void UiImageComponent::Render(LyShine::IRenderGraph* renderGraph)
     uint8 desiredPackedAlpha = static_cast<uint8>(desiredAlpha * 255.0f);
 
     ISprite* sprite = (m_overrideSprite) ? m_overrideSprite : m_sprite;
+    const bool isBackdrop = IsSpriteTypeBackdrop();
+    const AZ::Vector2 backdropCaptureSize = isBackdrop ? GetBackdropCaptureSize() : AZ::Vector2::CreateZero();
+
+    if (isBackdrop && m_cachedBackdropCaptureSize != backdropCaptureSize)
+    {
+        m_isRenderCacheDirty = true;
+    }
 
     if (m_isRenderCacheDirty)
     {
         int cellIndex = (m_overrideSprite) ? m_overrideSpriteCellIndex : m_spriteSheetCellIndex;
 
-        bool isTextureSRGB = IsSpriteTypeRenderTarget() && m_isRenderTargetSRGB;
+        bool isTextureSRGB = isBackdrop || (IsSpriteTypeRenderTarget() && m_isRenderTargetSRGB);
 
         AZ::Color color = AZ::Color::CreateFromVector3AndFloat(m_overrideColor.GetAsVector3(), 1.0f);
         if (!isTextureSRGB)
@@ -381,56 +388,64 @@ void UiImageComponent::Render(LyShine::IRenderGraph* renderGraph)
         uint32 packedColor = (desiredPackedAlpha << 24) | (color.GetR8() << 16) | (color.GetG8() << 8) | color.GetB8();
 #endif
 
-        ImageType imageType = m_imageType;
-
-        // if there is no texture we will just use a white texture and want to stretch it
-        const bool spriteOrTextureIsNull = sprite == nullptr || sprite->GetImage() == nullptr;
-
-        // Zero texture size may occur even if the UiImageComponent has a valid non-zero-sized texture,
-        // because a canvas can be requested to Render() before the texture asset is done loading.
-        if (!spriteOrTextureIsNull)
+        if (isBackdrop)
         {
-            const AZ::Vector2 textureSize = sprite->GetSize();
-            if (textureSize.GetX() == 0 || textureSize.GetY() == 0)
+            RenderBackdrop(backdropCaptureSize, packedColor);
+            m_cachedBackdropCaptureSize = backdropCaptureSize;
+        }
+        else
+        {
+            ImageType imageType = m_imageType;
+
+            // if there is no texture we will just use a white texture and want to stretch it
+            const bool spriteOrTextureIsNull = sprite == nullptr || sprite->GetImage() == nullptr;
+
+            // Zero texture size may occur even if the UiImageComponent has a valid non-zero-sized texture,
+            // because a canvas can be requested to Render() before the texture asset is done loading.
+            if (!spriteOrTextureIsNull)
             {
-                // don't render to cache and leave m_isRenderCacheDirty set to true
-                return;        
+                const AZ::Vector2 textureSize = sprite->GetSize();
+                if (textureSize.GetX() == 0 || textureSize.GetY() == 0)
+                {
+                    // don't render to cache and leave m_isRenderCacheDirty set to true
+                    return;
+                }
             }
-        }
 
-        // if the borders are zero width then sliced is the same as stretched and stretched is simpler to render
-        const bool spriteIsSlicedAndBordersAreZeroWidth = imageType == ImageType::Sliced && sprite && sprite->AreCellBordersZeroWidth(cellIndex);
+            // if the borders are zero width then sliced is the same as stretched and stretched is simpler to render
+            const bool spriteIsSlicedAndBordersAreZeroWidth = imageType == ImageType::Sliced && sprite && sprite->AreCellBordersZeroWidth(cellIndex);
 
-        if (spriteOrTextureIsNull || spriteIsSlicedAndBordersAreZeroWidth)
-        {
-            imageType = ImageType::Stretched;
-        }
+            if (spriteOrTextureIsNull || spriteIsSlicedAndBordersAreZeroWidth)
+            {
+                imageType = ImageType::Stretched;
+            }
 
-        switch (imageType)
-        {
-        case ImageType::Stretched:
-            RenderStretchedSprite(sprite, cellIndex, packedColor);
-            break;
-        case ImageType::Sliced:
-            AZ_Assert(sprite, "Should not get here if no sprite path is specified");
-            RenderSlicedSprite(sprite, cellIndex, packedColor);   // will not get here if sprite is null since we change type in that case above
-            break;
-        case ImageType::Fixed:
-            AZ_Assert(sprite, "Should not get here if no sprite path is specified");
-            RenderFixedSprite(sprite, cellIndex, packedColor);
-            break;
-        case ImageType::Tiled:
-            AZ_Assert(sprite, "Should not get here if no sprite path is specified");
-            RenderTiledSprite(sprite, packedColor);
-            break;
-        case ImageType::StretchedToFit:
-            AZ_Assert(sprite, "Should not get here if no sprite path is specified");
-            RenderStretchedToFitOrFillSprite(sprite, cellIndex, packedColor, true);
-            break;
-        case ImageType::StretchedToFill:
-            AZ_Assert(sprite, "Should not get here if no sprite path is specified");
-            RenderStretchedToFitOrFillSprite(sprite, cellIndex, packedColor, false);
-            break;
+            switch (imageType)
+            {
+            case ImageType::Stretched:
+                RenderStretchedSprite(sprite, cellIndex, packedColor);
+                break;
+            case ImageType::Sliced:
+                AZ_Assert(sprite, "Should not get here if no sprite path is specified");
+                RenderSlicedSprite(sprite, cellIndex, packedColor);   // will not get here if sprite is null since we change type in that case above
+                break;
+            case ImageType::Fixed:
+                AZ_Assert(sprite, "Should not get here if no sprite path is specified");
+                RenderFixedSprite(sprite, cellIndex, packedColor);
+                break;
+            case ImageType::Tiled:
+                AZ_Assert(sprite, "Should not get here if no sprite path is specified");
+                RenderTiledSprite(sprite, packedColor);
+                break;
+            case ImageType::StretchedToFit:
+                AZ_Assert(sprite, "Should not get here if no sprite path is specified");
+                RenderStretchedToFitOrFillSprite(sprite, cellIndex, packedColor, true);
+                break;
+            case ImageType::StretchedToFill:
+                AZ_Assert(sprite, "Should not get here if no sprite path is specified");
+                RenderStretchedToFitOrFillSprite(sprite, cellIndex, packedColor, false);
+                break;
+            }
         }
 
         if (!UiCanvasPixelAlignmentNotificationBus::Handler::BusIsConnected())
@@ -465,12 +480,26 @@ void UiImageComponent::Render(LyShine::IRenderGraph* renderGraph)
             }
         }
 
-        AZ::Data::Instance<AZ::RPI::Image> image = GetSpriteImage(sprite);
-        bool isClampTextureMode = m_imageType == ImageType::Tiled ? false : true;
-        bool isTextureSRGB = IsSpriteTypeRenderTarget() && m_isRenderTargetSRGB;
+        AZ::Data::Instance<AZ::RPI::Image> image = isBackdrop ? GetBackdropImage() : GetSpriteImage(sprite);
+        bool isClampTextureMode = isBackdrop || m_imageType != ImageType::Tiled;
+        bool isTextureSRGB = isBackdrop || (IsSpriteTypeRenderTarget() && m_isRenderTargetSRGB);
         bool isTexturePremultipliedAlpha = false; // we are not rendering from a render target with alpha in it
 
-        renderGraph->AddPrimitive(&m_cachedPrimitive, image, isClampTextureMode, isTextureSRGB, isTexturePremultipliedAlpha, m_blendMode);
+        if (isBackdrop && image && m_backdropBlurRadius > 0.0f)
+        {
+            renderGraph->AddBackdropPrimitive(
+                &m_cachedPrimitive,
+                image,
+                isClampTextureMode,
+                isTextureSRGB,
+                isTexturePremultipliedAlpha,
+                m_blendMode,
+                m_backdropBlurRadius);
+        }
+        else
+        {
+            renderGraph->AddPrimitive(&m_cachedPrimitive, image, isClampTextureMode, isTextureSRGB, isTexturePremultipliedAlpha, m_blendMode);
+        }
     }
 }
 
@@ -984,6 +1013,7 @@ void UiImageComponent::Reflect(AZ::ReflectContext* context)
             ->Field("Index", &UiImageComponent::m_spriteSheetCellIndex)
             ->Field("AttachmentImageAsset", &UiImageComponent::m_attachmentImageAsset)
             ->Field("IsRenderTargetSRGB", &UiImageComponent::m_isRenderTargetSRGB)
+            ->Field("BackdropBlurRadius", &UiImageComponent::m_backdropBlurRadius)
             ->Field("Color", &UiImageComponent::m_color)
             ->Field("Alpha", &UiImageComponent::m_alpha)
             ->Field("ImageType", &UiImageComponent::m_imageType)
@@ -1012,6 +1042,7 @@ void UiImageComponent::Reflect(AZ::ReflectContext* context)
             editInfo->DataElement(AZ::Edit::UIHandlers::ComboBox, &UiImageComponent::m_spriteType, "SpriteType", "The sprite type.")
                 ->EnumAttribute(UiImageInterface::SpriteType::SpriteAsset, "Sprite/Texture asset")
                 ->EnumAttribute(UiImageInterface::SpriteType::RenderTarget, "Render target")
+                ->EnumAttribute(UiImageInterface::SpriteType::Backdrop, "Backdrop capture")
                 ->Attribute(AZ::Edit::Attributes::ChangeNotify, &UiImageComponent::OnEditorSpriteTypeChange)
                 ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ_CRC("RefreshEntireTree", 0xefbc823c));
             editInfo->DataElement("Sprite", &UiImageComponent::m_spritePathname, "Sprite path", "The sprite path. Can be overridden by another component such as an interactable.")
@@ -1026,6 +1057,11 @@ void UiImageComponent::Reflect(AZ::ReflectContext* context)
                 ->Attribute(AZ::Edit::Attributes::ChangeNotify, &UiImageComponent::OnSpriteAttachmentImageAssetChange);
             editInfo->DataElement(AZ::Edit::UIHandlers::CheckBox, &UiImageComponent::m_isRenderTargetSRGB, "Render Target sRGB", "Check this box if the render target is in sRGB space instead of linear RGB space.")
                 ->Attribute(AZ::Edit::Attributes::Visibility, &UiImageComponent::IsSpriteTypeRenderTarget)
+                ->Attribute(AZ::Edit::Attributes::ChangeNotify, &UiImageComponent::OnEditorRenderSettingChange);
+            editInfo->DataElement(AZ::Edit::UIHandlers::Slider, &UiImageComponent::m_backdropBlurRadius, "Backdrop Blur Radius", "The blur radius applied when sampling the captured backdrop behind this panel.")
+                ->Attribute(AZ::Edit::Attributes::Visibility, &UiImageComponent::IsSpriteTypeBackdrop)
+                ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+                ->Attribute(AZ::Edit::Attributes::Max, 32.0f)
                 ->Attribute(AZ::Edit::Attributes::ChangeNotify, &UiImageComponent::OnEditorRenderSettingChange);
             editInfo->DataElement(AZ::Edit::UIHandlers::Color, &UiImageComponent::m_color, "Color", "The color tint for the image. Can be overridden by another component such as an interactable.")
                 ->Attribute(AZ::Edit::Attributes::ChangeNotify, &UiImageComponent::OnColorChange);
@@ -1107,6 +1143,7 @@ void UiImageComponent::Reflect(AZ::ReflectContext* context)
             ->Enum<(int)UiImageInterface::ImageType::StretchedToFill>("eUiImageType_StretchedToFill")
             ->Enum<(int)UiImageInterface::SpriteType::SpriteAsset>("eUiSpriteType_SpriteAsset")
             ->Enum<(int)UiImageInterface::SpriteType::RenderTarget>("eUiSpriteType_RenderTarget")
+            ->Enum<(int)UiImageInterface::SpriteType::Backdrop>("eUiSpriteType_Backdrop")
             ->Enum<(int)UiImageInterface::FillType::None>("eUiFillType_None")
             ->Enum<(int)UiImageInterface::FillType::Linear>("eUiFillType_Linear")
             ->Enum<(int)UiImageInterface::FillType::Radial>("eUiFillType_Radial")
@@ -1200,6 +1237,10 @@ void UiImageComponent::Init()
             {
                 m_sprite = AZ::Interface<ILyShine>::Get()->CreateSprite(m_attachmentImageAsset);
             }
+        }
+        else if (IsSpriteTypeBackdrop())
+        {
+            m_sprite = nullptr;
         }
         else
         {
@@ -1507,6 +1548,36 @@ void UiImageComponent::RenderStretchedToFitOrFillSprite(ISprite* sprite, int cel
     else
     {
         RenderFilledQuad(points.pt, uvs, packedColor);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+void UiImageComponent::RenderBackdrop(const AZ::Vector2& captureSize, uint32 packedColor)
+{
+    UiTransformInterface::RectPoints points;
+    UiTransformBus::Event(GetEntityId(), &UiTransformBus::Events::GetViewportSpacePoints, points);
+
+    AZ::Vector2 safeCaptureSize = captureSize;
+    if (safeCaptureSize.GetX() <= 0.0f || safeCaptureSize.GetY() <= 0.0f)
+    {
+        safeCaptureSize = AZ::Vector2(1.0f, 1.0f);
+    }
+
+    const AZ::Vector2 uvs[4] =
+    {
+        AZ::Vector2(points.TopLeft().GetX() / safeCaptureSize.GetX(), points.TopLeft().GetY() / safeCaptureSize.GetY()),
+        AZ::Vector2(points.TopRight().GetX() / safeCaptureSize.GetX(), points.TopRight().GetY() / safeCaptureSize.GetY()),
+        AZ::Vector2(points.BottomRight().GetX() / safeCaptureSize.GetX(), points.BottomRight().GetY() / safeCaptureSize.GetY()),
+        AZ::Vector2(points.BottomLeft().GetX() / safeCaptureSize.GetX(), points.BottomLeft().GetY() / safeCaptureSize.GetY()),
+    };
+
+    if (m_fillType != FillType::None)
+    {
+        RenderFilledQuad(points.pt, uvs, packedColor);
+    }
+    else
+    {
+        RenderSingleQuad(points.pt, uvs, packedColor);
     }
 }
 
@@ -2431,6 +2502,12 @@ bool UiImageComponent::IsSpriteTypeRenderTarget()
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+bool UiImageComponent::IsSpriteTypeBackdrop()
+{
+    return (m_spriteType == UiImageInterface::SpriteType::Backdrop);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
 bool UiImageComponent::IsFilled()
 {
     return (m_fillType != FillType::None);
@@ -2576,10 +2653,44 @@ void UiImageComponent::OnSpriteTypeChange()
     {
         OnSpriteAttachmentImageAssetChange();
     }
+    else if (IsSpriteTypeBackdrop())
+    {
+        if (UiSpriteSettingsChangeNotificationBus::Handler::BusIsConnected())
+        {
+            UiSpriteSettingsChangeNotificationBus::Handler::BusDisconnect();
+        }
+
+        SAFE_RELEASE(m_sprite);
+        m_cachedBackdropCaptureSize = AZ::Vector2::CreateZero();
+        InvalidateLayouts();
+        ResetSpriteSheetCellIndex();
+    }
     else
     {
         AZ_Assert(false, "unhandled sprite type");
     }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+AZ::Data::Instance<AZ::RPI::Image> UiImageComponent::GetBackdropImage() const
+{
+    AZ::EntityId canvasEntityId;
+    UiElementBus::EventResult(canvasEntityId, GetEntityId(), &UiElementBus::Events::GetCanvasEntityId);
+
+    AZ::Data::Instance<AZ::RPI::Image> backdropImage;
+    UiCanvasBus::EventResult(backdropImage, canvasEntityId, &UiCanvasBus::Events::GetBackdropCaptureImage);
+    return backdropImage;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+AZ::Vector2 UiImageComponent::GetBackdropCaptureSize() const
+{
+    AZ::EntityId canvasEntityId;
+    UiElementBus::EventResult(canvasEntityId, GetEntityId(), &UiElementBus::Events::GetCanvasEntityId);
+
+    AZ::Vector2 backdropCaptureSize = AZ::Vector2::CreateZero();
+    UiCanvasBus::EventResult(backdropCaptureSize, canvasEntityId, &UiCanvasBus::Events::GetBackdropCaptureSize);
+    return backdropCaptureSize;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Gems/LyShine/Code/Source/UiImageComponent.h
+++ b/Gems/LyShine/Code/Source/UiImageComponent.h
@@ -178,6 +178,7 @@ private: // member functions
     void RenderFixedSprite(ISprite* sprite, int cellIndex, uint32 packedColor);
     void RenderTiledSprite(ISprite* sprite, uint32 packedColor);
     void RenderStretchedToFitOrFillSprite(ISprite* sprite, int cellIndex, uint32 packedColor, bool toFit);
+    void RenderBackdrop(const AZ::Vector2& captureSize, uint32 packedColor);
 
     void RenderSingleQuad(const AZ::Vector2* positions, const AZ::Vector2* uvs, uint32 packedColor);
 
@@ -219,6 +220,7 @@ private: // member functions
     bool IsSpriteTypeAsset();
     bool IsSpriteTypeSpriteSheet();
     bool IsSpriteTypeRenderTarget();
+    bool IsSpriteTypeBackdrop();
 
     bool IsFilled();
     bool IsLinearFilled();
@@ -256,6 +258,9 @@ private: // member functions
     //! Returns a string representation of the indices used to index sprite-sheet types.
     LyShine::AZu32ComboBoxVec PopulateIndexStringList() const;
 
+    AZ::Data::Instance<AZ::RPI::Image> GetBackdropImage() const;
+    AZ::Vector2 GetBackdropCaptureSize() const;
+
 private: // static member functions
 
     static bool VersionConverter(AZ::SerializeContext& context,
@@ -266,6 +271,7 @@ private: // data
     AzFramework::SimpleAssetReference<LmbrCentral::TextureAsset> m_spritePathname;
     AZ::Data::Asset<AZ::RPI::AttachmentImageAsset> m_attachmentImageAsset;
     bool m_isRenderTargetSRGB           = false;
+    float m_backdropBlurRadius          = 0.0f;
     SpriteType m_spriteType             = SpriteType::SpriteAsset;
     AZ::Color m_color                   = AZ::Color(1.0f, 1.0f, 1.0f, 1.0f);
     float m_alpha                       = 1.0f;
@@ -296,5 +302,6 @@ private: // data
 
     // cached rendering data for performance optimization
     LyShine::UiPrimitive m_cachedPrimitive;
+    AZ::Vector2 m_cachedBackdropCaptureSize = AZ::Vector2::CreateZero();
     bool m_isRenderCacheDirty = true;
 };

--- a/Gems/LyShine/Code/Source/UiRenderer.cpp
+++ b/Gems/LyShine/Code/Source/UiRenderer.cpp
@@ -174,6 +174,7 @@ void UiRenderer::CacheShaderData(const AZ::RHI::Ptr<AZ::RPI::DynamicDrawContext>
     static const char textureIndexName[] = "m_texture";
     static const char worldToProjIndexName[] = "m_worldToProj";
     static const char isClampIndexName[] = "m_isClamp";
+    static const char backdropBlurRadiusIndexName[] = "m_backdropBlurRadius";
     AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> drawSrg = dynamicDraw->NewDrawSrg();
     const AZ::RHI::ShaderResourceGroupLayout* layout = drawSrg->GetLayout();
     m_uiShaderData.m_imageInputIndex = layout->FindShaderInputImageIndex(AZ::Name(textureIndexName));
@@ -185,6 +186,9 @@ void UiRenderer::CacheShaderData(const AZ::RHI::Ptr<AZ::RPI::DynamicDrawContext>
     m_uiShaderData.m_isClampInputIndex = layout->FindShaderInputConstantIndex(AZ::Name(isClampIndexName));
     AZ_Error(LogName, m_uiShaderData.m_isClampInputIndex.IsValid(), "Failed to find shader input constant %s.",
         isClampIndexName);
+    m_uiShaderData.m_backdropBlurRadiusInputIndex = layout->FindShaderInputConstantIndex(AZ::Name(backdropBlurRadiusIndexName));
+    AZ_Error(LogName, m_uiShaderData.m_backdropBlurRadiusInputIndex.IsValid(), "Failed to find shader input constant %s.",
+        backdropBlurRadiusIndexName);
 
     // Cache shader variants that will be used
     AZ::RPI::ShaderOptionList shaderOptionsTextureLinear;

--- a/Gems/LyShine/Code/Source/UiRenderer.cpp
+++ b/Gems/LyShine/Code/Source/UiRenderer.cpp
@@ -175,6 +175,7 @@ void UiRenderer::CacheShaderData(const AZ::RHI::Ptr<AZ::RPI::DynamicDrawContext>
     static const char worldToProjIndexName[] = "m_worldToProj";
     static const char isClampIndexName[] = "m_isClamp";
     static const char backdropBlurRadiusIndexName[] = "m_backdropBlurRadius";
+    static const char backdropInvTextureSizeIndexName[] = "m_backdropInvTextureSize";
     AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> drawSrg = dynamicDraw->NewDrawSrg();
     const AZ::RHI::ShaderResourceGroupLayout* layout = drawSrg->GetLayout();
     m_uiShaderData.m_imageInputIndex = layout->FindShaderInputImageIndex(AZ::Name(textureIndexName));
@@ -189,6 +190,9 @@ void UiRenderer::CacheShaderData(const AZ::RHI::Ptr<AZ::RPI::DynamicDrawContext>
     m_uiShaderData.m_backdropBlurRadiusInputIndex = layout->FindShaderInputConstantIndex(AZ::Name(backdropBlurRadiusIndexName));
     AZ_Error(LogName, m_uiShaderData.m_backdropBlurRadiusInputIndex.IsValid(), "Failed to find shader input constant %s.",
         backdropBlurRadiusIndexName);
+    m_uiShaderData.m_backdropInvTextureSizeInputIndex = layout->FindShaderInputConstantIndex(AZ::Name(backdropInvTextureSizeIndexName));
+    AZ_Error(LogName, m_uiShaderData.m_backdropInvTextureSizeInputIndex.IsValid(), "Failed to find shader input constant %s.",
+        backdropInvTextureSizeIndexName);
 
     // Cache shader variants that will be used
     AZ::RPI::ShaderOptionList shaderOptionsTextureLinear;

--- a/Gems/LyShine/Code/Source/UiRenderer.h
+++ b/Gems/LyShine/Code/Source/UiRenderer.h
@@ -32,6 +32,7 @@ public: // types
         AZ::RHI::ShaderInputConstantIndex m_viewProjInputIndex;
         AZ::RHI::ShaderInputConstantIndex m_isClampInputIndex;
         AZ::RHI::ShaderInputConstantIndex m_backdropBlurRadiusInputIndex;
+        AZ::RHI::ShaderInputConstantIndex m_backdropInvTextureSizeInputIndex;
 
         AZ::RPI::ShaderVariantId m_shaderVariantTextureLinear;
         AZ::RPI::ShaderVariantId m_shaderVariantTextureSrgb;

--- a/Gems/LyShine/Code/Source/UiRenderer.h
+++ b/Gems/LyShine/Code/Source/UiRenderer.h
@@ -31,6 +31,7 @@ public: // types
         AZ::RHI::ShaderInputImageIndex m_imageInputIndex;
         AZ::RHI::ShaderInputConstantIndex m_viewProjInputIndex;
         AZ::RHI::ShaderInputConstantIndex m_isClampInputIndex;
+        AZ::RHI::ShaderInputConstantIndex m_backdropBlurRadiusInputIndex;
 
         AZ::RPI::ShaderVariantId m_shaderVariantTextureLinear;
         AZ::RPI::ShaderVariantId m_shaderVariantTextureSrgb;


### PR DESCRIPTION
This PR adds a new LyShine UI image mode for translucent / frosted-glass panels.

Previously, `UiImage` could render from a sprite/texture asset or a render target, but it could not sample and blur the scene behind the UI. With this change, LyShine can capture scene color before UI rendering and expose it to UI elements through a new `SpriteType = Backdrop capture` mode. UI panels using that mode can now render a blurred version of the scene behind them, tinted by the panel color/alpha to create a translucent glass effect.

At a high level, this PR:
- adds a new `Backdrop` sprite type to `UiImage`
- adds a `Backdrop Blur Radius` property for that mode
- captures scene color in the LyShine pass before UI draws
- passes the captured image through the canvas/render graph to backdrop-enabled UI elements
- updates the LyShine UI shader to sample and blur the captured backdrop

This is the simpler scene-backdrop implementation, not a full “blur previously drawn UI” compositor. In other words, it blurs the scene behind the panel and keeps the runtime cost relatively modest for targeted popup/overlay usage.

## How was this PR tested?

Tested locally with a rebuilt engine and local Redemption runtime/editor binaries.

Validation performed:
- built local editor and launcher successfully
- verified the new `Backdrop capture` option appears in LyShine `UiImage`
- verified `Backdrop Blur Radius` is exposed and functional
- verified backdrop panels render blurred scene content behind them in-game
- verified existing non-backdrop UI rendering continued to work in the tested flows

Testing was manual/local only:
- LyShine canvas/editor testing
- local game runtime testing in Redemption
- no automated tests were added
- no device/mobile validation
