### PR TITLE
Editor: Add auto-scroll toggle button to console

### DIFF
--- a/Code/Editor/Controls/ConsoleSCB.cpp
+++ b/Code/Editor/Controls/ConsoleSCB.cpp
@@ -363,10 +363,7 @@ CConsoleSCB::CConsoleSCB(QWidget* parent)
     {
         if (m_autoScroll && value != ui->textEdit->verticalScrollBar()->maximum())
         {
-            m_autoScroll = false;
-            ui->autoScrollButton->setChecked(false);
-            ui->autoScrollButton->setIcon(QIcon(ConsoleConstants::AutoScrollOffIcon));
-            ui->autoScrollButton->setToolTip(tr("Auto Scroll: Off"));
+            SetAutoScroll(false);
         }
     });
 
@@ -375,10 +372,7 @@ CConsoleSCB::CConsoleSCB(QWidget* parent)
     {
         if (m_autoScroll && ui->textEdit->textCursor().hasSelection())
         {
-            m_autoScroll = false;
-            ui->autoScrollButton->setChecked(false);
-            ui->autoScrollButton->setIcon(QIcon(ConsoleConstants::AutoScrollOffIcon));
-            ui->autoScrollButton->setToolTip(tr("Auto Scroll: Off"));
+            SetAutoScroll(false);
         }
     });
 #endif
@@ -446,16 +440,23 @@ void CConsoleSCB::toggleClearOnPlay()
 #if defined(CARBONATED)
 void CConsoleSCB::toggleAutoScroll()
 {
-    m_autoScroll = !m_autoScroll;
-    ui->autoScrollButton->setChecked(m_autoScroll);
-    ui->autoScrollButton->setIcon(QIcon(m_autoScroll ? ConsoleConstants::AutoScrollOnIcon : ConsoleConstants::AutoScrollOffIcon));
-    ui->autoScrollButton->setToolTip(m_autoScroll ? tr("Auto Scroll: On") : tr("Auto Scroll: Off"));
+    SetAutoScroll(!m_autoScroll);
+}
 
-    // If re-enabling, jump to the bottom immediately
-    if (m_autoScroll)
+void CConsoleSCB::SetAutoScroll(bool autoScroll)
+{
+    if (m_autoScroll != autoScroll)
     {
-        QScrollBar* scrollBar = ui->textEdit->verticalScrollBar();
-        scrollBar->setValue(scrollBar->maximum());
+        m_autoScroll = autoScroll;
+        ui->autoScrollButton->setChecked(m_autoScroll);
+        ui->autoScrollButton->setIcon(QIcon(m_autoScroll ? ConsoleConstants::AutoScrollOnIcon : ConsoleConstants::AutoScrollOffIcon));
+        ui->autoScrollButton->setToolTip(m_autoScroll ? tr("Auto Scroll: On") : tr("Auto Scroll: Off"));
+
+        if (m_autoScroll)
+        {
+            QScrollBar* scrollBar = ui->textEdit->verticalScrollBar();
+            scrollBar->setValue(scrollBar->maximum());
+        }
     }
 }
 #endif

--- a/Code/Editor/Controls/ConsoleSCB.cpp
+++ b/Code/Editor/Controls/ConsoleSCB.cpp
@@ -47,6 +47,10 @@ namespace ConsoleConstants
     static constexpr const char* SearchIcon = ":/stylesheet/img/search.svg";
     static constexpr const char* ClearIcon = ":/stylesheet/img/lineedit-clear.png";
     static constexpr const char* MenuIcon = ":/Menu/menu.svg";
+#if defined(CARBONATED)
+    static constexpr const char* AutoScrollOnIcon = ":/stylesheet/img/lock_on.svg";
+    static constexpr const char* AutoScrollOffIcon = ":/stylesheet/img/lock_off.svg";
+#endif
 } // namespace ConsoleConstants
 
 class CConsoleSCB::SearchHighlighter : public QSyntaxHighlighter
@@ -351,6 +355,33 @@ CConsoleSCB::CConsoleSCB(QWidget* parent)
     GetIEditor()->RegisterNotifyListener(this);
 
     connect(ui->button, &QPushButton::clicked, this, &CConsoleSCB::showVariableEditor);
