### PR TITLE
Shader compile improvements (CAR-32156)

### DIFF
--- a/Code/Legacy/CrySystem/Log.cpp
+++ b/Code/Legacy/CrySystem/Log.cpp
@@ -934,10 +934,6 @@ void CLog::LogWithCallback(ELogType type, const LogWriteCallback& messageCallbac
                         m_logFileHandle.Write(timeStr.size(), timeStr.data());
                     }
                     m_logFileHandle.Write(logString.size(), logString.data());
-#if defined(CARBONATED) & defined(AZ_PLATFORM_LINUX)
-                    // add all the messages that go to log file to system console output
-                    printf(logString.data()[logString.size() - 1] == '\n' ?  "%s" : "%s\n", logString.data());
-#endif                    
 
 #if !defined(KEEP_LOG_FILE_OPEN)
                     CloseLogFile();
@@ -945,6 +941,10 @@ void CLog::LogWithCallback(ELogType type, const LogWriteCallback& messageCallbac
                     // do not use FLUSH on log files.  Doing so will slow the engine down greatly when logging.
                     // (the log is flushed automatically when an unhandled exception occurs)
                 }
+#if defined(CARBONATED) && defined(AZ_PLATFORM_LINUX)
+                // add all the messages that go to log file to system console output even if the log file is not opened
+                fwrite(logString.data(), logString.size(), 1, stdout);
+#endif
             }
         };
         LogStringToFileWithCallback(type, messageCallback, logCategoryString);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Material/Material.cpp
@@ -549,17 +549,25 @@ namespace AZ
 
                 for (const MaterialPropertyOutputId& connection : propertyDescriptor->GetOutputConnections())
                 {
-#if defined(CARBONATED) && defined(CARBONATED_MOBILE_PIPELINE_ON_MOBILE)
-#if defined(AZ_PLATFORM_IOS) || defined(AZ_PLATFORM_ANDROID)
+#if defined(CARBONATED)
+
+#if (defined(CARBONATED_MOBILE_PIPELINE_ON_MOBILE) && (defined(AZ_PLATFORM_IOS) || defined(AZ_PLATFORM_ANDROID))) || (defined(CARBONATED_MAIN_PIPELINE_ON_LINUX) && defined(AZ_PLATFORM_LINUX))
                     {
+                        const char* allowedPipeline =
+#if defined(AZ_PLATFORM_IOS) || defined(AZ_PLATFORM_ANDROID)
+                                                      "MobilePipeline";
+#else // must be AZ_PLATFORM_LINUX
+                                                      "MainPipeline";
+#endif                                                        
                         const char* pipelineName = connection.m_materialPipelineName.GetCStr();
-                        if (pipelineName[0] != 0 && strcmp(pipelineName, "MobilePipeline") != 0)
+                        if (pipelineName[0] != 0 && strcmp(pipelineName, allowedPipeline) != 0)
                         {
                             continue;
                         }
                     }
-#endif
-#endif
+#endif  // CARBONATED_MOBILE_PIPELINE_ON_MOBILE or CARBONATED_MAIN_PIPELINE_ON_LINUX
+
+#endif  // CARBONATED
                     [[maybe_unused]] bool applied =
                         TryApplyPropertyConnectionToShaderInput(value, connection, propertyDescriptor) ||
                         TryApplyPropertyConnectionToShaderOption(value, connection) ||

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialTypeAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialTypeAsset.cpp
@@ -86,13 +86,20 @@ namespace AZ
             {
                 return false;
             }
-#if defined(CARBONATED) && defined(CARBONATED_MOBILE_PIPELINE_ON_MOBILE)
+#if defined(CARBONATED)
+
+#if (defined(CARBONATED_MOBILE_PIPELINE_ON_MOBILE) && (defined(AZ_PLATFORM_IOS) || defined(AZ_PLATFORM_ANDROID))) || (defined(CARBONATED_MAIN_PIPELINE_ON_LINUX) && defined(AZ_PLATFORM_LINUX))
+            const char* allowedPipeline =
 #if defined(AZ_PLATFORM_IOS) || defined(AZ_PLATFORM_ANDROID)
+                                          "MobilePipeline";
+#else // must be AZ_PLATFORM_LINUX
+                                          "MainPipeline";
+#endif                                                        
             //  erase non-mobile pipeline info from the pipeline payload map
             for (auto it = m_materialPipelinePayloads.begin(); it != m_materialPipelinePayloads.end(); )
             {
                 const char* pipelineName = it->first.GetCStr();
-                if (pipelineName[0] != 0 && strcmp(pipelineName, "MobilePipeline") != 0)
+                if (pipelineName[0] != 0 && strcmp(pipelineName, allowedPipeline) != 0)
                 {
                     it = m_materialPipelinePayloads.erase(it);
                 }
@@ -101,8 +108,9 @@ namespace AZ
                     it++;
                 }
             }
-#endif
-#endif
+#endif  // CARBONATED_MOBILE_PIPELINE_ON_MOBILE or CARBONATED_MAIN_PIPELINE_ON_LINUX
+
+#endif  // CARBONATED
             for (auto& materialPipelinePair : m_materialPipelinePayloads)
             {
                 if (!materialPipelinePair.second.m_shaderCollection.InitializeShaderOptionGroups())

--- a/Gems/PhysX/Core/Code/Source/PhysXCharacters/Components/CharacterControllerComponent.cpp
+++ b/Gems/PhysX/Core/Code/Source/PhysXCharacters/Components/CharacterControllerComponent.cpp
@@ -736,7 +736,7 @@ namespace PhysX
     void CharacterControllerComponent::OnTick(float deltaTime,[[maybe_unused]] AZ::ScriptTimePoint time)
     {
         //Wrapping this here rather than disconnected because there was a note about destroy not being appropriate for disconnecting from the tick bus?
-        if (auto* controller = GetControllerConst())
+        if ([[maybe_unused]] auto* controller = GetControllerConst())
         {
             AZ::Vector3 physicsTranslation = GetBasePosition();
 


### PR DESCRIPTION
## What does this PR do?

On linux platform load shaders for main pipeline only. This shortens shader compile time about 2.5 times for the first time compile, when the loading time is huge) and if cached.

Collateral:
- log fix for OCGA when normal log file cannot be opened
- compile bug fix

## How was this PR tested?

Local linux builds, check loading logs and timing.
