### PR TITLE
Fix pass error due to slot type mismatch

### DIFF
--- a/Gems/LyShine/Assets/Passes/LyShineParent.pass
+++ b/Gems/LyShine/Assets/Passes/LyShineParent.pass
@@ -9,23 +9,19 @@
             "Slots": [
                 {
                     "Name": "ColorInput",
-                    "SlotType": "Input",
-                    "ScopeAttachmentUsage": "Copy"
+                    "SlotType": "Input"
                 },
                 {
                     "Name": "ColorInputOutput",
-                    "SlotType": "InputOutput",
-                    "ScopeAttachmentUsage": "RenderTarget"
+                    "SlotType": "InputOutput"
                 },
                 {
                     "Name": "BackdropCaptureOutput",
-                    "SlotType": "Output",
-                    "ScopeAttachmentUsage": "Copy"
+                    "SlotType": "InputOutput"
                 },
                 {
                     "Name": "DepthInputOutput",
-                    "SlotType": "InputOutput",
-                    "ScopeAttachmentUsage": "DepthStencil"
+                    "SlotType": "InputOutput"
                 }
             ],
             "ImageAttachments": [


### PR DESCRIPTION
## What does this PR do?

Fix error caused by https://github.com/carbonated-dev/o3de/pull/516 because of mismatch of slot types.
Removed unnecessary ScopeAttachmentUsage in LyShineParent pass. Updated copy as InputOutput type.

```
<15:51:24.189> [Error] (Pass System) - Pass::ProcessConnection Root.MobilePipeline_0.LyShinePass.LyShineChildPass:BackdropInput -> Parent:BackdropCaptureOutput: Slot Type Mismatch - When connecting to a child slot, both slots must be of the same type, or one must be InputOutput.
<15:51:24.189> [Error] (Pass System) - Pass::ProcessConnection Root.MobilePipeline_0.LyShinePass.LyShineChildPass:BackdropInput -> Parent:BackdropCaptureOutput: Could not find binding on target.
<15:51:24.190> (PassSystem) - 
--- PASS VALIDATION FAILURE ---
--Critical Errors--

<15:51:24.190> (PassSystem) - 
There are 1 passes with errors:

<15:51:24.190> (PassSystem) - 
- Root.MobilePipeline_0.LyShinePass.LyShineChildPass
   Pass::ProcessConnection Root.MobilePipeline_0.LyShinePass.LyShineChildPass:BackdropInput -> Parent:BackdropCaptureOutput: Slot Type Mismatch - When connecting to a child slot, both slots must be of the same type, or one must be InputOutput.
   Pass::ProcessConnection Root.MobilePipeline_0.LyShinePass.LyShineChildPass:BackdropInput -> Parent:BackdropCaptureOutput: Could not find binding on target.

<15:51:24.190> (PassSystem) - 
There are 1 passes with missing Inputs:

<15:51:24.190> (PassSystem) - 
- Root.MobilePipeline_0.LyShinePass.LyShineChildPass
   BackdropInput has no valid attachment
```

## How was this PR tested?

Run Editor on PC and checked that there's no errors when building the pass tree.