+#if defined(CARBONATED)
+    connect(ui->autoScrollButton, &QToolButton::clicked, this, &CConsoleSCB::toggleAutoScroll);
+
+    // Disable auto-scroll when the user manually scrolls away from the bottom
+    connect(ui->textEdit->verticalScrollBar(), &QScrollBar::valueChanged, this, [this](int value)
+    {
+        if (m_autoScroll && value != ui->textEdit->verticalScrollBar()->maximum())
+        {
+            m_autoScroll = false;
+            ui->autoScrollButton->setChecked(false);
+            ui->autoScrollButton->setIcon(QIcon(ConsoleConstants::AutoScrollOffIcon));
+            ui->autoScrollButton->setToolTip(tr("Auto Scroll: Off"));
+        }
+    });
+
+    // Disable auto-scroll when the user makes a text selection
+    connect(ui->textEdit, &QPlainTextEdit::selectionChanged, this, [this]()
+    {
+        if (m_autoScroll && ui->textEdit->textCursor().hasSelection())
+        {
+            m_autoScroll = false;
+            ui->autoScrollButton->setChecked(false);
+            ui->autoScrollButton->setIcon(QIcon(ConsoleConstants::AutoScrollOffIcon));
+            ui->autoScrollButton->setToolTip(tr("Auto Scroll: Off"));
+        }
+    });
+#endif
     connect(ui->findButton, &QPushButton::clicked, this, &CConsoleSCB::toggleConsoleSearch);
     connect(ui->textEdit, &AzToolsFramework::ConsoleTextEdit::searchBarRequested, this, [this]
     {
@@ -412,6 +443,23 @@ void CConsoleSCB::toggleClearOnPlay()
     gSettings.clearConsoleOnGameModeStart = !gSettings.clearConsoleOnGameModeStart;
 }
 
+#if defined(CARBONATED)
+void CConsoleSCB::toggleAutoScroll()
+{
+    m_autoScroll = !m_autoScroll;
+    ui->autoScrollButton->setChecked(m_autoScroll);
+    ui->autoScrollButton->setIcon(QIcon(m_autoScroll ? ConsoleConstants::AutoScrollOnIcon : ConsoleConstants::AutoScrollOffIcon));
+    ui->autoScrollButton->setToolTip(m_autoScroll ? tr("Auto Scroll: On") : tr("Auto Scroll: Off"));
+
+    // If re-enabling, jump to the bottom immediately
+    if (m_autoScroll)
+    {
+        QScrollBar* scrollBar = ui->textEdit->verticalScrollBar();
+        scrollBar->setValue(scrollBar->maximum());
+    }
+}
+#endif
+
 void CConsoleSCB::RegisterViewClass()
 {
     AzToolsFramework::ViewPaneOptions opts;
@@ -437,6 +485,10 @@ void CConsoleSCB::OnEditorPreferencesChanged()
 void CConsoleSCB::RefreshStyle()
 {
     ui->button->setIcon(QIcon(ConsoleConstants::ButtonIcon));
+#if defined(CARBONATED)
+    ui->autoScrollButton->setIcon(QIcon(m_autoScroll ? ConsoleConstants::AutoScrollOnIcon : ConsoleConstants::AutoScrollOffIcon));
+    ui->autoScrollButton->setToolTip(m_autoScroll ? tr("Auto Scroll: On") : tr("Auto Scroll: Off"));
+#endif
     ui->findButton->setIcon(QIcon(ConsoleConstants::SearchIcon));
     ui->closeButton->setIcon(QIcon(ConsoleConstants::ClearIcon));
     ui->optionsButton->setIcon(QIcon(ConsoleConstants::MenuIcon));
@@ -551,7 +603,13 @@ void CConsoleSCB::FlushText()
     // If the user has selected some text in the text edit area or has scrolled
     // away from the bottom, then restore the previous cursor and keep the scroll
     // bar in the same location
+#if defined(CARBONATED)
+    // When auto-scroll is ON, always scroll to the bottom — the user signals intent
+    // to disable it by scrolling up or selecting text (handled via signal connections).
+    if (!m_autoScroll && (oldCursor.hasSelection() || scrolledOffBottom))
+#else
     if (oldCursor.hasSelection() || scrolledOffBottom)
+#endif
     {
         ui->textEdit->setTextCursor(oldCursor);
         scrollBar->setValue(oldScrollValue);

--- a/Code/Editor/Controls/ConsoleSCB.h
+++ b/Code/Editor/Controls/ConsoleSCB.h
@@ -153,6 +153,7 @@ public:
     void SetInputFocus();
 #if defined(CARBONATED)
     bool HasInputFocus() const;
+    void SetAutoScroll(bool autoScroll);
 #endif
     void AddToConsole(const QString& text, bool bNewLine);
     void FlushText();

--- a/Code/Editor/Controls/ConsoleSCB.h
+++ b/Code/Editor/Controls/ConsoleSCB.h
@@ -173,6 +173,9 @@ private Q_SLOTS:
     void findPrevious();
     void findNext();
     void toggleClearOnPlay();
+#if defined(CARBONATED)
+    void toggleAutoScroll();
+#endif
 
 private:
     void OnEditorNotifyEvent(EEditorNotifyEvent event) override;
@@ -192,6 +195,9 @@ private:
 
     QMenu* m_optionsMenu;
     QAction* m_clearOnPlayAction;
+#if defined(CARBONATED)
+    bool m_autoScroll = true;
+#endif
 };
 
 #endif // CRYINCLUDE_EDITOR_CONTROLS_CONSOLESCB_H

--- a/Code/Editor/Controls/ConsoleSCB.ui
+++ b/Code/Editor/Controls/ConsoleSCB.ui
@@ -240,6 +240,40 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QToolButton" name="autoScrollButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>20</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>20</width>
+          <height>30</height>
+         </size>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="autoRaise">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
Adds a checkable lock button to the right of the hamburger menu in the console toolbar to control auto-scroll behaviour.

Behaviour:
- Defaults to ON at launch — new output always scrolls to the bottom
- Scrolling up in the log automatically disables auto-scroll
- Making a text selection automatically disables auto-scroll
- Clicking the button toggles auto-scroll; re-enabling jumps to bottom

Icons: lock_on.svg / lock_off.svg from AzQtComponents stylesheet. All changes wrapped in #if defined(CARBONATED).

## How was this PR tested?

Tested in editor on PC
