### PR TITLE
[CAR-32096] Volumetric Fog

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/TextureSettings.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/TextureSettings.cpp
@@ -41,6 +41,9 @@ namespace ImageProcessingAtom
 
     void TextureSettings::Reflect(AZ::ReflectContext* context)
     {
+#if defined(CARBONATED)
+        FlipbookSettings::Reflect(context);
+#endif // defined(CARBONATED)
         AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context);
         if (serialize)
         {
@@ -57,7 +60,11 @@ namespace ImageProcessingAtom
                 ->Field("MipMapAlphaAdjustments", &TextureSettings::m_mipAlphaAdjust)
                 ->Field("PlatformSpecificOverrides", &TextureSettings::m_platfromOverrides)
                 ->Field("OverridingPlatform", &TextureSettings::m_overridingPlatform)
-                ->Field("Tags", &TextureSettings::m_tags);
+                ->Field("Tags", &TextureSettings::m_tags)
+#if defined(CARBONATED)
+                ->Field("Flipbook", &TextureSettings::m_flipBookSettings)
+#endif // defined(CARBONATED)
+                ;
 
             AZ::EditContext* edit = serialize->GetEditContext();
             if (edit)
@@ -350,4 +357,51 @@ namespace ImageProcessingAtom
 
         return STRING_OUTCOME_SUCCESS;
     }
-}
+
+#if defined(CARBONATED)
+    void TextureSettings::FlipbookSettings::Reflect(AZ::ReflectContext* context)
+    {
+        AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context);
+        if (serialize)
+        {
+            serialize->Class<FlipbookSettings>()
+                ->Version(0)
+                ->Field("Columns", &FlipbookSettings::m_numColumns)
+                ->Field("Rows", &FlipbookSettings::m_numRows);
+
+            AZ::EditContext* edit = serialize->GetEditContext();
+            if (edit)
+            {
+                edit->Class<FlipbookSettings>("Flipbook Settings", "")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
+
+                    ->ClassElement(AZ::Edit::ClassElements::Group, "Flipbook Settings")
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
+
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &FlipbookSettings::m_numColumns,
+                        "Number of columns",
+                        "Number of columns in the flipbook")
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->Attribute(AZ::Edit::Attributes::ContainerCanBeModified, false)
+                    ->ElementAttribute(AZ::Edit::UIHandlers::Handler, AZ::Edit::UIHandlers::Slider)
+                    ->ElementAttribute(AZ::Edit::Attributes::Min, 0)
+                    ->ElementAttribute(AZ::Edit::Attributes::Max, 128)
+                    ->ElementAttribute(AZ::Edit::Attributes::Step, 1)
+
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default, &FlipbookSettings::m_numRows, "Number of rows", "Number of rows in the flipbook")
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->Attribute(AZ::Edit::Attributes::ContainerCanBeModified, false)
+                    ->ElementAttribute(AZ::Edit::UIHandlers::Handler, AZ::Edit::UIHandlers::Slider)
+                    ->ElementAttribute(AZ::Edit::Attributes::Min, 0)
+                    ->ElementAttribute(AZ::Edit::Attributes::Max, 128)
+                    ->ElementAttribute(AZ::Edit::Attributes::Step, 1);
+            }
+        }
+    }
+#endif // defined(CARBONATED)
+} // namespace ImageProcessingAtom

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/TextureSettings.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/TextureSettings.cpp
@@ -374,7 +374,7 @@ namespace ImageProcessingAtom
             {
                 edit->Class<FlipbookSettings>("Flipbook Settings", "")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
 
                     ->ClassElement(AZ::Edit::ClassElements::Group, "Flipbook Settings")
@@ -385,8 +385,6 @@ namespace ImageProcessingAtom
                         &FlipbookSettings::m_numColumns,
                         "Number of columns",
                         "Number of columns in the flipbook")
-                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
-                    ->Attribute(AZ::Edit::Attributes::ContainerCanBeModified, false)
                     ->ElementAttribute(AZ::Edit::UIHandlers::Handler, AZ::Edit::UIHandlers::Slider)
                     ->ElementAttribute(AZ::Edit::Attributes::Min, 0)
                     ->ElementAttribute(AZ::Edit::Attributes::Max, 128)
@@ -394,8 +392,6 @@ namespace ImageProcessingAtom
 
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default, &FlipbookSettings::m_numRows, "Number of rows", "Number of rows in the flipbook")
-                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
-                    ->Attribute(AZ::Edit::Attributes::ContainerCanBeModified, false)
                     ->ElementAttribute(AZ::Edit::UIHandlers::Handler, AZ::Edit::UIHandlers::Slider)
                     ->ElementAttribute(AZ::Edit::Attributes::Min, 0)
                     ->ElementAttribute(AZ::Edit::Attributes::Max, 128)

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/TextureSettings.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/TextureSettings.h
@@ -152,6 +152,30 @@ namespace ImageProcessingAtom
 
         AZStd::set<AZStd::string> m_tags;
 
+#if defined(CARBONATED)
+        // Describes the grid layout of frames packed in a 2D flipbook texture.
+        // Each tile becomes one depth slice of the resulting 3D volume texture.
+        struct FlipbookSettings
+        {
+            AZ_TYPE_INFO(FlipbookSettings, "{334D20DF-3D5D-42D7-B60F-C5AF7A00CB23}");
+            static void Reflect(AZ::ReflectContext* context);
+
+            AZ::u32 m_numColumns = 0;
+            AZ::u32 m_numRows = 0;
+
+            bool IsValid() const
+            {
+                return m_numColumns > 0 && m_numRows > 0;
+            }
+        };
+
+        // Optional flipbook settings. When valid (IsValid() == true), the input image is treated as a
+        // 2D flipbook: it will be sliced into frames and assembled into a 3D volume texture before the
+        // rest of the pipeline runs. The input image must already be in R32G32B32A32F at that point
+        // (i.e. after StepConvertToLinear). Ignored when the input already has EIF_Volumetexture set.
+        FlipbookSettings m_flipBookSettings;
+#endif // defined(CARBONATED)
+
     private:
         // Platform overrides in form of DataPatch. Each entry is a patch for a specified platform.
         // This map is used to generate TextureSettings with overridden values. The map is empty if

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Compressors/ASTCCompressor.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Compressors/ASTCCompressor.cpp
@@ -193,21 +193,116 @@ namespace ImageProcessingAtom
         const AZ::u32 dstMips = dstImage->GetMipCount();
         for (AZ::u32 mip = 0; mip < dstMips; ++mip)
         {
-            astcenc_image image;
-            image.dim_x = srcImage->GetWidth(mip);
-            image.dim_y = srcImage->GetHeight(mip);
-            image.dim_z = 1;
-            image.data_type = dataType;
-                        
             AZ::u8* srcMem;
             AZ::u32 srcPitch;
             srcImage->GetImagePointer(mip, srcMem, srcPitch);
-            image.data = reinterpret_cast<void**>(&srcMem);
-                        
+
             AZ::u8* dstMem;
             AZ::u32 dstPitch;
             dstImage->GetImagePointer(mip, dstMem, dstPitch);
+
+#if defined(CARBONATED)
+            const AZ::u32 mipWidth     = srcImage->GetWidth(mip);
+            const AZ::u32 mipHeight    = srcImage->GetHeight(mip);
+            const AZ::u32 mipDepth     = srcImage->GetDepth(mip);
+            const AZ::u32 srcSliceBytes = mipHeight * srcPitch;
+            const AZ::u32 dstSliceBytes = dstImage->GetMipBufSize(mip) / mipDepth;
+
+            for (AZ::u32 d = 0; d < mipDepth; ++d)
+            {
+                AZ::u8* sliceSrc = srcMem + d * srcSliceBytes;
+                AZ::u8* sliceDst = dstMem + d * dstSliceBytes;
+                AZ::u32 dataSize = dstSliceBytes;
+
+                astcenc_image image;
+                image.dim_x = mipWidth;
+                image.dim_y = mipHeight;
+                image.dim_z = 1;
+                image.data_type = dataType;
+                image.data = reinterpret_cast<void**>(&sliceSrc);
+
+                if (threadCount == 1)
+                {
+                    astcenc_error error = astcenc_compress_image(context, &image, &swizzle, sliceDst, dataSize, 0);
+                    if (error != ASTCENC_SUCCESS)
+                    {
+                        status = error;
+                    }
+                }
+                else
+                {
+                    AZ::JobCompletion* completionJob = nullptr;
+                    if (!currentJob)
+                    {
+                        completionJob = aznew AZ::JobCompletion();
+                    }
+                    // Create jobs for each compression thread
+                    for (AZ::u32 threadIdx = 0; threadIdx < threadCount; threadIdx++)
+                    {
+                        const auto jobLambda = [&status, context, &image, &swizzle, sliceDst, dataSize, threadIdx]()
+                        {
+                            astcenc_error error = astcenc_compress_image(context, &image, &swizzle, sliceDst, dataSize, threadIdx);
+                            if (error != ASTCENC_SUCCESS)
+                            {
+                                status = error;
+                            }
+                        };
+
+                        AZ::Job* simulationJob = AZ::CreateJobFunction(AZStd::move(jobLambda), true, nullptr);  //auto-deletes
+
+                        // adds this job as child to current job if there is a current job
+                        // otherwise adds it as a dependent for the complete job
+                        if (currentJob)
+                        {
+                            currentJob->StartAsChild(simulationJob);
+                        }
+                        else
+                        {
+                            simulationJob->SetDependent(completionJob);
+                            simulationJob->Start();
+                        }
+
+                        astcenc_error error = astcenc_compress_image(context, &image, &swizzle, sliceDst, dataSize, threadIdx);
+                        if (error != ASTCENC_SUCCESS)
+                        {
+                            status = error;
+                        }
+                    }
+
+                    if (currentJob)
+                    {
+                        currentJob->WaitForChildren();
+                    }
+
+                    if (completionJob)
+                    {
+                        completionJob->StartAndWaitForCompletion();
+                        delete completionJob;
+                        completionJob = nullptr;
+                    }
+                }
+
+                if (status != ASTCENC_SUCCESS)
+                {
+                    AZ_Error("Image Processing", false, "ASTCCompressor::CompressImage failed: %s\n", astcenc_get_error_string(status));
+                    astcenc_context_free(context);
+                    return nullptr;
+                }
+
+                // Reset context between depth slices (and between mips).
+                astcenc_compress_reset(context);
+            } // for: depth slices
+#else
+            const AZ::u32 mipWidth  = srcImage->GetWidth(mip);
+            const AZ::u32 mipHeight = srcImage->GetHeight(mip);
             AZ::u32 dataSize = dstImage->GetMipBufSize(mip);
+
+            astcenc_image image;
+            image.dim_x = mipWidth;
+            image.dim_y = mipHeight;
+            image.dim_z = 1;
+            image.data_type = dataType;
+            image.data = reinterpret_cast<void**>(&srcMem);
 
             if (threadCount == 1)
             {
@@ -256,7 +351,7 @@ namespace ImageProcessingAtom
                         status = error;
                     }
                 }
-                
+
                 if (currentJob)
                 {
                     currentJob->WaitForChildren();
@@ -277,9 +372,9 @@ namespace ImageProcessingAtom
                 return nullptr;
             }
 
-            // Need to reset to compress next mip
             astcenc_compress_reset(context);
-        }
+#endif // defined(CARBONATED)
+        } // for: mips
         astcenc_context_free(context);
 
         return dstImage;

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Compressors/ASTCCompressor.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Compressors/ASTCCompressor.cpp
@@ -236,16 +236,13 @@ namespace ImageProcessingAtom
                     {
                         completionJob = aznew AZ::JobCompletion();
                     }
+                    AZStd::vector<astcenc_error> jobResults(threadCount, ASTCENC_SUCCESS);
                     // Create jobs for each compression thread
                     for (AZ::u32 threadIdx = 0; threadIdx < threadCount; threadIdx++)
                     {
-                        const auto jobLambda = [&status, context, &image, &swizzle, sliceDst, dataSize, threadIdx]()
+                        const auto jobLambda = [&jobResults, context, &image, &swizzle, sliceDst, dataSize, threadIdx]()
                         {
-                            astcenc_error error = astcenc_compress_image(context, &image, &swizzle, sliceDst, dataSize, threadIdx);
-                            if (error != ASTCENC_SUCCESS)
-                            {
-                                status = error;
-                            }
+                            jobResults[threadIdx] = astcenc_compress_image(context, &image, &swizzle, sliceDst, dataSize, threadIdx);
                         };
 
                         AZ::Job* simulationJob = AZ::CreateJobFunction(AZStd::move(jobLambda), true, nullptr);  //auto-deletes
@@ -261,12 +258,6 @@ namespace ImageProcessingAtom
                             simulationJob->SetDependent(completionJob);
                             simulationJob->Start();
                         }
-
-                        astcenc_error error = astcenc_compress_image(context, &image, &swizzle, sliceDst, dataSize, threadIdx);
-                        if (error != ASTCENC_SUCCESS)
-                        {
-                            status = error;
-                        }
                     }
 
                     if (currentJob)
@@ -279,6 +270,16 @@ namespace ImageProcessingAtom
                         completionJob->StartAndWaitForCompletion();
                         delete completionJob;
                         completionJob = nullptr;
+                    }
+
+                    // Check the job results
+                    for(auto result : jobResults)
+                    {
+                        if (result != ASTCENC_SUCCESS)
+                        {
+                            status = result;
+                            break;
+                        }
                     }
                 }
 

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Compressors/ASTCCompressor.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Compressors/ASTCCompressor.cpp
@@ -193,6 +193,7 @@ namespace ImageProcessingAtom
         const AZ::u32 dstMips = dstImage->GetMipCount();
         for (AZ::u32 mip = 0; mip < dstMips; ++mip)
         {
+#if defined(CARBONATED)
             AZ::u8* srcMem;
             AZ::u32 srcPitch;
             srcImage->GetImagePointer(mip, srcMem, srcPitch);
@@ -201,7 +202,6 @@ namespace ImageProcessingAtom
             AZ::u32 dstPitch;
             dstImage->GetImagePointer(mip, dstMem, dstPitch);
 
-#if defined(CARBONATED)
             const AZ::u32 mipWidth     = srcImage->GetWidth(mip);
             const AZ::u32 mipHeight    = srcImage->GetHeight(mip);
             const AZ::u32 mipDepth     = srcImage->GetDepth(mip);
@@ -293,17 +293,21 @@ namespace ImageProcessingAtom
                 astcenc_compress_reset(context);
             } // for: depth slices
 #else
-            const AZ::u32 mipWidth  = srcImage->GetWidth(mip);
-            const AZ::u32 mipHeight = srcImage->GetHeight(mip);
-            AZ::u32 dataSize = dstImage->GetMipBufSize(mip);
-
             astcenc_image image;
-            image.dim_x = mipWidth;
-            image.dim_y = mipHeight;
+            image.dim_x = srcImage->GetWidth(mip);
+            image.dim_y = srcImage->GetHeight(mip);
             image.dim_z = 1;
             image.data_type = dataType;
+
+            AZ::u8* srcMem;
+            AZ::u32 srcPitch;
+            srcImage->GetImagePointer(mip, srcMem, srcPitch);
             image.data = reinterpret_cast<void**>(&srcMem);
 
+            AZ::u8* dstMem;
+            AZ::u32 dstPitch;
+            dstImage->GetImagePointer(mip, dstMem, dstPitch);
+            AZ::u32 dataSize = dstImage->GetMipBufSize(mip);
             if (threadCount == 1)
             {
                 astcenc_error error = astcenc_compress_image(context, &image, &swizzle, dstMem, dataSize, 0);
@@ -331,7 +335,7 @@ namespace ImageProcessingAtom
                         }
                     };
 
-                    AZ::Job* simulationJob = AZ::CreateJobFunction(AZStd::move(jobLambda), true, nullptr);  //auto-deletes
+                    AZ::Job* simulationJob = AZ::CreateJobFunction(AZStd::move(jobLambda), true, nullptr); // auto-deletes
 
                     // adds this job as child to current job if there is a current job
                     // otherwise adds it as a dependent for the complete job

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Compressors/CTSquisher.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Compressors/CTSquisher.cpp
@@ -342,15 +342,22 @@ namespace ImageProcessingAtom
             uint32 dwDstPitch;
             dstImage->GetImagePointer(dwMip, pDstMem, dwDstPitch);
 
+#if defined(CARBONATED)
+            uint32 dwLocalDepth = srcImage->GetDepth(dwMip);
+
+            const uint32 dwSrcSliceBytes = dwLocalHeight * dwSrcPitch;
+            const uint32 dwDstSliceBytes = dstImage->GetMipBufSize(dwMip) / dwLocalDepth;
+
+            for (uint32 d = 0; d < dwLocalDepth; ++d)
             {
                 CrySquisherCallbackUserData userData;
                 userData.m_pImageObject = dstImage;
                 userData.m_dstOffset = 0;
-                userData.m_dstMem = pDstMem;
+                userData.m_dstMem = pDstMem + d * dwDstSliceBytes;
 
                 CryTextureSquisher::CompressorParameters compress;
 
-                compress.srcBuffer = pSrcMem;
+                compress.srcBuffer = pSrcMem + d * dwSrcSliceBytes;
                 compress.width = dwLocalWidth;
                 compress.height = dwLocalHeight;
                 compress.pitch = dwSrcPitch;
@@ -385,7 +392,51 @@ namespace ImageProcessingAtom
                 compress.preset = GetCompressPreset(fmtDst, fmtSrc);
 
                 CryTextureSquisher::Compress(compress);
+            } // for: depth slices
+#else
+            CrySquisherCallbackUserData userData;
+            userData.m_pImageObject = dstImage;
+            userData.m_dstOffset = 0;
+            userData.m_dstMem = pDstMem;
+
+            CryTextureSquisher::CompressorParameters compress;
+
+            compress.srcBuffer = pSrcMem;
+            compress.width = dwLocalWidth;
+            compress.height = dwLocalHeight;
+            compress.pitch = dwSrcPitch;
+
+            compress.srcType = (CPixelFormats::GetInstance().IsFormatFloatingPoint(fmtSrc, true) ?
+                                CryTextureSquisher::eBufferType_ufloat : CryTextureSquisher::eBufferType_uint8);
+            if (CPixelFormats::GetInstance().IsFormatSigned(fmtDst))
+            {
+                compress.srcType = (compress.srcType == CryTextureSquisher::eBufferType_ufloat ?
+                                    CryTextureSquisher::eBufferType_sfloat : CryTextureSquisher::eBufferType_sint8);
             }
+
+            const AZ::Vector3 uniform = AZ::Vector3(0.3333f, 0.3334f, 0.3333f);
+
+            compress.weights[0] = weights.GetX();
+            compress.weights[1] = weights.GetY();
+            compress.weights[2] = weights.GetZ();
+
+            compress.perceptual =
+                (compress.weights[0] != uniform.GetX()) ||
+                (compress.weights[1] != uniform.GetY()) ||
+                (compress.weights[2] != uniform.GetZ());
+
+            compress.quality =
+                (quality == eQuality_Preview ? CryTextureSquisher::eQualityProfile_Low :
+                 (quality == eQuality_Fast ? CryTextureSquisher::eQualityProfile_Low :
+                  (quality == eQuality_Slow ? CryTextureSquisher::eQualityProfile_High :
+                   CryTextureSquisher::eQualityProfile_Medium)));
+
+            compress.userPtr = &userData;
+            compress.userOutputFunction = CrySquisherOutputCallback;
+            compress.preset = GetCompressPreset(fmtDst, fmtSrc);
+
+            CryTextureSquisher::Compress(compress);
+#endif // defined(CARBONATED)
         } // for: all mips
 
         return dstImage;

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Compressors/CTSquisher.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Compressors/CTSquisher.cpp
@@ -394,48 +394,51 @@ namespace ImageProcessingAtom
                 CryTextureSquisher::Compress(compress);
             } // for: depth slices
 #else
-            CrySquisherCallbackUserData userData;
-            userData.m_pImageObject = dstImage;
-            userData.m_dstOffset = 0;
-            userData.m_dstMem = pDstMem;
-
-            CryTextureSquisher::CompressorParameters compress;
-
-            compress.srcBuffer = pSrcMem;
-            compress.width = dwLocalWidth;
-            compress.height = dwLocalHeight;
-            compress.pitch = dwSrcPitch;
-
-            compress.srcType = (CPixelFormats::GetInstance().IsFormatFloatingPoint(fmtSrc, true) ?
-                                CryTextureSquisher::eBufferType_ufloat : CryTextureSquisher::eBufferType_uint8);
-            if (CPixelFormats::GetInstance().IsFormatSigned(fmtDst))
             {
-                compress.srcType = (compress.srcType == CryTextureSquisher::eBufferType_ufloat ?
-                                    CryTextureSquisher::eBufferType_sfloat : CryTextureSquisher::eBufferType_sint8);
+                CrySquisherCallbackUserData userData;
+                userData.m_pImageObject = dstImage;
+                userData.m_dstOffset = 0;
+                userData.m_dstMem = pDstMem;
+
+                CryTextureSquisher::CompressorParameters compress;
+
+                compress.srcBuffer = pSrcMem;
+                compress.width = dwLocalWidth;
+                compress.height = dwLocalHeight;
+                compress.pitch = dwSrcPitch;
+
+                compress.srcType =
+                    (CPixelFormats::GetInstance().IsFormatFloatingPoint(fmtSrc, true) ? CryTextureSquisher::eBufferType_ufloat
+                                                                                      : CryTextureSquisher::eBufferType_uint8);
+                if (CPixelFormats::GetInstance().IsFormatSigned(fmtDst))
+                {
+                    compress.srcType =
+                        (compress.srcType == CryTextureSquisher::eBufferType_ufloat ? CryTextureSquisher::eBufferType_sfloat
+                                                                                    : CryTextureSquisher::eBufferType_sint8);
+                }
+
+                const AZ::Vector3 uniform = AZ::Vector3(0.3333f, 0.3334f, 0.3333f);
+
+                compress.weights[0] = weights.GetX();
+                compress.weights[1] = weights.GetY();
+                compress.weights[2] = weights.GetZ();
+
+                compress.perceptual = (compress.weights[0] != uniform.GetX()) || (compress.weights[1] != uniform.GetY()) ||
+                    (compress.weights[2] != uniform.GetZ());
+
+                compress.quality =
+                    (quality == eQuality_Preview
+                         ? CryTextureSquisher::eQualityProfile_Low
+                         : (quality == eQuality_Fast ? CryTextureSquisher::eQualityProfile_Low
+                                                     : (quality == eQuality_Slow ? CryTextureSquisher::eQualityProfile_High
+                                                                                 : CryTextureSquisher::eQualityProfile_Medium)));
+
+                compress.userPtr = &userData;
+                compress.userOutputFunction = CrySquisherOutputCallback;
+                compress.preset = GetCompressPreset(fmtDst, fmtSrc);
+
+                CryTextureSquisher::Compress(compress);
             }
-
-            const AZ::Vector3 uniform = AZ::Vector3(0.3333f, 0.3334f, 0.3333f);
-
-            compress.weights[0] = weights.GetX();
-            compress.weights[1] = weights.GetY();
-            compress.weights[2] = weights.GetZ();
-
-            compress.perceptual =
-                (compress.weights[0] != uniform.GetX()) ||
-                (compress.weights[1] != uniform.GetY()) ||
-                (compress.weights[2] != uniform.GetZ());
-
-            compress.quality =
-                (quality == eQuality_Preview ? CryTextureSquisher::eQualityProfile_Low :
-                 (quality == eQuality_Fast ? CryTextureSquisher::eQualityProfile_Low :
-                  (quality == eQuality_Slow ? CryTextureSquisher::eQualityProfile_High :
-                   CryTextureSquisher::eQualityProfile_Medium)));
-
-            compress.userPtr = &userData;
-            compress.userOutputFunction = CrySquisherOutputCallback;
-            compress.preset = GetCompressPreset(fmtDst, fmtSrc);
-
-            CryTextureSquisher::Compress(compress);
 #endif // defined(CARBONATED)
         } // for: all mips
 

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Compressors/ISPCTextureCompressor.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Compressors/ISPCTextureCompressor.cpp
@@ -193,18 +193,73 @@ namespace ImageProcessingAtom
             uint32 sourcePitch = 0;
             AZ::u8* sourceImageData = nullptr;
             sourceImage->GetImagePointer(mip, sourceImageData, sourcePitch);
-            rgba_surface sourceSurface = {};
-            {
-                sourceSurface.ptr = sourceImageData;
-                sourceSurface.width = sourceImage->GetWidth(mip);
-                sourceSurface.height = sourceImage->GetHeight(mip);
-                sourceSurface.stride = static_cast<int32_t>(sourcePitch);
-            }
 
             // Get the mip image destination pointer
             uint32_t destinationPitch = 0;
             AZ::u8* destinationImageData = nullptr;
             destinationImage->GetImagePointer(mip, destinationImageData, destinationPitch);
+
+#if defined(CARBONATED)
+            const uint32_t mipWidth  = sourceImage->GetWidth(mip);
+            const uint32_t mipHeight = sourceImage->GetHeight(mip);
+            const uint32_t mipDepth  = sourceImage->GetDepth(mip);
+            const uint32_t srcSliceBytes = mipHeight * sourcePitch;
+            const uint32_t dstSliceBytes = destinationImage->GetMipBufSize(mip) / mipDepth;
+
+            for (uint32_t d = 0; d < mipDepth; ++d)
+            {
+                rgba_surface sourceSurface = {};
+                sourceSurface.ptr    = sourceImageData + d * srcSliceBytes;
+                sourceSurface.width  = mipWidth;
+                sourceSurface.height = mipHeight;
+                sourceSurface.stride = static_cast<int32_t>(sourcePitch);
+
+                AZ::u8* sliceDst = destinationImageData + d * dstSliceBytes;
+
+                // Compress with the correct function, depending on the destination format
+                switch (destinationFormat)
+                {
+                case ePixelFormat_BC3:
+                    CompressBlocksBC3(&sourceSurface, sliceDst);
+                    break;
+                case ePixelFormat_BC6UH:
+                {
+                    // Get the profile setter
+                    bc6h_enc_settings settings = {};
+                    const auto setProfile = compressionProfile->GetBC6();
+                    setProfile(&settings);
+
+                    // Compress with BC6 half precision
+                    CompressBlocksBC6H(&sourceSurface, sliceDst, &settings);
+                }
+                break;
+                case ePixelFormat_BC7:
+                case ePixelFormat_BC7t:
+                {
+                    // Get the profile setter
+                    bc7_enc_settings settings = {};
+                    const auto setProfile = compressionProfile->GetBC7(discardAlpha);
+                    setProfile(&settings);
+
+                    // Compress with BC7
+                    CompressBlocksBC7(&sourceSurface, sliceDst, &settings);
+                }
+                break;
+                default:
+                {
+                    // No valid pixel format
+                    AZ_Assert(false, "Unhandled pixel format %d", destinationFormat);
+                    return nullptr;
+                }
+                break;
+                }
+            } // for: depth slices
+#else
+            rgba_surface sourceSurface = {};
+            sourceSurface.ptr    = sourceImageData;
+            sourceSurface.width  = sourceImage->GetWidth(mip);
+            sourceSurface.height = sourceImage->GetHeight(mip);
+            sourceSurface.stride = static_cast<int32_t>(sourcePitch);
 
             // Compress with the correct function, depending on the destination format
             switch (destinationFormat)
@@ -243,6 +298,7 @@ namespace ImageProcessingAtom
             }
             break;
             }
+#endif // defined(CARBONATED)
         }
 
         return destinationImage;

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Compressors/ISPCTextureCompressor.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Compressors/ISPCTextureCompressor.cpp
@@ -204,8 +204,16 @@ namespace ImageProcessingAtom
             const uint32_t mipHeight = sourceImage->GetHeight(mip);
             const uint32_t mipDepth  = sourceImage->GetDepth(mip);
             const uint32_t srcSliceBytes = mipHeight * sourcePitch;
+            AZ_Assert(mipDepth > 0, "ISPCTextureCompressor: mip depth must be greater than zero");
+            AZ_Assert(
+                destinationImage->GetMipBufSize(mip) % mipDepth == 0,
+                "ISPCTextureCompressor: destination mip size is not evenly divisible by depth");
             const uint32_t dstSliceBytes = destinationImage->GetMipBufSize(mip) / mipDepth;
-
+            [[maybe_unused]] const uint32_t expectedBytes = ((mipWidth + 3) / 4) * ((mipHeight + 3) / 4) * 16;
+            AZ_Assert(
+                dstSliceBytes == expectedBytes,
+                "ISPCTextureCompressor: bytes per slice doesn't match the expected value: found %d, expected %d",
+                dstSliceBytes, expectedBytes);
             for (uint32_t d = 0; d < mipDepth; ++d)
             {
                 rgba_surface sourceSurface = {};

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Compressors/ISPCTextureCompressor.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Compressors/ISPCTextureCompressor.cpp
@@ -189,6 +189,7 @@ namespace ImageProcessingAtom
         const uint32 mipCount = destinationImage->GetMipCount();
         for (uint32_t mip = 0; mip < mipCount; mip++)
         {
+#if defined(CARBONATED)
             // Create rgba_surface as input
             uint32 sourcePitch = 0;
             AZ::u8* sourceImageData = nullptr;
@@ -199,7 +200,6 @@ namespace ImageProcessingAtom
             AZ::u8* destinationImageData = nullptr;
             destinationImage->GetImagePointer(mip, destinationImageData, destinationPitch);
 
-#if defined(CARBONATED)
             const uint32_t mipWidth  = sourceImage->GetWidth(mip);
             const uint32_t mipHeight = sourceImage->GetHeight(mip);
             const uint32_t mipDepth  = sourceImage->GetDepth(mip);
@@ -255,11 +255,22 @@ namespace ImageProcessingAtom
                 }
             } // for: depth slices
 #else
+            // Create rgba_surface as input
+            uint32 sourcePitch = 0;
+            AZ::u8* sourceImageData = nullptr;
+            sourceImage->GetImagePointer(mip, sourceImageData, sourcePitch);
             rgba_surface sourceSurface = {};
-            sourceSurface.ptr    = sourceImageData;
-            sourceSurface.width  = sourceImage->GetWidth(mip);
-            sourceSurface.height = sourceImage->GetHeight(mip);
-            sourceSurface.stride = static_cast<int32_t>(sourcePitch);
+            {
+                sourceSurface.ptr = sourceImageData;
+                sourceSurface.width = sourceImage->GetWidth(mip);
+                sourceSurface.height = sourceImage->GetHeight(mip);
+                sourceSurface.stride = static_cast<int32_t>(sourcePitch);
+            }
+
+            // Get the mip image destination pointer
+            uint32_t destinationPitch = 0;
+            AZ::u8* destinationImageData = nullptr;
+            destinationImage->GetImagePointer(mip, destinationImageData, destinationPitch);
 
             // Compress with the correct function, depending on the destination format
             switch (destinationFormat)

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/FlipbookSettingWidget.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/FlipbookSettingWidget.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "FlipbookSettingWidget.h"
+#include <Source/Editor/ui_FlipbookSettingWidget.h>
+
+#include <AzCore/Component/ComponentApplicationBus.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.hxx>
+
+namespace ImageProcessingAtomEditor
+{
+    using namespace ImageProcessingAtom;
+
+    FlipbookSettingWidget::FlipbookSettingWidget(EditorTextureSetting& textureSetting, QWidget* parent /*= nullptr*/)
+        : QWidget(parent)
+        , m_ui(new Ui::FlipbookSettingWidget)
+        , m_textureSetting(&textureSetting)
+    {
+        m_ui->setupUi(this);
+
+        AZ::SerializeContext* serializeContext = nullptr;
+        AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
+        AZ_Assert(serializeContext, "Serialization context not available");
+
+        m_ui->propertyEditor->SetAutoResizeLabels(true);
+        m_ui->propertyEditor->Setup(serializeContext, this, true, 250);
+        m_ui->propertyEditor->ClearInstances();
+
+        TextureSettings::FlipbookSettings* flipbookSettings = &m_textureSetting->GetMultiplatformTextureSetting().m_flipBookSettings;
+        m_ui->propertyEditor->AddInstance(flipbookSettings, AZ::SerializeTypeInfo<TextureSettings::FlipbookSettings>::GetUuid());
+        m_ui->propertyEditor->InvalidateAll();
+        m_ui->propertyEditor->ExpandAll();
+
+        EditorInternalNotificationBus::Handler::BusConnect();
+    }
+
+    FlipbookSettingWidget::~FlipbookSettingWidget()
+    {
+        EditorInternalNotificationBus::Handler::BusDisconnect();
+    }
+
+    void FlipbookSettingWidget::AfterPropertyModified(AzToolsFramework::InstanceDataNode* /*node*/)
+    {
+        m_textureSetting->PropagateCommonSettings();
+        m_ui->propertyEditor->InvalidateValues();
+        EditorInternalNotificationBus::Broadcast(&EditorInternalNotificationBus::Events::OnEditorSettingsChanged, false, BuilderSettingManager::s_defaultPlatform);
+    }
+
+    void FlipbookSettingWidget::OnEditorSettingsChanged(bool needRefresh, const AZStd::string& /*platform*/)
+    {
+        if (needRefresh)
+        {
+            m_ui->propertyEditor->InvalidateValues();
+        }
+    }
+}//namespace ImageProcessingAtomEditor
+#include <Source/Editor/moc_FlipbookSettingWidget.cpp>

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/FlipbookSettingWidget.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/FlipbookSettingWidget.h
@@ -22,6 +22,8 @@ namespace Ui
 
 namespace ImageProcessingAtomEditor
 {
+    //! Qt widget rendered inside the Texture Settings editor panel when the selected texture is detected as a flipbook (sprite sheet).
+    //! Exposes rows/columns and frame-rate fields.
     class FlipbookSettingWidget
         : public QWidget
         , public AzToolsFramework::IPropertyEditorNotify
@@ -35,6 +37,7 @@ namespace ImageProcessingAtomEditor
 
         // IPropertyEditorNotify
         void BeforePropertyModified([[maybe_unused]] AzToolsFramework::InstanceDataNode*) override {}
+        //! Propagates the changed flipbook property back to EditorTextureSetting and triggers an asset rebuild.
         void AfterPropertyModified(AzToolsFramework::InstanceDataNode* node) override;
         void SetPropertyEditingActive([[maybe_unused]] AzToolsFramework::InstanceDataNode*) override {}
         void SetPropertyEditingComplete([[maybe_unused]] AzToolsFramework::InstanceDataNode*) override {}
@@ -43,11 +46,12 @@ namespace ImageProcessingAtomEditor
     protected:
         ////////////////////////////////////////////////////////////////////////
         // EditorInternalNotificationBus
+        //! Refreshes the widget if the platform selection changes (flipbook columns/rows can differ per platform).
         void OnEditorSettingsChanged(bool needRefresh, const AZStd::string& platform) override;
         ////////////////////////////////////////////////////////////////////////
 
     private:
         QScopedPointer<Ui::FlipbookSettingWidget> m_ui;
-        EditorTextureSetting* m_textureSetting;
+        EditorTextureSetting* m_textureSetting; // non-owning pointer to the parent EditorTextureSetting; valid for the lifetime of the panel
     };
 } //namespace ImageProcessingAtomEditor

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/FlipbookSettingWidget.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/FlipbookSettingWidget.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#if !defined(Q_MOC_RUN)
+#include <QWidget>
+#include <AzCore/Memory/SystemAllocator.h>
+#include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
+#include <Source/Editor/EditorCommon.h>
+#endif
+
+namespace Ui
+{
+    class FlipbookSettingWidget;
+}
+
+namespace ImageProcessingAtomEditor
+{
+    class FlipbookSettingWidget
+        : public QWidget
+        , public AzToolsFramework::IPropertyEditorNotify
+        , protected EditorInternalNotificationBus::Handler
+    {
+        Q_OBJECT
+    public:
+        AZ_CLASS_ALLOCATOR(FlipbookSettingWidget, AZ::SystemAllocator);
+        explicit FlipbookSettingWidget(EditorTextureSetting& textureSetting, QWidget* parent = nullptr);
+        ~FlipbookSettingWidget();
+
+        // IPropertyEditorNotify
+        void BeforePropertyModified([[maybe_unused]] AzToolsFramework::InstanceDataNode*) override {}
+        void AfterPropertyModified(AzToolsFramework::InstanceDataNode* node) override;
+        void SetPropertyEditingActive([[maybe_unused]] AzToolsFramework::InstanceDataNode*) override {}
+        void SetPropertyEditingComplete([[maybe_unused]] AzToolsFramework::InstanceDataNode*) override {}
+        void SealUndoStack() override {}
+
+    protected:
+        ////////////////////////////////////////////////////////////////////////
+        // EditorInternalNotificationBus
+        void OnEditorSettingsChanged(bool needRefresh, const AZStd::string& platform) override;
+        ////////////////////////////////////////////////////////////////////////
+
+    private:
+        QScopedPointer<Ui::FlipbookSettingWidget> m_ui;
+        EditorTextureSetting* m_textureSetting;
+    };
+} //namespace ImageProcessingAtomEditor

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/FlipbookSettingWidget.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/FlipbookSettingWidget.h
@@ -23,7 +23,7 @@ namespace Ui
 namespace ImageProcessingAtomEditor
 {
     //! Qt widget rendered inside the Texture Settings editor panel when the selected texture is detected as a flipbook (sprite sheet).
-    //! Exposes rows/columns and frame-rate fields.
+    //! Exposes rows/columns of the flipbook.
     class FlipbookSettingWidget
         : public QWidget
         , public AzToolsFramework::IPropertyEditorNotify
@@ -46,7 +46,7 @@ namespace ImageProcessingAtomEditor
     protected:
         ////////////////////////////////////////////////////////////////////////
         // EditorInternalNotificationBus
-        //! Refreshes the widget if the platform selection changes (flipbook columns/rows can differ per platform).
+        //! Refreshes the widget if the platform selection changes.
         void OnEditorSettingsChanged(bool needRefresh, const AZStd::string& platform) override;
         ////////////////////////////////////////////////////////////////////////
 

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/FlipbookSettingWidget.ui
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/FlipbookSettingWidget.ui
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+    <class>FlipbookSettingWidget</class>
+    <widget class="QWidget" name="FlipbookSettingWidget">
+        <property name="geometry">
+            <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>461</width>
+                <height>90</height>
+            </rect>
+        </property>
+        <property name="maximumSize">
+            <size>
+                <width>16777215</width>
+                <height>70</height>
+            </size>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout">
+            <property name="leftMargin"><number>0</number></property>
+            <property name="topMargin"><number>0</number></property>
+            <property name="rightMargin"><number>0</number></property>
+            <property name="bottomMargin"><number>0</number></property>
+            <item>
+                <widget class="AzToolsFramework::ReflectedPropertyEditor" name="propertyEditor"/>
+            </item>
+        </layout>
+    </widget>
+    <customwidgets>
+        <customwidget>
+            <class>AzToolsFramework::ReflectedPropertyEditor</class>
+            <extends>QFrame</extends>
+            <header location="global">AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.hxx</header>
+            <container>1</container>
+        </customwidget>
+    </customwidgets>
+    <resources/>
+    <connections/>
+</ui>

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/TexturePropertyEditor.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/TexturePropertyEditor.cpp
@@ -76,6 +76,12 @@ namespace ImageProcessingAtomEditor
         m_resolutionSettingWidget.reset(aznew ResolutionSettingWidget(ResoultionWidgetType::TexturePropety, m_textureSetting, this));
         m_ui->settingsLayout->layout()->addWidget(m_resolutionSettingWidget.data());
 
+#if defined(CARBONATED)
+        //FlipbookSettingWidget shows the flipbook grid layout settings for volume texture conversion
+        m_flipbookSettingWidget.reset(aznew FlipbookSettingWidget(m_textureSetting, this));
+        m_ui->settingsLayout->layout()->addWidget(m_flipbookSettingWidget.data());
+#endif // defined(CARBONATED)
+
         //MipmapSettingWidget will be simple ReflectedProperty editor to reflect mipmap settings section
         m_mipmapSettingWidget.reset(aznew MipmapSettingWidget(m_textureSetting, this));
         m_ui->settingsLayout->layout()->addWidget(m_mipmapSettingWidget.data());

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/TexturePropertyEditor.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/TexturePropertyEditor.h
@@ -24,6 +24,9 @@ AZ_POP_DISABLE_WARNING
 #include <Source/Editor/TexturePreviewWidget.h>
 #include <Source/Editor/ResolutionSettingWidget.h>
 #include <Source/Editor/MipmapSettingWidget.h>
+#if defined(CARBONATED)
+#include <Source/Editor/FlipbookSettingWidget.h>
+#endif // defined(CARBONATED)
 #endif
 
 namespace Ui
@@ -63,6 +66,9 @@ namespace ImageProcessingAtomEditor
         QScopedPointer<TexturePresetSelectionWidget> m_presetSelectionWidget;
         QScopedPointer<ResolutionSettingWidget> m_resolutionSettingWidget;
         QScopedPointer<MipmapSettingWidget> m_mipmapSettingWidget;
+#if defined(CARBONATED)
+        QScopedPointer<FlipbookSettingWidget> m_flipbookSettingWidget;
+#endif // defined(CARBONATED)
 
         EditorTextureSetting m_textureSetting;
         bool m_validImage = true;

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/TexturePropertyEditor.ui
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/TexturePropertyEditor.ui
@@ -5,13 +5,13 @@
         <property name="minimumSize">
             <size>
                 <width>1000</width>
-                <height>604</height>
+                <height>704</height>
             </size>
         </property>
         <property name="maximumSize">
             <size>
                 <width>1000</width>
-                <height>604</height>
+                <height>704</height>
             </size>
         </property>
         <property name="windowTitle">
@@ -24,7 +24,7 @@
                     <x>0</x>
                     <y>0</y>
                     <width>532</width>
-                    <height>572</height>
+                    <height>672</height>
                 </rect>
             </property>
             <layout class="QVBoxLayout" name="mainLayout">
@@ -40,7 +40,7 @@
                     <x>532</x>
                     <y>0</y>
                     <width>468</width>
-                    <height>572</height>
+                    <height>672</height>
                 </rect>
             </property>
             <layout class="QVBoxLayout" name="settingsLayout">
@@ -54,7 +54,7 @@
             <property name="geometry">
                 <rect>
                     <x>0</x>
-                    <y>572</y>
+                    <y>672</y>
                     <width>1000</width>
                     <height>32</height>
                 </rect>

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageConvert.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageConvert.cpp
@@ -586,9 +586,7 @@ namespace ImageProcessingAtom
     }
 
 #if defined(CARBONATED)
-    // ──────────────────────────────────────────────────────────────────────────────
     // Flipbook / volume texture helpers
-    // ──────────────────────────────────────────────────────────────────────────────
 
     static inline AZ::u8* SlicePtr(AZ::u8* base, AZ::u32 sliceIndex, AZ::u32 rowCount, AZ::u32 pitch)
     {
@@ -633,7 +631,7 @@ namespace ImageProcessingAtom
         const AZ::u32 frameW = totalW / numCols;
         const AZ::u32 frameH = totalH / numRows;
         const AZ::u32 depth  = numCols * numRows;
-        constexpr AZ::u32 bytesPerPixel = 16; // R32G32B32A32F: 4 channels × 4 bytes
+        constexpr AZ::u32 bytesPerPixel = 16; // R32G32B32A32F: 4 channels x 4 bytes
 
         IImageObjectPtr volumeImage(IImageObject::CreateImage(frameW, frameH, depth, 1, ePixelFormat_R32G32B32A32F));
         volumeImage->CopyPropertiesFrom(srcImage);
@@ -676,7 +674,7 @@ namespace ImageProcessingAtom
         const AZ::u32 dstD = dstImg->GetDepth(dstMip);
         constexpr AZ::u32 numChannels = 4;
 
-        // Step 1: XY resample — filter each source slice from (srcW x srcH) to (dstW x dstH).
+        // Step 1: XY resample. Filter each source slice from (srcW x srcH) to (dstW x dstH).
         IImageObjectPtr xyFiltered(IImageObject::CreateImage(dstW, dstH, srcD, 1, ePixelFormat_R32G32B32A32F));
         xyFiltered->AddImageFlags(EIF_Volumetexture);
 
@@ -706,7 +704,7 @@ namespace ImageProcessingAtom
             }
         }
 
-        // Step 2: Z box filter — average (srcD / dstD) consecutive XY-filtered slices per output slice.
+        // Step 2: Z box filter. Average (srcD / dstD) consecutive XY-filtered slices per output slice.
         AZ::u8* dstMem; AZ::u32 dstPitch;
         dstImg->GetImagePointer(dstMip, dstMem, dstPitch);
 

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageConvert.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageConvert.cpp
@@ -21,7 +21,11 @@
 #include <BuilderSettings/PresetSettings.h>
 
 
+#if defined(CARBONATED)
+#include <AzCore/std/algorithm.h>
+#endif // defined(CARBONATED)
 #include <AzCore/std/time.h>
+
 #include <AzCore/StringFunc/StringFunc.h>
 
 #include <Atom/RHI.Reflect/Format.h>
@@ -52,6 +56,9 @@ namespace ImageProcessingAtom
     {
         StepValidateInput = 0,
         StepConvertToLinear,
+#if defined(CARBONATED)
+        StepConvertFromFlipbook, // Assemble 2D flipbook frames into a 3D volume texture (no-op when not a flipbook).
+#endif // defined(CARBONATED)
         StepSwizzle,
         StepCubemapLayout,
         StepPreNormalize,
@@ -70,6 +77,9 @@ namespace ImageProcessingAtom
     {
         "ValidateInput",
         "ConvertToLinear",
+#if defined(CARBONATED)
+        "ConvertFromFlipbook",
+#endif // defined(CARBONATED)
         "Swizzle",
         "CubemapLayout",
         "PreNormalize",
@@ -144,6 +154,13 @@ namespace ImageProcessingAtom
         return (cubemapSettings != nullptr && cubemapSettings->m_requiresConvolve == false);
     }
 
+#if defined(CARBONATED)
+    bool ImageConvertProcess::IsFlipbook()
+    {
+        return m_input->m_textureSetting.m_flipBookSettings.IsValid();
+    }
+#endif // defined(CARBONATED)
+
     void ImageConvertProcess::UpdateProcess()
     {
         if (m_isFinished)
@@ -192,6 +209,20 @@ namespace ImageProcessingAtom
             // convert to linear space and the output image pixel format should be rgba32f
             ConvertToLinear();
             break;
+#if defined(CARBONATED)
+        case StepConvertFromFlipbook:
+            // When the input descriptor carries valid FlipbookSettings, slice the current
+            // 2D image (already in R32G32B32A32F from StepConvertToLinear) into a 3D volume
+            // texture. For all other inputs this step is a no-op.
+            if (IsFlipbook())
+            {
+                if (!ConvertFromFlipbook())
+                {
+                    m_image->Set(nullptr);
+                }
+            }
+            break;
+#endif // defined(CARBONATED)
         case StepSwizzle:
             {
                 // swizzle if swizzle was set or decard alpha
@@ -289,6 +320,16 @@ namespace ImageProcessingAtom
                     }
                 }
             }
+#if defined(CARBONATED)
+            else if (m_image->Get() && m_image->Get()->HasImageFlags(EIF_Volumetexture))
+            {
+                if (!FillVolumeMipmaps())
+                {
+                    m_isSucceed = false;
+                    m_isFinished = true;
+                }
+            }
+#endif // defined(CARBONATED)
             else
             {
                 FillMipmaps();
@@ -543,6 +584,233 @@ namespace ImageProcessingAtom
         m_image->Set(outImage);
         return true;
     }
+
+#if defined(CARBONATED)
+    // ──────────────────────────────────────────────────────────────────────────────
+    // Flipbook / volume texture helpers
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    static inline AZ::u8* SlicePtr(AZ::u8* base, AZ::u32 sliceIndex, AZ::u32 rowCount, AZ::u32 pitch)
+    {
+        return base + static_cast<size_t>(sliceIndex) * rowCount * pitch;
+    }
+
+    static inline const AZ::u8* SlicePtrConst(const AZ::u8* base, AZ::u32 sliceIndex, AZ::u32 rowCount, AZ::u32 pitch)
+    {
+        return base + static_cast<size_t>(sliceIndex) * rowCount * pitch;
+    }
+
+    IImageObjectPtr CreateVolumeTextureFromFlipbook(const IImageObjectPtr& srcImage, const TextureSettings::FlipbookSettings& settings)
+    {
+        if (!settings.IsValid())
+        {
+            AZ_Error("Image Processing", false,
+                "CreateVolumeTextureFromFlipbook: FlipbookSettings must have non-zero numColumns and numRows");
+            return nullptr;
+        }
+
+        if (!srcImage || srcImage->GetPixelFormat() != ePixelFormat_R32G32B32A32F)
+        {
+            AZ_Error("Image Processing", false,
+                "CreateVolumeTextureFromFlipbook: source image must be in R32G32B32A32F format");
+            return nullptr;
+        }
+
+        const AZ::u32 numCols = settings.m_numColumns;
+        const AZ::u32 numRows = settings.m_numRows;
+        const AZ::u32 totalW  = srcImage->GetWidth(0);
+        const AZ::u32 totalH  = srcImage->GetHeight(0);
+
+        if (totalW % numCols != 0 || totalH % numRows != 0)
+        {
+            AZ_Error("Image Processing", false,
+                "CreateVolumeTextureFromFlipbook: source image size (%ux%u) is not evenly divisible "
+                "by the flipbook grid (%ux%u)",
+                totalW, totalH, numCols, numRows);
+            return nullptr;
+        }
+
+        const AZ::u32 frameW = totalW / numCols;
+        const AZ::u32 frameH = totalH / numRows;
+        const AZ::u32 depth  = numCols * numRows;
+        constexpr AZ::u32 bytesPerPixel = 16; // R32G32B32A32F: 4 channels × 4 bytes
+
+        IImageObjectPtr volumeImage(IImageObject::CreateImage(frameW, frameH, depth, 1, ePixelFormat_R32G32B32A32F));
+        volumeImage->CopyPropertiesFrom(srcImage);
+        volumeImage->AddImageFlags(EIF_Volumetexture);
+
+        AZ::u8* srcMem; AZ::u32 srcPitch;
+        srcImage->GetImagePointer(0, srcMem, srcPitch);
+
+        AZ::u8* dstMem; AZ::u32 dstPitch;
+        volumeImage->GetImagePointer(0, dstMem, dstPitch);
+
+        for (AZ::u32 frameIdx = 0; frameIdx < depth; ++frameIdx)
+        {
+            const AZ::u32 colIdx = frameIdx % numCols;
+            const AZ::u32 rowIdx = frameIdx / numCols;
+
+            for (AZ::u32 y = 0; y < frameH; ++y)
+            {
+                const AZ::u32 srcY = rowIdx * frameH + y;
+                const AZ::u8* srcRow = srcMem + srcY * srcPitch + colIdx * frameW * bytesPerPixel;
+                AZ::u8* dstRow = SlicePtr(dstMem, frameIdx, frameH, dstPitch) + y * dstPitch;
+                memcpy(dstRow, srcRow, frameW * bytesPerPixel);
+            }
+        }
+
+        return volumeImage;
+    }
+
+    void FilterVolumeImage(
+        MipGenType filterType,
+        MipGenEvalType evalType,
+        const IImageObjectPtr& srcImg, AZ::u32 srcMip,
+        IImageObjectPtr& dstImg, AZ::u32 dstMip)
+    {
+        const AZ::u32 srcW = srcImg->GetWidth(srcMip);
+        const AZ::u32 srcH = srcImg->GetHeight(srcMip);
+        const AZ::u32 srcD = srcImg->GetDepth(srcMip);
+        const AZ::u32 dstW = dstImg->GetWidth(dstMip);
+        const AZ::u32 dstH = dstImg->GetHeight(dstMip);
+        const AZ::u32 dstD = dstImg->GetDepth(dstMip);
+        constexpr AZ::u32 numChannels = 4;
+
+        // Step 1: XY resample — filter each source slice from (srcW x srcH) to (dstW x dstH).
+        IImageObjectPtr xyFiltered(IImageObject::CreateImage(dstW, dstH, srcD, 1, ePixelFormat_R32G32B32A32F));
+        xyFiltered->AddImageFlags(EIF_Volumetexture);
+
+        IImageObjectPtr srcSlice(IImageObject::CreateImage(srcW, srcH, 1, 1, ePixelFormat_R32G32B32A32F));
+        IImageObjectPtr dstSlice(IImageObject::CreateImage(dstW, dstH, 1, 1, ePixelFormat_R32G32B32A32F));
+
+        AZ::u8* srcMem; AZ::u32 srcPitch;
+        srcImg->GetImagePointer(srcMip, srcMem, srcPitch);
+
+        AZ::u8* filtMem; AZ::u32 filtPitch;
+        xyFiltered->GetImagePointer(0, filtMem, filtPitch);
+
+        for (AZ::u32 d = 0; d < srcD; ++d)
+        {
+            {
+                AZ::u8* sliceMem; AZ::u32 slicePitch;
+                srcSlice->GetImagePointer(0, sliceMem, slicePitch);
+                memcpy(sliceMem, SlicePtr(srcMem, d, srcH, srcPitch), srcH * srcPitch);
+            }
+
+            FilterImage(filterType, evalType, 0.0f, 0.0f, srcSlice, 0, dstSlice, 0, nullptr, nullptr);
+
+            {
+                AZ::u8* sliceMem; AZ::u32 slicePitch;
+                dstSlice->GetImagePointer(0, sliceMem, slicePitch);
+                memcpy(SlicePtr(filtMem, d, dstH, filtPitch), sliceMem, dstH * filtPitch);
+            }
+        }
+
+        // Step 2: Z box filter — average (srcD / dstD) consecutive XY-filtered slices per output slice.
+        AZ::u8* dstMem; AZ::u32 dstPitch;
+        dstImg->GetImagePointer(dstMip, dstMem, dstPitch);
+
+        const AZ::u32 ratio = AZStd::max(srcD / dstD, 1u);
+        const float invRatio = 1.0f / static_cast<float>(ratio);
+
+        for (AZ::u32 d = 0; d < dstD; ++d)
+        {
+            const AZ::u32 firstSrcSlice = d * ratio;
+
+            for (AZ::u32 y = 0; y < dstH; ++y)
+            {
+                float* dst = reinterpret_cast<float*>(SlicePtr(dstMem, d, dstH, dstPitch) + y * dstPitch);
+
+                const float* row0 = reinterpret_cast<const float*>(
+                    SlicePtrConst(filtMem, firstSrcSlice, dstH, filtPitch) + y * filtPitch);
+                memcpy(dst, row0, dstW * numChannels * sizeof(float));
+
+                for (AZ::u32 s = 1; s < ratio; ++s)
+                {
+                    const float* rowS = reinterpret_cast<const float*>(
+                        SlicePtrConst(filtMem, firstSrcSlice + s, dstH, filtPitch) + y * filtPitch);
+                    for (AZ::u32 x = 0; x < dstW * numChannels; ++x)
+                    {
+                        dst[x] += rowS[x];
+                    }
+                }
+
+                if (ratio > 1)
+                {
+                    for (AZ::u32 x = 0; x < dstW * numChannels; ++x)
+                    {
+                        dst[x] *= invRatio;
+                    }
+                }
+            }
+        }
+    }
+
+    bool ImageConvertProcess::ConvertFromFlipbook()
+    {
+        const EPixelFormat srcPixelFormat = m_image->Get()->GetPixelFormat();
+        if (srcPixelFormat != ePixelFormat_R32G32B32A32F)
+        {
+            AZ_Assert(false, "%s requires pixel format R32G32B32A32F (run after StepConvertToLinear)", __FUNCTION__);
+            return false;
+        }
+
+        IImageObjectPtr volumeImage = CreateVolumeTextureFromFlipbook(m_image->Get(), m_input->m_textureSetting.m_flipBookSettings);
+        if (!volumeImage)
+        {
+            return false;
+        }
+
+        m_image->Set(volumeImage);
+        return true;
+    }
+
+    bool ImageConvertProcess::FillVolumeMipmaps()
+    {
+        const EPixelFormat srcPixelFormat = m_image->Get()->GetPixelFormat();
+        if (srcPixelFormat != ePixelFormat_R32G32B32A32F)
+        {
+            AZ_Assert(false, "%s only works with pixel format R32G32B32A32F", __FUNCTION__);
+            return false;
+        }
+
+        if (m_image->Get()->GetMipCount() != 1)
+        {
+            AZ_Assert(false, "%s called for an already-mipmapped image", __FUNCTION__);
+            return false;
+        }
+
+        // Determine the desired XY output size, same as the 2D FillMipmaps.
+        // Size reduction (maxTextureSize, sizeReduceLevel, etc.) is absorbed into mip 0
+        // by GenerateVolumeMipmaps, which always filters directly from the original source.
+        AZ::u32 outWidth, outHeight, outReduce;
+        GetOutputExtent(
+            m_image->Get()->GetWidth(0), m_image->Get()->GetHeight(0),
+            outWidth, outHeight, outReduce,
+            &m_input->m_textureSetting, &m_input->m_presetSetting);
+
+        const AZ::u32 mipCount =
+            (m_input->m_presetSetting.m_mipmapSetting == nullptr || !m_input->m_textureSetting.m_enableMipmap)
+            ? 1
+            : UINT32_MAX;
+
+        const AZ::u32 depth = m_image->Get()->GetDepth(0);
+        IImageObjectPtr outImage(IImageObject::CreateImage(outWidth, outHeight, depth, mipCount, ePixelFormat_R32G32B32A32F));
+        outImage->CopyPropertiesFrom(m_image->Get());
+
+        for (AZ::u32 mip = 0; mip < outImage->GetMipCount(); ++mip)
+        {
+            FilterVolumeImage(
+                m_input->m_textureSetting.m_mipGenType,
+                m_input->m_textureSetting.m_mipGenEval,
+                m_image->Get(), 0,
+                outImage, mip);
+        }
+
+        m_image->Set(outImage);
+        return true;
+    }
+#endif // defined(CARBONATED)
 
     // Set (alpha-weighted) average color computed from given mip
     bool ImageConvertProcess::SetAverageColor(AZ::u32 mip)

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageConvert.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageConvert.h
@@ -61,6 +61,19 @@ namespace ImageProcessingAtom
     void GetOutputExtent(AZ::u32 inputWidth, AZ::u32 inputHeight, AZ::u32& outWidth, AZ::u32& outHeight, AZ::u32& outReduce,
         const TextureSettings* textureSettings, const PresetSettings* presetSettings);
 
+#if defined(CARBONATED)
+    // Converts a 2D flipbook texture into a 3D volume texture (R32G32B32A32F, EIF_Volumetexture).
+    IImageObjectPtr CreateVolumeTextureFromFlipbook(const IImageObjectPtr& srcImage, const TextureSettings::FlipbookSettings& settings);
+
+    // Fills one mip level of a 3D volume texture from a source volume texture.
+    // XY is resampled via FilterImage; Z is reduced with a box filter.
+    void FilterVolumeImage(
+        MipGenType filterType,
+        MipGenEvalType evalType,
+        const IImageObjectPtr& srcImg, AZ::u32 srcMip,
+        IImageObjectPtr& dstImg, AZ::u32 dstMip);
+#endif // defined(CARBONATED)
+
     // The structure used to create a ImageConvertProcess
     struct ImageConvertProcessDescriptor
     {
@@ -162,6 +175,17 @@ namespace ImageProcessingAtom
         //mipmap generation for cubemap
         bool FillCubemapMipmaps();
 
+#if defined(CARBONATED)
+        // Converts the current 2D processing image into a 3D volume texture using the
+        // FlipbookSettings from the input descriptor. Called from StepConvertFromFlipbook.
+        bool ConvertFromFlipbook();
+
+        // Mipmap generation for 3D volume textures. Respects the enableMipmap setting and
+        // applies GetOutputExtent for XY size reduction. Called from StepMipmap when the
+        // current image has EIF_Volumetexture set.
+        bool FillVolumeMipmaps();
+#endif // defined(CARBONATED)
+
         //set (alpha-weighted) average color computed from given mip
         bool SetAverageColor(AZ::u32 mip);
 
@@ -185,5 +209,10 @@ namespace ImageProcessingAtom
 
         //if the input image is a pre-convolved cubemap
         bool IsPreconvolvedCubemap();
+
+#if defined(CARBONATED)
+        //if the input is a 2D flipbook
+        bool IsFlipbook();
+#endif // defined(CARBONATED)
     };
 }// namespace ImageProcessingAtom

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/imageprocessing_files.cmake
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/imageprocessing_files.cmake
@@ -69,6 +69,11 @@ set(FILES
     Source/Editor/ImagePopup.h
     Source/Editor/ImagePopup.ui
     Source/Editor/ImageProcessing.qrc
+# Begin Carbonated
+    Source/Editor/FlipbookSettingWidget.cpp
+    Source/Editor/FlipbookSettingWidget.h
+    Source/Editor/FlipbookSettingWidget.ui
+# End Carbonated
     Source/Editor/MipmapSettingWidget.cpp
     Source/Editor/MipmapSettingWidget.h
     Source/Editor/MipmapSettingWidget.ui

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Common/TransparentPassVertexAndPixel.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Common/TransparentPassVertexAndPixel.azsli
@@ -8,6 +8,10 @@
  
 #pragma once
 
+// Begin Carbonated
+#include <Atom/Features/VolumetricFog/ApplyVolumetricFog.azsli>
+// End Carbonated
+
 struct ForwardPassOutput
 {
     [[vk::location(0), vk::index(0)]]
@@ -54,7 +58,10 @@ ForwardPassOutput PixelShader(VsOutput IN, bool isFrontFace : SV_IsFrontFace)
     float3 specular = lightingData.specularLighting.rgb;
     specular = lerp(specular, specular * surface.alpha, surface.opacityAffectsSpecularFactor);
 
-    OUT.m_color1.rgb = diffuse + specular;
+// Begin Carbonated
+    OUT.m_color1.rgb = ApplyVolumetricFog(diffuse + specular, surface.position).rgb;
+// was: OUT.m_color1.rgb = diffuse + specular;
+// End Carbonated
 
     // Increase opacity at grazing angles for surfaces with a low m_opacityAffectsSpecularFactor.
     // For m_opacityAffectsSpecularFactor values close to 0, that indicates a transparent surface

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/ForwardPass_BaseLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/ForwardPass_BaseLighting.azsli
@@ -40,6 +40,9 @@
 #define ENABLE_SPECULARAA 0
 #define ENABLE_PARALLAX 0
 #define ENABLE_MOBILEBRDF 1
+// CARBONATED
+#define ENABLE_VOLUMETRIC_FOG 0
+//CARBONATED
 
 
 //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/ForwardPass_StandardLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/ForwardPass_StandardLighting.azsli
@@ -41,6 +41,9 @@
 #define ENABLE_SPECULARAA 0
 #define ENABLE_PARALLAX 0
 #define ENABLE_MOBILEBRDF 1
+// CARBONATED
+#define ENABLE_VOLUMETRIC_FOG 0
+//CARBONATED
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/ForwardPass_StandardLighting_CustomZ.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/ForwardPass_StandardLighting_CustomZ.azsli
@@ -41,6 +41,9 @@
 #define ENABLE_SPECULARAA 0
 #define ENABLE_PARALLAX 0
 #define ENABLE_MOBILEBRDF 1
+// CARBONATED
+#define ENABLE_VOLUMETRIC_FOG 0
+//CARBONATED
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/Transparent_StandardLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Pipelines/Mobile/Transparent_StandardLighting.azsli
@@ -40,6 +40,9 @@
 #define ENABLE_SPECULARAA 0
 #define ENABLE_PARALLAX 0
 #define ENABLE_MOBILEBRDF 1
+// CARBONATED
+#define ENABLE_VOLUMETRIC_FOG 0
+//CARBONATED
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/Gems/Atom/Feature/Common/Assets/Passes/FroxelComposite.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/FroxelComposite.pass
@@ -1,0 +1,37 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "FroxelCompositePassTemplate",
+            "PassClass": "FullScreenTriangle",
+            "Slots": [
+                {
+                    "Name": "RenderTargetInputOutput",
+                    "SlotType": "InputOutput",
+                    "ScopeAttachmentUsage": "RenderTarget"
+                },
+                {
+                    "Name": "FroxelIntegrated",
+                    "ShaderInputName": "m_froxelIntegrated",
+                    "SlotType": "Input",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                {
+                    "Name": "InputLinearDepth",
+                    "SlotType": "Input",
+                    "ShaderInputName": "m_linearDepthTexture",
+                    "ScopeAttachmentUsage": "Shader"
+                }
+            ],
+            "PassData": {
+                "$type": "FullscreenTrianglePassData",
+                "ShaderAsset": {
+                    "FilePath": "Shaders/VolumetricFog/FroxelComposite.shader"
+                },
+                "BindViewSrg": true
+            }
+        }
+    }
+}

--- a/Gems/Atom/Feature/Common/Assets/Passes/FroxelInject.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/FroxelInject.pass
@@ -1,0 +1,77 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "FroxelInjectTemplate",
+            "PassClass": "FroxelPass",
+            "Slots": [
+                {
+                    "Name": "FroxelVolume",
+                    "SlotType": "Output",
+                    "ShaderInputName": "m_froxelVolume",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                {
+                    "Name": "FroxelEmissive",
+                    "SlotType": "Output",
+                    "ShaderInputName": "m_froxelEmissive",
+                    "ScopeAttachmentUsage": "Shader"
+                }
+            ],
+            "ImageAttachments": [
+                {
+                    "Name": "FroxelVolume",
+                    "SizeSource": {
+                        "Source": {
+                            "Pass": "Parent",
+                            "Attachment": "PipelineOutput"
+                        }
+                    },
+                    "ImageDescriptor": {
+                        "Format": "R16G16B16A16_FLOAT",
+                        "Dimension" : 3
+                    }
+                },
+                {
+                    "Name": "FroxelEmissive",
+                    "SizeSource": {
+                        "Source": {
+                            "Pass": "This",
+                            "Attachment": "FroxelVolume"
+                        }
+                    },
+                    "ImageDescriptor": {
+                        "Format": "R11G11B10_FLOAT",
+                        "Dimension" : 3
+                    }
+                }
+            ],
+            "Connections": [
+                {
+                    "LocalSlot": "FroxelVolume",
+                    "AttachmentRef": {
+                        "Pass": "This",
+                        "Attachment": "FroxelVolume"
+                    }
+                },
+                {
+                    "LocalSlot": "FroxelEmissive",
+                    "AttachmentRef": {
+                        "Pass": "This",
+                        "Attachment": "FroxelEmissive"
+                    }
+                }
+            ],             
+            "PassData": {
+                "$type": "ComputePassData",
+                "ShaderAsset": {
+                    "FilePath": "Shaders/VolumetricFog/FroxelInject.shader"
+                },
+                "Make Fullscreen Pass": true,
+                "BindViewSrg" : true
+            }
+        }
+    }
+}

--- a/Gems/Atom/Feature/Common/Assets/Passes/FroxelIntegrate.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/FroxelIntegrate.pass
@@ -1,0 +1,117 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "FroxelIntegrateTemplate",
+            "PassClass": "FroxelIntegratePass",
+            "Slots": [
+                {
+                    "Name": "FroxelScattered",
+                    "SlotType": "Input",
+                    "ShaderInputName": "m_froxelScattered",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                {
+                    "Name": "FroxelHistory",
+                    "SlotType": "Input",
+                    "ShaderInputName": "m_froxelHistory",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                {
+                    "Name": "FroxelMedium",
+                    "SlotType": "Input",
+                    "ShaderInputName": "m_froxelMedium",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                {
+                    "Name": "FroxelEmissive",
+                    "SlotType": "Input",
+                    "ShaderInputName": "m_froxelEmissive",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                {
+                    "Name": "FroxelIntegrated",
+                    "SlotType": "Output",
+                    "ShaderInputName": "m_froxelIntegrated",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                {
+                    "Name": "FroxelOutput",
+                    "SlotType": "Output",
+                    "ShaderInputName": "m_froxelTemporalOutput",
+                    "ScopeAttachmentUsage": "Shader"
+                }
+            ],
+            "ImageAttachments": [
+                {
+                    "Name": "Scattering1",
+                    "Lifetime": "Imported",
+                    "FormatSource": {
+                        "Pass": "This",
+                        "Attachment": "FroxelScattered"
+                    },
+                    "SizeSource": {
+                        "Source": {
+                            "Pass": "This",
+                            "Attachment": "FroxelScattered"
+                        }
+                    },
+                    "ImageDescriptor": {
+                        "Dimension": 3
+                    }
+                },
+                {
+                    "Name": "Scattering2",
+                    "Lifetime": "Imported",
+                    "FormatSource": {
+                        "Pass": "This",
+                        "Attachment": "FroxelScattered"
+                    },
+                    "SizeSource": {
+                        "Source": {
+                            "Pass": "This",
+                            "Attachment": "FroxelScattered"
+                        }
+                    },
+                    "ImageDescriptor": {
+                        "Dimension": 3
+                    }
+                },
+                {
+                    "Name": "FroxelIntegrated",
+                    "SizeSource": {
+                        "Source": {
+                            "Pass": "This",
+                            "Attachment": "FroxelScattered"
+                        }
+                    },
+                     "FormatSource": {
+                        "Pass": "This",
+                        "Attachment": "FroxelScattered"
+                    },
+                    "ImageDescriptor": {
+                        "Dimension": 3
+                    }
+                }
+            ],
+            "Connections": [
+                {
+                    "LocalSlot": "FroxelIntegrated",
+                    "AttachmentRef": {
+                        "Pass": "This",
+                        "Attachment": "FroxelIntegrated"
+                    }
+                }
+            ],
+            "PassData": {
+                "$type": "ComputePassData",
+                "ShaderAsset": {
+                    "FilePath": "Shaders/VolumetricFog/FroxelIntegrate.shader"
+                },
+                "BindViewSrg": true
+            }
+        }
+    }
+}

--- a/Gems/Atom/Feature/Common/Assets/Passes/FroxelLocalVolume.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/FroxelLocalVolume.pass
@@ -1,0 +1,51 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "FroxelLocalVolumeTemplate",
+            "PassClass": "RasterPass",
+            "Slots": [
+                {
+                    "Name": "FroxelMedium",
+                    "SlotType": "InputOutput",
+                    "ScopeAttachmentUsage": "RenderTarget",
+                    "LoadStoreAction": {
+                        "LoadAction": "Load",
+                        "StoreAction": "Store"
+                    },
+                    "ImageViewDesc": {
+                        "OverrideBindFlags": [
+                            "Color"
+                        ]
+                    }
+                },
+                {
+                    "Name": "FroxelEmissive",
+                    "SlotType": "InputOutput",
+                    "ScopeAttachmentUsage": "RenderTarget",
+                    "LoadStoreAction": {
+                        "LoadAction": "Load",
+                        "StoreAction": "Store"
+                    },
+                    "ImageViewDesc": {
+                        "OverrideBindFlags": [
+                            "Color"
+                        ]
+                    }
+                }
+            ],
+            "PassData": {
+                "$type": "RasterPassData",
+                "DrawListTag": "froxelLocalVolume",
+                "PipelineViewTag": "MainCamera",
+                "PassSrgShaderAsset": {
+                    "FilePath": "Shaders/VolumetricFog/FroxelLocalVolume.shader"
+                },
+                "BindViewSrg": true,
+                "ViewportScissorTargetOutputIndex" : 0
+            }
+        }
+    }
+}

--- a/Gems/Atom/Feature/Common/Assets/Passes/FroxelParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/FroxelParent.pass
@@ -1,0 +1,155 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "FroxelParentTemplate",
+            "PassClass": "ParentPass",
+            "Slots": [
+                {
+                    "Name": "PipelineOutput",
+                    "SlotType": "Input"
+                },
+                {
+                    "Name": "TileLightData",
+                    "SlotType": "Input"
+                },
+                {
+                    "Name": "LightListRemapped",
+                    "SlotType": "Input"
+                },
+                {
+                    "Name": "FroxelIntegrated",
+                    "SlotType": "Output"
+                },
+                {
+                    "Name": "DirectionalShadowmap",
+                    "SlotType": "Input"
+                },
+                {
+                    "Name": "DirectionalESM",
+                    "SlotType": "Input"
+                },
+                {
+                    "Name": "ProjectedShadowmap",
+                    "SlotType": "Input"
+                },
+                {
+                    "Name": "ProjectedESM",
+                    "SlotType": "Input"
+                }
+            ],
+            "Connections": [
+                {
+                    "LocalSlot": "FroxelIntegrated",
+                    "AttachmentRef": {
+                        "Pass": "FroxeIntegratePass",
+                        "Attachment": "FroxelIntegrated"
+                    }
+                }
+            ],
+            "PassRequests": [
+                {
+                    "Name": "FroxelInjectPass",
+                    "TemplateName": "FroxelInjectTemplate"
+                },
+                {
+                    "Name": "FroxelLocalVolumePass",
+                    "TemplateName": "FroxelLocalVolumeTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "FroxelMedium",
+                            "AttachmentRef": {
+                                "Pass": "FroxelInjectPass",
+                                "Attachment": "FroxelVolume"
+                            }
+                        },
+                        {
+                            "LocalSlot": "FroxelEmissive",
+                            "AttachmentRef": {
+                                "Pass": "FroxelInjectPass",
+                                "Attachment": "FroxelEmissive"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "FroxeScatterPass",
+                    "TemplateName": "FroxelScatterTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "TileLightData",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "TileLightData"
+                            }
+                        },
+                        {
+                            "LocalSlot": "LightListRemapped",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "LightListRemapped"
+                            }
+                        },
+                        {
+                            "LocalSlot": "DirectionalShadowmap",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "DirectionalShadowmap"
+                            }
+                        },
+                        {
+                            "LocalSlot": "DirectionalESM",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "DirectionalESM"
+                            }
+                        },
+                        {
+                            "LocalSlot": "ProjectedShadowmap",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "ProjectedShadowmap"
+                            }
+                        },
+                        {
+                            "LocalSlot": "ExponentialShadowmapProjected",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "ProjectedESM"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "FroxeIntegratePass",
+                    "TemplateName": "FroxelIntegrateTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "FroxelScattered",
+                            "AttachmentRef": {
+                                "Pass": "FroxeScatterPass",
+                                "Attachment": "FroxelScatterResult"
+                            }
+                        },
+                        {
+                            "LocalSlot": "FroxelEmissive",
+                            "AttachmentRef": {
+                                "Pass": "FroxelLocalVolumePass",
+                                "Attachment": "FroxelEmissive"
+                            }
+                        },
+                        {
+                            "LocalSlot": "FroxelMedium",
+                            "AttachmentRef": {
+                                "Pass": "FroxelLocalVolumePass",
+                                "Attachment": "FroxelMedium"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/Gems/Atom/Feature/Common/Assets/Passes/FroxelScatter.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/FroxelScatter.pass
@@ -1,0 +1,119 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "FroxelScatterTemplate",
+            "PassClass": "FroxelPass",
+            "Slots": [
+                {
+                    "Name": "FroxelScatterResult",
+                    "SlotType": "Output",
+                    "ShaderInputName": "m_froxelScatterResult",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                {
+                    "Name": "TileLightData",
+                    "SlotType": "Input",
+                    "ShaderInputName": "m_tileLightData",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                {
+                    "Name": "LightListRemapped",
+                    "SlotType": "Input",
+                    "ShaderInputName": "m_lightListRemapped",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                {
+                    "Name": "DirectionalShadowmap",
+                    "ShaderInputName": "m_directionalLightShadowmap",
+                    "SlotType": "Input",
+                    "ScopeAttachmentUsage": "Shader",
+                    "ImageViewDesc": {
+                        "IsArray": 1
+                    }
+                },
+                {
+                    "Name": "DirectionalESM",
+                    "ShaderInputName": "m_directionalLightExponentialShadowmap",
+                    "SlotType": "Input",
+                    "ScopeAttachmentUsage": "Shader",
+                    "ImageViewDesc": {
+                        "IsArray": 1
+                    }
+                },
+                {
+                    "Name": "ProjectedShadowmap",
+                    "ShaderInputName": "m_projectedShadowmaps",
+                    "SlotType": "Input",
+                    "ScopeAttachmentUsage": "Shader",
+                    "ImageViewDesc": {
+                        "IsArray": 1
+                    }
+                },
+                {
+                    "Name": "ExponentialShadowmapProjected",
+                    "ShaderInputName": "m_projectedExponentialShadowmap",
+                    "SlotType": "Input",
+                    "ScopeAttachmentUsage": "Shader",
+                    "ImageViewDesc": {
+                        "IsArray": 1
+                    }
+                },
+                {
+                    "Name": "BRDFTextureInput",
+                    "ShaderInputName": "m_brdfMap",
+                    "SlotType": "Input",
+                    "ScopeAttachmentUsage": "Shader"
+                }
+            ],
+            "ImageAttachments": [
+                {
+                    "Name": "FroxelScatterResult",
+                    "SizeSource": {
+                        "Source": {
+                            "Pass": "Parent",
+                            "Attachment": "PipelineOutput"
+                        }
+                    },
+                    "ImageDescriptor": {
+                        "Format": "R16G16B16A16_FLOAT",
+                        "Dimension": 3
+                    }
+                },
+                {
+                    "Name": "BRDFTexture",
+                    "Lifetime": "Imported",
+                    "AssetRef": {
+                        "FilePath": "Textures/BRDFTexture.attimage"
+                    }
+                }
+            ],
+            "Connections": [
+                {
+                    "LocalSlot": "FroxelScatterResult",
+                    "AttachmentRef": {
+                        "Pass": "This",
+                        "Attachment": "FroxelScatterResult"
+                    }
+                },
+                {
+                    "LocalSlot": "BRDFTextureInput",
+                    "AttachmentRef": {
+                        "Pass": "This",
+                        "Attachment": "BRDFTexture"
+                    }
+                }
+            ],
+            "PassData": {
+                "$type": "ComputePassData",
+                "ShaderAsset": {
+                    "FilePath": "Shaders/VolumetricFog/FroxelScatter.shader"
+                },
+                "Make Fullscreen Pass": true,
+                "BindViewSrg" : true
+            }
+        }
+    }
+}

--- a/Gems/Atom/Feature/Common/Assets/Passes/MainPipeline.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/MainPipeline.pass
@@ -116,7 +116,7 @@
                             }
                         }
                     ]
-                },
+                },                
                 {
                     "Name": "Shadows",
                     "TemplateName": "ShadowParentTemplate",
@@ -140,6 +140,62 @@
                             "AttachmentRef": {
                                 "Pass": "DepthPrePass",
                                 "Attachment": "DepthMSAA" 
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "FroxelParentPass",
+                    "TemplateName": "FroxelParentTemplate",
+                    "Enabled": false,
+                    "Connections": [
+                        {
+                            "LocalSlot": "TileLightData",
+                            "AttachmentRef": {
+                                "Pass": "LightCullingPass",
+                                "Attachment": "TileLightData"
+                            }
+                        },
+                        {
+                            "LocalSlot": "LightListRemapped",
+                            "AttachmentRef": {
+                                "Pass": "LightCullingPass",
+                                "Attachment": "LightListRemapped"
+                            }
+                        },
+                        {
+                            "LocalSlot": "PipelineOutput",
+                            "AttachmentRef": {
+                                "Pass": "PipelineGlobal",
+                                "Attachment": "PipelineOutput"
+                            }
+                        },
+                        {
+                            "LocalSlot": "DirectionalShadowmap",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "DirectionalShadowmap"
+                            }
+                        },
+                        {
+                            "LocalSlot": "DirectionalESM",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "DirectionalESM"
+                            }
+                        },
+                        {
+                            "LocalSlot": "ProjectedShadowmap",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "ProjectedShadowmap"
+                            }
+                        },
+                        {
+                            "LocalSlot": "ProjectedESM",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "ProjectedESM"
                             }
                         }
                     ]
@@ -214,6 +270,34 @@
                     ]
                 },
                 {
+                    "Name": "FroxelCompositePass",
+                    "TemplateName": "FroxelCompositeTemplate",
+                    "Enabled": false,
+                    "Connections": [
+                        {
+                            "LocalSlot": "InputLinearDepth",
+                            "AttachmentRef": {
+                                "Pass": "DepthPrePass",
+                                "Attachment": "DepthLinear"
+                            }
+                        },
+                        {
+                            "LocalSlot": "FroxelIntegrated",
+                            "AttachmentRef": {
+                                "Pass": "FroxelParentPass",
+                                "Attachment": "FroxelIntegrated"
+                            }
+                        },
+                        {
+                            "LocalSlot": "RenderTargetInputOutput",
+                            "AttachmentRef": {
+                                "Pass": "OpaquePass",
+                                "Attachment": "Output"
+                            }
+                        }
+                    ]
+                },
+                {
                     "Name": "TransparentPass",
                     "TemplateName": "TransparentParentTemplate",
                     "Connections": [
@@ -267,6 +351,13 @@
                             }
                         },
                         {
+                            "LocalSlot": "FroxelVolumetricFog",
+                            "AttachmentRef": {
+                                "Pass": "FroxelParentPass",
+                                "Attachment": "FroxelIntegrated"
+                            }
+                        },
+                        {
                             "LocalSlot": "DepthStencil",
                             "AttachmentRef": {
                                 "Pass": "DepthPrePass",
@@ -276,8 +367,8 @@
                         {
                             "LocalSlot": "InputOutput",
                             "AttachmentRef": {
-                                "Pass": "OpaquePass",
-                                "Attachment": "Output"
+                                "Pass": "FroxelCompositePass",
+                                "Attachment": "RenderTargetInputOutput"
                             }
                         }
                     ]

--- a/Gems/Atom/Feature/Common/Assets/Passes/PassTemplates.azasset
+++ b/Gems/Atom/Feature/Common/Assets/Passes/PassTemplates.azasset
@@ -643,6 +643,30 @@
             {
                 "Name": "TaaParentTemplate",
                 "Path": "Passes/TaaParent.pass"
+            },
+            {
+                "Name": "FroxelParentTemplate",
+                "Path": "Passes/FroxelParent.pass"
+            },
+            {
+                "Name": "FroxelInjectTemplate",
+                "Path": "Passes/FroxelInject.pass"
+            },
+            {
+                "Name": "FroxelScatterTemplate",
+                "Path": "Passes/FroxelScatter.pass"
+            },
+            {
+                "Name": "FroxelIntegrateTemplate",
+                "Path": "Passes/FroxelIntegrate.pass"
+            },
+            {
+                "Name": "FroxelCompositeTemplate",
+                "Path": "Passes/FroxelComposite.pass"
+            },
+            {
+                "Name": "FroxelLocalVolumeTemplate",
+                "Path": "Passes/FroxelLocalVolume.pass"
             }
         ]
     }

--- a/Gems/Atom/Feature/Common/Assets/Passes/ToolsPipeline.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ToolsPipeline.pass
@@ -221,6 +221,62 @@
                     ]
                 },
                 {
+                    "Name": "FroxelParentPass",
+                    "TemplateName": "FroxelParentTemplate",
+                    "Enabled": false,                    
+                    "Connections": [
+                        {
+                            "LocalSlot": "TileLightData",
+                            "AttachmentRef": {
+                                "Pass": "LightCullingPass",
+                                "Attachment": "TileLightData"
+                            }
+                        },
+                        {
+                            "LocalSlot": "LightListRemapped",
+                            "AttachmentRef": {
+                                "Pass": "LightCullingPass",
+                                "Attachment": "LightListRemapped"
+                            }
+                        },
+                        {
+                            "LocalSlot": "PipelineOutput",
+                            "AttachmentRef": {
+                                "Pass": "PipelineGlobal",
+                                "Attachment": "PipelineOutput"
+                            }
+                        },
+                        {
+                            "LocalSlot": "DirectionalShadowmap",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "DirectionalShadowmap"
+                            }
+                        },
+                        {
+                            "LocalSlot": "DirectionalESM",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "DirectionalESM"
+                            }
+                        },
+                        {
+                            "LocalSlot": "ProjectedShadowmap",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "ProjectedShadowmap"
+                            }
+                        },
+                        {
+                            "LocalSlot": "ProjectedESM",
+                            "AttachmentRef": {
+                                "Pass": "Shadows",
+                                "Attachment": "ProjectedESM"
+                            }
+                        }
+                    ]
+                },
+                {
                     "Name": "TransparentPass",
                     "TemplateName": "TransparentParentTemplate",
                     "Connections": [
@@ -271,6 +327,13 @@
                             "AttachmentRef": {
                                 "Pass": "DepthPrePass",
                                 "Attachment": "DepthLinear"
+                            }
+                        },
+                        {
+                            "LocalSlot": "FroxelVolumetricFog",
+                            "AttachmentRef": {
+                                "Pass": "FroxelParentPass",
+                                "Attachment": "FroxelIntegrated"
                             }
                         },
                         {

--- a/Gems/Atom/Feature/Common/Assets/Passes/Transparent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/Transparent.pass
@@ -73,6 +73,12 @@
                     "ShaderInputName": "m_linearDepthTexture",
                     "ScopeAttachmentUsage": "Shader"
                 },
+                {
+                    "Name": "FroxelVolumetricFog",
+                    "SlotType": "Input",
+                    "ShaderInputName": "m_froxelVolumetricFog",
+                    "ScopeAttachmentUsage": "Shader"
+                },
                 // Input/Outputs
                 {
                     "Name": "DepthStencil",

--- a/Gems/Atom/Feature/Common/Assets/Passes/TransparentParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/TransparentParent.pass
@@ -36,6 +36,10 @@
                     "Name": "InputLinearDepth",
                     "SlotType": "Input"
                 },
+                {
+                    "Name": "FroxelVolumetricFog",
+                    "SlotType": "Input"
+                },
                 // Input/Outputs...
                 {
                     "Name": "DepthStencil",
@@ -100,6 +104,13 @@
                             "AttachmentRef": {
                                 "Pass": "Parent",
                                 "Attachment": "InputLinearDepth"
+                            }
+                        },
+                        {
+                            "LocalSlot": "FroxelVolumetricFog",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "FroxelVolumetricFog"
                             }
                         },
                         // Input/Outputs...

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lighting/LightingData.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lighting/LightingData.azsli
@@ -8,10 +8,15 @@
 
 #pragma once
 
+#ifndef USING_COMPUTE_SHADER_LIGHT
+#define USING_COMPUTE_SHADER_LIGHT 0
+#endif
+
 #include <viewsrg.srgi>
 #include <Atom/Features/Debug.azsli>
 #include <Atom/Features/LightCulling/LightCullingTileIterator.azsli>
 #include <Atom/Features/PBR/LightingUtils.azsli>
+
 
 class LightingData
 {
@@ -82,7 +87,11 @@ void LightingData::Init(real3 positionWS, real3 normal, real roughnessLinear, fl
     // sample BRDF map (indexed by smoothness values rather than roughness)
     NdotV = saturate(dot(normal, dirToCamera));
     real2 brdfUV = real2(NdotV, (1.0 - roughnessLinear));
+#if USING_COMPUTE_SHADER_LIGHT
+    brdf = real2(PassSrg::m_brdfMap.SampleLevel(PassSrg::LinearSampler, brdfUV, 0).rg);
+#else
     brdf = real2(PassSrg::m_brdfMap.Sample(PassSrg::LinearSampler, brdfUV).rg);
+#endif
 }
 
 void LightingData::CalculateMultiscatterCompensation(real3 specularF0, bool enabled)

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lighting/LightingData.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lighting/LightingData.azsli
@@ -8,9 +8,11 @@
 
 #pragma once
 
+// Begin Carbonated
 #ifndef USING_COMPUTE_SHADER_LIGHT
 #define USING_COMPUTE_SHADER_LIGHT 0
 #endif
+// End Carbonated
 
 #include <viewsrg.srgi>
 #include <Atom/Features/Debug.azsli>
@@ -87,11 +89,13 @@ void LightingData::Init(real3 positionWS, real3 normal, real roughnessLinear, fl
     // sample BRDF map (indexed by smoothness values rather than roughness)
     NdotV = saturate(dot(normal, dirToCamera));
     real2 brdfUV = real2(NdotV, (1.0 - roughnessLinear));
+// Begin Carbonated
 #if USING_COMPUTE_SHADER_LIGHT
     brdf = real2(PassSrg::m_brdfMap.SampleLevel(PassSrg::LinearSampler, brdfUV, 0).rg);
 #else
     brdf = real2(PassSrg::m_brdfMap.Sample(PassSrg::LinearSampler, brdfUV).rg);
 #endif
+// End Carbonated
 }
 
 void LightingData::CalculateMultiscatterCompensation(real3 specularF0, bool enabled)

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/LightingOptions.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/LightingOptions.azsli
@@ -77,6 +77,14 @@
 #define ENABLE_MOBILEBRDF               0
 #endif
 
+// --- Other defines ---
+
+// Begin Carbonated
+#ifndef ENABLE_VOLUMETRIC_FOG
+#define ENABLE_VOLUMETRIC_FOG            1
+#endif
+// End Carbonated
+
 // --- Shader Options ---
 
 option bool o_specularF0_enableMultiScatterCompensation = true;

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/CapsuleLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/CapsuleLight.azsli
@@ -54,8 +54,13 @@ void SampleCapsule(float2 randomPoint, ViewSrg::CapsuleLight light, float capToC
     }
 }
 
-void ApplyCapsuleLight(ViewSrg::CapsuleLight light, Surface surface, inout LightingData lightingData)
+// Begin Carbonated
+void ApplyCapsuleLight(ViewSrg::CapsuleLight light, Surface surface, inout LightingData lightingData, out ApplyLightingInfo outInfo)
+// was: void ApplyCapsuleLight(ViewSrg::CapsuleLight light, Surface surface, inout LightingData lightingData)
+// End Carbonated
 {
+    float lightIntensity = 0;
+
     float lightLength = light.m_length;
     float3 startPoint = light.m_startPoint;
     float3 startToEnd = light.m_direction * lightLength;
@@ -121,7 +126,7 @@ void ApplyCapsuleLight(ViewSrg::CapsuleLight light, Surface surface, inout Light
         float intensity = (NdotStart + NdotEnd) / (distanceToStart * distanceToEnd + dot(surfaceToStart, surfaceToEnd));
         intensity *= INV_PI; // normalize for lambert reflectance.
 
-        float3 lightIntensity = (intensity * radiusAttenuation * ratioVisible) * light.m_rgbIntensityCandelas;
+        lightIntensity = (intensity * radiusAttenuation * ratioVisible) * light.m_rgbIntensityCandelas;
         lightingData.diffuseLighting += max(0.0, surface.albedo * lightIntensity);
 
         // Calculate the reflection of the normal from the view direction
@@ -174,10 +179,13 @@ void ApplyCapsuleLight(ViewSrg::CapsuleLight light, Surface surface, inout Light
         float sphereToCapsuleAreaRatio = 2.0 * light.m_radius / max(2.0 * light.m_radius + light.m_length, EPSILON);
 
         // Specular contribution
-        lightIntensity = sphereToCapsuleAreaRatio * radiusAttenuation / d2;
-        lightIntensity *= light.m_rgbIntensityCandelas;
-        lightingData.specularLighting += sphereIntensityNormalization * GetSpecularLighting(surface, lightingData, lightIntensity, normalize(posToLight));
+        float3 specularLightIntensity = sphereToCapsuleAreaRatio * radiusAttenuation / d2;
+        specularLightIntensity *= light.m_rgbIntensityCandelas;
+        lightingData.specularLighting += sphereIntensityNormalization * GetSpecularLighting(surface, lightingData, specularLightIntensity, normalize(posToLight));
     }
+// Begin Carbonated
+    outInfo.m_intensity = lightIntensity;
+// End Carbonated
 }
 
 void ValidateCapsuleLight(ViewSrg::CapsuleLight light, Surface surface, inout LightingData lightingData)
@@ -228,7 +236,10 @@ void ValidateCapsuleLight(ViewSrg::CapsuleLight light, Surface surface, inout Li
 #endif
 }
 
-void ApplyCapsuleLightInternal(uint lightIndex, Surface surface, inout LightingData lightingData)
+// Begin Carbonated
+void ApplyCapsuleLightInternal(uint lightIndex, Surface surface, inout LightingData lightingData, out ApplyLightingInfo outInfo)
+// was: void ApplyCapsuleLightInternal(uint lightIndex, Surface surface, inout LightingData lightingData)
+// End Carbonated
 {
     if (o_enableCapsuleLights)
     {
@@ -246,10 +257,24 @@ void ApplyCapsuleLightInternal(uint lightIndex, Surface surface, inout LightingD
         else
 #endif // ENABLE_AREA_LIGHT_VALIDATION
         {
-            ApplyCapsuleLight(light, surface, lightingData);
+            ApplyCapsuleLight(light, surface, lightingData, outInfo);
         }
     }
 }
+
+// Begin Carbonated
+void ApplyCapsuleLight(ViewSrg::CapsuleLight light, Surface surface, inout LightingData lightingData)
+{
+    ApplyLightingInfo outInfo;
+    ApplyCapsuleLight(light, surface, lightingData, outInfo);
+}
+
+void ApplyCapsuleLightInternal(uint lightIndex, Surface surface, inout LightingData lightingData)
+{
+    ApplyLightingInfo outInfo;
+    ApplyCapsuleLightInternal(lightIndex, surface, lightingData, outInfo);
+}
+// End Carbonated
 
 void ApplyCapsuleLights(Surface surface, inout LightingData lightingData)
 {    

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/CapsuleLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/CapsuleLight.azsli
@@ -59,7 +59,9 @@ void ApplyCapsuleLight(ViewSrg::CapsuleLight light, Surface surface, inout Light
 // was: void ApplyCapsuleLight(ViewSrg::CapsuleLight light, Surface surface, inout LightingData lightingData)
 // End Carbonated
 {
+// Begin Carbonated
     float lightIntensity = 0;
+// End Carbonated
 
     float lightLength = light.m_length;
     float3 startPoint = light.m_startPoint;
@@ -257,7 +259,10 @@ void ApplyCapsuleLightInternal(uint lightIndex, Surface surface, inout LightingD
         else
 #endif // ENABLE_AREA_LIGHT_VALIDATION
         {
+            // Begin Carbonated
             ApplyCapsuleLight(light, surface, lightingData, outInfo);
+            // was: ApplyCapsuleLight(light, surface, lightingData);
+            // End Carbonated
         }
     }
 }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/DirectionalLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/DirectionalLight.azsli
@@ -14,21 +14,43 @@
 #include <Atom/Features/Shadow/DirectionalLightShadow.azsli>
 #endif
 
-void ApplyDirectionalLights(Surface surface, inout LightingData lightingData, float4 screenUv)
+// Begin Carbonated
+static real camToSurfDist = 0;
+
+void ApplyDirectionalLight(int lightIndex, Surface surface, inout LightingData lightingData, float4 screenUv, out ApplyLightingInfo outInfo)
 {
+    SceneSrg::DirectionalLight light = SceneSrg::m_directionalLights[lightIndex];
+    if(!IsSameLightChannel(lightingData.lightingChannels, light.m_lightingChannelMask))
+    {
+        return;
+    }
     // Shadowed check
     const uint shadowIndex = ViewSrg::m_shadowIndexDirectionalLight;
-    real litRatio = 1.0;
-    real camToSurfDist = real(distance(ViewSrg::m_worldPosition, surface.position));
+    real3 dirToLight = normalize(real3(-light.m_direction));
 
-    // Distance travelled by the light inside the object. If not redefined to a non-negative value, it will take the following behavior:
-    // - If transmission mode is thick object -> use transmission thickness parameter instead
-    // - If transmission mode is thin object -> ignore back lighting
-    real transmissionDistance = -1.0;
+    // Adjust the direction of the light based on its angular diameter.
+    real3 reflectionDir = reflect(-lightingData.dirToCamera, surface.GetSpecularNormal());
+    real3 lightDirToReflectionDir = reflectionDir - dirToLight;
+    real lightDirToReflectionDirLen = length(lightDirToReflectionDir);
+    lightDirToReflectionDir = lightDirToReflectionDir / lightDirToReflectionDirLen; // normalize the length
+    lightDirToReflectionDirLen = min(real(light.m_angularRadius), lightDirToReflectionDirLen);
+    dirToLight += lightDirToReflectionDir * lightDirToReflectionDirLen;
+
+    // [GFX TODO][ATOM-2012] care of multiple directional light
+    // Currently shadow check is done only for lightIndex == shadowIndex.
+
+    real currentTransmissionDistance = -1.0;
+    float currentLitRatio = 1.0;
 
 #if ENABLE_SHADOWS
-    if (o_enableShadows && shadowIndex <  SceneSrg::m_directionalLightCount)
-    {           
+    if (o_enableShadows && lightIndex == shadowIndex)
+    {
+        real litRatio = 1.0;
+        // Distance travelled by the light inside the object. If not redefined to a non-negative value, it will take the following behavior:
+        // - If transmission mode is thick object -> use transmission thickness parameter instead
+        // - If transmission mode is thin object -> ignore back lighting
+        real transmissionDistance = -1.0;
+
 #if ENABLE_TRANSMISSION
         if (o_transmission_mode == TransmissionMode::ThickObject)
         {
@@ -52,58 +74,52 @@ void ApplyDirectionalLights(Surface surface, inout LightingData lightingData, fl
         litRatio = DirectionalLightShadow::GetVisibility(shadowIndex, surface.position, surface.vertexNormal, screenUv);
 #endif // ENABLE_TRANSMISSION
 
+        // Add contribution only if current directional light is the active one for shadows
+        currentLitRatio = real(litRatio);
+        currentTransmissionDistance = transmissionDistance;
     }
 #endif // ENABLE_SHADOWS
+    
+    real3 lightIntensity = real3(light.m_rgbIntensityLux);
+    // Transmission contribution
+#if ENABLE_TRANSMISSION
+    lightingData.translucentBackLighting += GetBackLighting(surface, lightingData, lightIntensity, dirToLight, real(currentTransmissionDistance), camToSurfDist);
+#endif
+    
+    lightingData.diffuseLighting += GetDiffuseLighting(surface, lightingData, lightIntensity, dirToLight) * currentLitRatio;
+    lightingData.specularLighting += GetSpecularLighting(surface, lightingData, lightIntensity, dirToLight) * currentLitRatio;
+
+#if ENABLE_SHADER_DEBUGGING
+    if(IsDebuggingEnabled_PLACEHOLDER() && GetRenderDebugViewMode() == RenderDebugViewMode::CascadeShadows)
+    {
+        customDebugFloats.rgb = currentLitRatio.xxx;
+    }
+#endif
+    outInfo.m_intensity = lightIntensity;
+    outInfo.m_litRatio = currentLitRatio;
+}
+
+void ApplyDirectionalLight(int lightIndex, Surface surface, inout LightingData lightingData, float4 screenUv)
+{
+    ApplyLightingInfo outInfo;
+    ApplyDirectionalLight(lightIndex, surface, lightingData, screenUv, outInfo);
+}
+// End Carbonated
+
+void ApplyDirectionalLights(Surface surface, inout LightingData lightingData, float4 screenUv)
+{
+// Begin Carbonated
+    camToSurfDist = real(distance(ViewSrg::m_worldPosition, surface.position));
+// End Carbonated
 
     // Add the lighting contribution for each directional light
     for (int index = 0; index < SceneSrg::m_directionalLightCount; index++)
     {
-        SceneSrg::DirectionalLight light = SceneSrg::m_directionalLights[index];
-        if(!IsSameLightChannel(lightingData.lightingChannels, light.m_lightingChannelMask))
-        {
-            continue;
-        }
-        real3 dirToLight = normalize(real3(-light.m_direction));
-
-        // Adjust the direction of the light based on its angular diameter.
-        real3 reflectionDir = reflect(-lightingData.dirToCamera, surface.GetSpecularNormal());
-        real3 lightDirToReflectionDir = reflectionDir - dirToLight;
-        real lightDirToReflectionDirLen = length(lightDirToReflectionDir);
-        lightDirToReflectionDir = lightDirToReflectionDir / lightDirToReflectionDirLen; // normalize the length
-        lightDirToReflectionDirLen = min(real(light.m_angularRadius), lightDirToReflectionDirLen);
-        dirToLight += lightDirToReflectionDir * lightDirToReflectionDirLen;
-
-        // [GFX TODO][ATOM-2012] care of multiple directional light
-        // Currently shadow check is done only for index == shadowIndex.
-        real currentLitRatio = 1.0;
-        real currentTransmissionDistance = -1.0;
-
-#if ENABLE_SHADOWS
-        if (o_enableShadows && index == shadowIndex)
-        {
-            // Add contribution only if current directional light is the active one for shadows
-            currentLitRatio = real(litRatio);
-            currentTransmissionDistance = transmissionDistance;
-        }
-#endif
-
-        // Transmission contribution
-#if ENABLE_TRANSMISSION
-        lightingData.translucentBackLighting += GetBackLighting(surface, lightingData, real3(light.m_rgbIntensityLux), dirToLight, real(currentTransmissionDistance), camToSurfDist);
-#endif
-        
-        lightingData.diffuseLighting += GetDiffuseLighting(surface, lightingData, real3(light.m_rgbIntensityLux), dirToLight) * currentLitRatio;
-        lightingData.specularLighting += GetSpecularLighting(surface, lightingData, real3(light.m_rgbIntensityLux), dirToLight) * currentLitRatio;
-
-#if ENABLE_SHADER_DEBUGGING
-        if(IsDebuggingEnabled_PLACEHOLDER() && GetRenderDebugViewMode() == RenderDebugViewMode::CascadeShadows)
-        {
-            customDebugFloats.rgb = currentLitRatio.xxx;
-        }
-#endif
+        ApplyDirectionalLight(index, surface, lightingData, screenUv);
     }
 
-#if ENABLE_SHADOWS    
+#if ENABLE_SHADOWS
+    const uint shadowIndex = ViewSrg::m_shadowIndexDirectionalLight;
     // Add debug coloring for directional light shadow
     if (o_enableShadows && shadowIndex <  SceneSrg::m_directionalLightCount)
     {

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/DiskLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/DiskLight.azsli
@@ -20,8 +20,15 @@ enum DiskLightFlag
     UseConeAngle = 1,
 };
 
-void ApplyDiskLight(ViewSrg::DiskLight light, Surface surface, inout LightingData lightingData)
+// Begin Carbonated
+void ApplyDiskLight(ViewSrg::DiskLight light, Surface surface, inout LightingData lightingData, out ApplyLightingInfo outInfo)
+// was: void ApplyDiskLight(ViewSrg::DiskLight light, Surface surface, inout LightingData lightingData)
+// End Carbonated
 {
+    float3 lightIntensity = 0;
+    // shadow
+    float litRatio = 1.0;
+
     float3 posToLight = light.m_position - surface.position;
     float distanceToLight2 = dot(posToLight, posToLight); // light distance squared
     float falloff = distanceToLight2 * light.m_invAttenuationRadiusSquared;
@@ -71,15 +78,12 @@ void ApplyDiskLight(ViewSrg::DiskLight light, Surface surface, inout LightingDat
 
         // Standard quadratic falloff
         distanceToDisk2 = max(0.001 * 0.001, distanceToDisk2); // clamp the light to at least 1mm away to avoid extreme values.
-        float3 lightIntensity = (light.m_rgbIntensityCandelas / distanceToDisk2) * radiusAttenuation * angleFalloff;
+        lightIntensity = (light.m_rgbIntensityCandelas / distanceToDisk2) * radiusAttenuation * angleFalloff;
 
         // Adjust brightness based on the disk size relative to its distance.
         // The larger the disk is relative to the surface point, the dimmer it becomes.
         // 0 radius disks are unaffected.
         lightIntensity /= ((light.m_diskRadius / distanceToPlane) + 1.0);
-
-        // shadow
-        float litRatio = 1.0;
 
         // Distance travelled by the light inside the object. If not redefined to a non-negative value, it will take the following behavior:
         // - If transmission mode is thick object -> use transmission thickness parameter instead
@@ -167,6 +171,11 @@ void ApplyDiskLight(ViewSrg::DiskLight light, Surface surface, inout LightingDat
         // Specular contribution
         lightingData.specularLighting += diskIntensityNormalization * GetSpecularLighting(surface, lightingData, lightIntensity, normalize(posToLight)) * litRatio;
     }
+
+// Begin Carbonated
+    outInfo.m_intensity = lightIntensity;
+    outInfo.m_litRatio = litRatio;
+// End Carbonated
 }
 
 float3 SampleDisk(float2 randomPoint, ViewSrg::DiskLight light)
@@ -215,7 +224,10 @@ void ValidateDiskLight(ViewSrg::DiskLight light, Surface surface, inout Lighting
     lightingData.specularLighting += (specularAcc / float(sampleCount)) * light.m_rgbIntensityCandelas;
 }
 
-void ApplyDiskLightInternal(uint lightIndex, Surface surface, inout LightingData lightingData)
+// Begin Carbonated
+void ApplyDiskLightInternal(uint lightIndex, Surface surface, inout LightingData lightingData, out ApplyLightingInfo outInfo)
+// was: void ApplyDiskLightInternal(uint lightIndex, Surface surface, inout LightingData lightingData)
+// End Carbonated
 {
     if (o_enableDiskLights)
     {
@@ -232,10 +244,24 @@ void ApplyDiskLightInternal(uint lightIndex, Surface surface, inout LightingData
         else
 #endif // ENABLE_AREA_LIGHT_VALIDATION
         {
-            ApplyDiskLight(light, surface, lightingData);
+            ApplyDiskLight(light, surface, lightingData, outInfo);
         }
     }
 }
+
+// Begin Carbonated
+void ApplyDiskLight(ViewSrg::DiskLight light, Surface surface, inout LightingData lightingData)
+{
+    ApplyLightingInfo outInfo;
+    ApplyDiskLight(light, surface, lightingData, outInfo);
+}
+
+void ApplyDiskLightInternal(uint lightIndex, Surface surface, inout LightingData lightingData)
+{
+    ApplyLightingInfo outInfo;
+    ApplyDiskLightInternal(lightIndex, surface, lightingData, outInfo);
+}
+// End Carbonated
 
 void ApplyDiskLights(Surface surface, inout LightingData lightingData)
 {    

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/DiskLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/DiskLight.azsli
@@ -25,9 +25,11 @@ void ApplyDiskLight(ViewSrg::DiskLight light, Surface surface, inout LightingDat
 // was: void ApplyDiskLight(ViewSrg::DiskLight light, Surface surface, inout LightingData lightingData)
 // End Carbonated
 {
+    // Begin Carbonated
     float3 lightIntensity = 0;
     // shadow
     float litRatio = 1.0;
+    // End Carbonated
 
     float3 posToLight = light.m_position - surface.position;
     float distanceToLight2 = dot(posToLight, posToLight); // light distance squared

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/LightTypesCommon.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/LightTypesCommon.azsli
@@ -13,6 +13,30 @@
 #include <Atom/Features/PBR/BackLighting.azsli>
 #include <Atom/Features/PBR/Hammersley.azsli>
 
+// Begin Carbonated
+#ifndef USING_COMPUTE_SHADER_LIGHT
+#define USING_COMPUTE_SHADER_LIGHT 0
+#endif
+
+#if USING_COMPUTE_SHADER_LIGHT
+    #define SampleTexture(text, sampler, coord) text.SampleLevel(sampler, coord, 0)
+#else
+    #define SampleTexture(text, sampler, coord) text.Sample(sampler, coord)
+#endif
+
+class ApplyLightingInfo
+{
+    float3 m_intensity;
+    float m_litRatio;
+
+    void Init()
+    {
+        m_intensity = 0;
+        m_litRatio = 1.0;
+    }
+};
+// End Carbonated
+
 //! Adjust the intensity of specular light based on the radius of the light source and roughness of the surface to approximate energy conservation.
 real GetIntensityAdjustedByRadiusAndRoughness(real roughnessA, real radius, real distance2)
 {

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/Ltc.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/Ltc.azsli
@@ -61,7 +61,7 @@ float2 LtcCoords(float cosTheta, float roughness)
 // Constructs an LTC matrix from the provided texture and coordinates.
 float3x3 LtcMatrix(Texture2D<float4> ltcMatrix, float2 coord)
 {
-    float4 t = ltcMatrix.Sample(SceneSrg::LtcSampler, coord);
+    float4 t = SampleTexture(ltcMatrix, SceneSrg::LtcSampler, coord);
 
     return float3x3(
         1.0, 0.0, t.w,
@@ -405,7 +405,7 @@ void LtcQuadEvaluate(
     float specular = LtcEvaluateSpecularUnscaled(ltcCoords, ltcMatrix, polygon, vertexCount, doubleSided);
 
     // Apply BRDF scale terms (BRDF magnitude and Schlick Fresnel)
-    float2 schlick = ltcAmpMatrix.Sample(SceneSrg::LtcSampler, ltcCoords).xy;
+    float2 schlick = SampleTexture(ltcAmpMatrix, SceneSrg::LtcSampler, ltcCoords).xy;
     float3 specularRgb = specular * (schlick.x * surface.GetSpecularF0() + (1.0 - surface.GetSpecularF0()) * schlick.y);
     
 #if ENABLE_CLEAR_COAT
@@ -419,7 +419,7 @@ void LtcQuadEvaluate(
 
             // Apply BRDF scale terms (BRDF magnitude and Schlick Fresnel)
             const float clearCoatSpecularF0 = 0.04;
-            float2 schlickCc = ltcAmpMatrix.Sample(SceneSrg::LtcSampler, ltcCoordsCc).xy;
+            float2 schlickCc = SampleTexture(ltcAmpMatrix, SceneSrg::LtcSampler, ltcCoordsCc).xy;
             float F = schlickCc.x * clearCoatSpecularF0 + (1.0 - clearCoatSpecularF0) * schlickCc.y;
             F *= surface.clearCoat.factor;
 
@@ -631,7 +631,7 @@ void LtcPolygonEvaluate(
     specular = -specular;
 
     // Apply BRDF scale terms (BRDF magnitude and Schlick Fresnel)
-    float2 schlick = ltcAmpMatrix.Sample(SceneSrg::LtcSampler, ltcCoords).xy;
+    float2 schlick = SampleTexture(ltcAmpMatrix, SceneSrg::LtcSampler, ltcCoords).xy;
     float3 specularRgb = specular * ((schlick.x * surface.GetSpecularF0()) + (1.0 - surface.GetSpecularF0()) * schlick.y);
 
 #if ENABLE_CLEAR_COAT
@@ -667,7 +667,7 @@ void LtcPolygonEvaluate(
 
             // Apply BRDF scale terms (BRDF magnitude and Schlick Fresnel)
             const float clearCoatSpecularF0 = 0.04;
-            float2 schlickCc = ltcAmpMatrix.Sample(SceneSrg::LtcSampler, ltcCoordsCc).xy;
+            float2 schlickCc = SampleTexture(ltcAmpMatrix, SceneSrg::LtcSampler, ltcCoordsCc).xy;
             float F = clearCoatSpecularF0 * schlickCc.x + (1.0 - clearCoatSpecularF0) * schlickCc.y;
             F *= surface.clearCoat.factor;
 

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/Ltc.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/Ltc.azsli
@@ -61,7 +61,10 @@ float2 LtcCoords(float cosTheta, float roughness)
 // Constructs an LTC matrix from the provided texture and coordinates.
 float3x3 LtcMatrix(Texture2D<float4> ltcMatrix, float2 coord)
 {
+    // Begin Carbonated
+    // was: float4 t = ltcMatrix.Sample(SceneSrg::LtcSampler, coord);
     float4 t = SampleTexture(ltcMatrix, SceneSrg::LtcSampler, coord);
+    // End Carbonated
 
     return float3x3(
         1.0, 0.0, t.w,
@@ -405,7 +408,10 @@ void LtcQuadEvaluate(
     float specular = LtcEvaluateSpecularUnscaled(ltcCoords, ltcMatrix, polygon, vertexCount, doubleSided);
 
     // Apply BRDF scale terms (BRDF magnitude and Schlick Fresnel)
+    // Begin Carbonated
+    // was: float2 schlick = ltcAmpMatrix.Sample(SceneSrg::LtcSampler, ltcCoords).xy;
     float2 schlick = SampleTexture(ltcAmpMatrix, SceneSrg::LtcSampler, ltcCoords).xy;
+    // End Carbonated
     float3 specularRgb = specular * (schlick.x * surface.GetSpecularF0() + (1.0 - surface.GetSpecularF0()) * schlick.y);
     
 #if ENABLE_CLEAR_COAT
@@ -419,7 +425,10 @@ void LtcQuadEvaluate(
 
             // Apply BRDF scale terms (BRDF magnitude and Schlick Fresnel)
             const float clearCoatSpecularF0 = 0.04;
+            // Begin Carbonated
+            // was: float2 schlickCc = ltcAmpMatrix.Sample(SceneSrg::LtcSampler, ltcCoordsCc).xy;
             float2 schlickCc = SampleTexture(ltcAmpMatrix, SceneSrg::LtcSampler, ltcCoordsCc).xy;
+            // End Carbonated
             float F = schlickCc.x * clearCoatSpecularF0 + (1.0 - clearCoatSpecularF0) * schlickCc.y;
             F *= surface.clearCoat.factor;
 
@@ -631,7 +640,10 @@ void LtcPolygonEvaluate(
     specular = -specular;
 
     // Apply BRDF scale terms (BRDF magnitude and Schlick Fresnel)
+    // Begin Carbonated
+    // was: float2 schlick = ltcAmpMatrix.Sample(SceneSrg::LtcSampler, ltcCoords).xy;
     float2 schlick = SampleTexture(ltcAmpMatrix, SceneSrg::LtcSampler, ltcCoords).xy;
+    // End Carbonated
     float3 specularRgb = specular * ((schlick.x * surface.GetSpecularF0()) + (1.0 - surface.GetSpecularF0()) * schlick.y);
 
 #if ENABLE_CLEAR_COAT
@@ -667,7 +679,10 @@ void LtcPolygonEvaluate(
 
             // Apply BRDF scale terms (BRDF magnitude and Schlick Fresnel)
             const float clearCoatSpecularF0 = 0.04;
+            // Begin Carbonated
+            // was: float2 schlickCc = ltcAmpMatrix.Sample(SceneSrg::LtcSampler, ltcCoordsCc).xy;
             float2 schlickCc = SampleTexture(ltcAmpMatrix, SceneSrg::LtcSampler, ltcCoordsCc).xy;
+            // End Carbonated
             float F = clearCoatSpecularF0 * schlickCc.x + (1.0 - clearCoatSpecularF0) * schlickCc.y;
             F *= surface.clearCoat.factor;
 

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/PointLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/PointLight.azsli
@@ -73,8 +73,15 @@ uint ComputeShadowIndex(const ViewSrg::PointLight light, const Surface surface)
 
 #endif // ENABLE_SHADOWS
 
-void ApplyPointLight(ViewSrg::PointLight light, Surface surface, inout LightingData lightingData)
+// Begin Carbonated
+void ApplyPointLight(ViewSrg::PointLight light, Surface surface, inout LightingData lightingData, out ApplyLightingInfo outInfo)
+// was: void ApplyPointLight(ViewSrg::PointLight light, Surface surface, inout LightingData lightingData)
+// End Carbonated
 {
+    // shadow
+    real litRatio = 1.0;
+    real3 lightIntensity = 0;
+
     real3 posToLight = real3(light.m_position) - real3(surface.position);
     real posToLightDist = length(posToLight);
     real d2 = dot(posToLight, posToLight); // light distance squared
@@ -89,10 +96,7 @@ void ApplyPointLight(ViewSrg::PointLight light, Surface surface, inout LightingD
         
         // Standard quadratic falloff
         d2 = max(0.001 * 0.001, d2); // clamp the light to at least 1mm away to avoid extreme values.
-        real3 lightIntensity = (real3(light.m_rgbIntensityCandelas) / d2) * radiusAttenuation;
-
-        // shadow
-        real litRatio = 1.0;
+        lightIntensity = (real3(light.m_rgbIntensityCandelas) / d2) * radiusAttenuation;
 
         // Distance travelled by the light inside the object. If not redefined to a non-negative value, it will take the following behavior:
         // - If transmission mode is thick object -> use transmission thickness parameter instead
@@ -149,6 +153,10 @@ void ApplyPointLight(ViewSrg::PointLight light, Surface surface, inout LightingD
         // Specular contribution
         lightingData.specularLighting += sphereIntensityNormalization * GetSpecularLighting(surface, lightingData, lightIntensity, normalize(posToLight)) * litRatio;
     }
+// Begin Carbonated
+    outInfo.m_intensity = lightIntensity;
+    outInfo.m_litRatio = litRatio;
+// End Carbonated
 }
 
 real3 SampleSphere(real2 randomPoint)
@@ -190,7 +198,10 @@ void ValidatePointLight(ViewSrg::PointLight light, Surface surface, inout Lighti
 #endif
 }
 
-void ApplyPointLightInternal(uint lightIndex, Surface surface, inout LightingData lightingData)
+// Begin Carbonated
+void ApplyPointLightInternal(uint lightIndex, Surface surface, inout LightingData lightingData, out ApplyLightingInfo outInfo)
+// was: void ApplyPointLightInternal(uint lightIndex, Surface surface, inout LightingData lightingData)
+// End Carbonated
 {
     if (o_enableSphereLights)
     {
@@ -207,10 +218,24 @@ void ApplyPointLightInternal(uint lightIndex, Surface surface, inout LightingDat
         else
 #endif // ENABLE_AREA_LIGHT_VALIDATION
         {
-            ApplyPointLight(light, surface, lightingData);
+            ApplyPointLight(light, surface, lightingData, outInfo);
         }
     }
 }
+
+// Begin Carbonated
+void ApplyPointLight(ViewSrg::PointLight light, Surface surface, inout LightingData lightingData)
+{
+    ApplyLightingInfo outInfo;
+    ApplyPointLight(light, surface, lightingData, outInfo);
+}
+
+void ApplyPointLightInternal(uint lightIndex, Surface surface, inout LightingData lightingData)
+{
+    ApplyLightingInfo outInfo;
+    ApplyPointLightInternal(lightIndex, surface, lightingData, outInfo);
+}
+// End Carbonated
 
 void ApplyPointLights(Surface surface, inout LightingData lightingData)
 {

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/PointLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/PointLight.azsli
@@ -78,9 +78,11 @@ void ApplyPointLight(ViewSrg::PointLight light, Surface surface, inout LightingD
 // was: void ApplyPointLight(ViewSrg::PointLight light, Surface surface, inout LightingData lightingData)
 // End Carbonated
 {
+// Begin Carbonated
     // shadow
     real litRatio = 1.0;
     real3 lightIntensity = 0;
+// End Carbonated
 
     real3 posToLight = real3(light.m_position) - real3(surface.position);
     real posToLightDist = length(posToLight);

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/PolygonLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/PolygonLight.azsli
@@ -14,8 +14,12 @@
 
 #if ENABLE_POLYGON_LTC_LIGHTS
 // Polygon lights using Linearly Transformed Cosines
-void ApplyPoylgonLight(ViewSrg::PolygonLight light, Surface surface, inout LightingData lightingData)
+// Begin Carbonated
+void ApplyPoylgonLight(ViewSrg::PolygonLight light, Surface surface, inout LightingData lightingData, out ApplyLightingInfo outInfo)
+// was: void ApplyPoylgonLight(ViewSrg::PolygonLight light, Surface surface, inout LightingData lightingData)
+// End Carbonated
 {
+    float3 intensity = 0;
     float3 posToLight = light.m_position - surface.position;
     float distanceToLight2 = dot(posToLight, posToLight); // light distance squared
     float falloff = distanceToLight2 * abs(light.m_invAttenuationRadiusSquared);
@@ -52,11 +56,24 @@ void ApplyPoylgonLight(ViewSrg::PolygonLight light, Surface surface, inout Light
     specularRgb = doubleSided ? abs(specularRgb) : max(0.0, specularRgb);
 
     // Scale by inverse surface area of hemisphere (1/2pi), attenuation, and light intensity
-    float3 intensity = 0.5 * INV_PI * radiusAttenuation * abs(light.m_rgbIntensityNits);
+    intensity = 0.5 * INV_PI * radiusAttenuation * abs(light.m_rgbIntensityNits);
 
     lightingData.diffuseLighting += surface.albedo * diffuse * intensity;
     lightingData.specularLighting += specularRgb * intensity;
+
+// Begin Carbonated
+    outInfo.m_intensity = intensity;
+// End Carbonated
 }
+
+// Begin Carbonated
+void ApplyPoylgonLight(ViewSrg::PolygonLight light, Surface surface, inout LightingData lightingData)
+{
+    ApplyLightingInfo outInfo;
+    ApplyPoylgonLight(light, surface, lightingData, outInfo);
+}
+// End Carbonated
+
 
 void ApplyPolygonLights(Surface surface, inout LightingData lightingData)
 {

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/QuadLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/QuadLight.azsli
@@ -76,8 +76,12 @@ float3 GetSpecularDominantDirection(float3 normal, float3 reflection, float roug
 }
 
 // Quad light approximation. Diffuse portion based on https://seblagarde.files.wordpress.com/2015/07/course_notes_moving_frostbite_to_pbr_v32.pdf Pages 49-50.
-void ApplyQuadLight(ViewSrg::QuadLight light, Surface surface, inout LightingData lightingData)
+// Begin Carbonated
+void ApplyQuadLight(ViewSrg::QuadLight light, Surface surface, inout LightingData lightingData, out ApplyLightingInfo outInfo)
+// was: void ApplyQuadLight(ViewSrg::QuadLight light, Surface surface, inout LightingData lightingData)
+// End Carbonated
 {
+    float3 intensity = 0;
     float3 lightDirection = cross(light.m_leftDir, light.m_upDir); // left and up are already normalized.
 
     float3 posToLight = light.m_position - surface.position;
@@ -118,7 +122,7 @@ void ApplyQuadLight(ViewSrg::QuadLight light, Surface surface, inout LightingDat
             LtcQuadEvaluate(surface, lightingData, SceneSrg::m_ltcMatrix, SceneSrg::m_ltcAmplification, p, doubleSided, diffuse, specular);
 
             // Scale by inverse surface area of hemisphere (1/2pi), attenuation, and light intensity
-            float3 intensity = 0.5 * INV_PI * radiusAttenuation * light.m_rgbIntensityNits;
+            intensity = 0.5 * INV_PI * radiusAttenuation * light.m_rgbIntensityNits;
 
             lightingData.diffuseLighting += surface.albedo * diffuse * intensity;
             lightingData.specularLighting += specular * intensity;
@@ -138,7 +142,7 @@ void ApplyQuadLight(ViewSrg::QuadLight light, Surface surface, inout LightingDat
 
             // Intensity is the solid angle times the brightness of the light surface.
             // Each position contributes 1/5 of the light (4 corners + center)
-            float3 intensity = solidAngle * 0.2 * radiusAttenuation * light.m_rgbIntensityNits;
+            intensity = solidAngle * 0.2 * radiusAttenuation * light.m_rgbIntensityNits;
 
             lightingData.diffuseLighting += 
             (
@@ -209,6 +213,9 @@ void ApplyQuadLight(ViewSrg::QuadLight light, Surface surface, inout LightingDat
             lightingData.specularLighting += GetSpecularLighting(surface, lightingData, specularintensity, dirToLight) * radiusAttenuation;
         }
     }
+// Begin Carbonated
+    outInfo.m_intensity = intensity;
+// End Carbonated
 }
 
 float3 SampleRectangle(float2 randomPoint, ViewSrg::QuadLight light)
@@ -252,7 +259,10 @@ void ValidateQuadLight(ViewSrg::QuadLight light, Surface surface, inout Lighting
 #endif
 }
 
-void ApplyQuadLightInternal(uint lightIndex, Surface surface, inout LightingData lightingData)
+// Begin Carbonated
+void ApplyQuadLightInternal(uint lightIndex, Surface surface, inout LightingData lightingData, out ApplyLightingInfo outInfo)
+// was: void ApplyQuadLightInternal(uint lightIndex, Surface surface, inout LightingData lightingData)
+// End Carbonated
 {
     if (o_enableQuadLightApprox || o_enableQuadLightLTC)
     {
@@ -269,10 +279,24 @@ void ApplyQuadLightInternal(uint lightIndex, Surface surface, inout LightingData
         else
 #endif //ENABLE_AREA_LIGHT_VALIDATION
         {
-            ApplyQuadLight(light, surface, lightingData);
+            ApplyQuadLight(light, surface, lightingData, outInfo);
         }
     }
 }
+
+// Begin Carbonated
+void ApplyQuadLight(ViewSrg::QuadLight light, Surface surface, inout LightingData lightingData)
+{
+    ApplyLightingInfo outInfo;
+    ApplyQuadLight(light, surface, lightingData, outInfo);
+}
+
+void ApplyQuadLightInternal(uint lightIndex, Surface surface, inout LightingData lightingData)
+{
+    ApplyLightingInfo outInfo;
+    ApplyQuadLightInternal(lightIndex, surface, lightingData, outInfo);
+}
+// End Carbonated
 
 void ApplyQuadLights(Surface surface, inout LightingData lightingData)
 {

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/SimplePointLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/SimplePointLight.azsli
@@ -10,8 +10,12 @@
 
 #include <Atom/Features/LightCulling/LightCullingTileIterator.azsli>
 
-void ApplySimplePointLight(ViewSrg::SimplePointLight light, Surface surface, inout LightingData lightingData)
+// Begin Carbonated
+void ApplySimplePointLight(ViewSrg::SimplePointLight light, Surface surface, inout LightingData lightingData, out ApplyLightingInfo outInfo)
+// was: void ApplySimplePointLight(ViewSrg::SimplePointLight light, Surface surface, inout LightingData lightingData)
+// End Carbonated
 {
+    real3 lightIntensity = 0;
     real3 posToLight = real3(light.m_position - surface.position);
     real d2 = dot(posToLight, posToLight); // light distance squared
     real falloff = d2 * real(light.m_invAttenuationRadiusSquared);
@@ -25,7 +29,7 @@ void ApplySimplePointLight(ViewSrg::SimplePointLight light, Surface surface, ino
         
         // Standard quadratic falloff
         d2 = max(0.001 * 0.001, d2); // clamp the light to at least 1mm away to avoid extreme values.
-        real3 lightIntensity = (real3(light.m_rgbIntensityCandelas) / d2) * radiusAttenuation;
+        lightIntensity = (real3(light.m_rgbIntensityCandelas) / d2) * radiusAttenuation;
         real3 posToLightDir = normalize(posToLight);
 
         // Diffuse contribution
@@ -34,9 +38,15 @@ void ApplySimplePointLight(ViewSrg::SimplePointLight light, Surface surface, ino
         // Specular contribution
         lightingData.specularLighting += GetSpecularLighting(surface, lightingData, lightIntensity, posToLightDir);
     }
+// Begin Carbonated
+    outInfo.m_intensity = lightIntensity;
+// End Carbonated
 }
 
-void ApplySimplePointLightInternal(uint lightIndex, Surface surface, inout LightingData lightingData)
+// Begin Carbonated
+void ApplySimplePointLightInternal(uint lightIndex, Surface surface, inout LightingData lightingData, out ApplyLightingInfo outInfo)
+// was: void ApplySimplePointLightInternal(uint lightIndex, Surface surface, inout LightingData lightingData)
+// End Carbonated
 {
     if (o_enableSimplePointLights)
     {
@@ -45,9 +55,23 @@ void ApplySimplePointLightInternal(uint lightIndex, Surface surface, inout Light
         {
             return;
         }
-        ApplySimplePointLight(light, surface, lightingData);
+        ApplySimplePointLight(light, surface, lightingData, outInfo);
     }
 }
+
+// Begin Carbonated
+void ApplySimplePointLight(ViewSrg::SimplePointLight light, Surface surface, inout LightingData lightingData)
+{
+    ApplyLightingInfo outInfo;
+    ApplySimplePointLight(light, surface, lightingData, outInfo);
+}
+
+void ApplySimplePointLightInternal(uint lightIndex, Surface surface, inout LightingData lightingData)
+{
+    ApplyLightingInfo outInfo;
+    ApplySimplePointLightInternal(lightIndex, surface, lightingData, outInfo);
+}
+// End Carbonated
 
 void ApplySimplePointLights(Surface surface, inout LightingData lightingData)
 {

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/SimplePointLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/SimplePointLight.azsli
@@ -15,7 +15,9 @@ void ApplySimplePointLight(ViewSrg::SimplePointLight light, Surface surface, ino
 // was: void ApplySimplePointLight(ViewSrg::SimplePointLight light, Surface surface, inout LightingData lightingData)
 // End Carbonated
 {
+// Begin Carbonated
     real3 lightIntensity = 0;
+// End Carbonated
     real3 posToLight = real3(light.m_position - surface.position);
     real d2 = dot(posToLight, posToLight); // light distance squared
     real falloff = d2 * real(light.m_invAttenuationRadiusSquared);
@@ -55,7 +57,10 @@ void ApplySimplePointLightInternal(uint lightIndex, Surface surface, inout Light
         {
             return;
         }
+        // Begin Carbonated
+        // was: ApplySimplePointLight(light, surface, lightingData);
         ApplySimplePointLight(light, surface, lightingData, outInfo);
+        // End Carbonated
     }
 }
 

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/SimpleSpotLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/SimpleSpotLight.azsli
@@ -8,14 +8,26 @@
 
 #pragma once
 
+// Begin Carbonated
+#ifndef USING_COMPUTE_SHADER_LIGHT
+#define USING_COMPUTE_SHADER_LIGHT 0
+#endif
+// End Carbonated
+
 #include <Atom/Features/PBR/Lights/LightTypesCommon.azsli>
 
 #if ENABLE_SHADOWS
 #include <Atom/Features/Shadow/ProjectedShadow.azsli>
 #endif
 
-void ApplySimpleSpotLight(ViewSrg::SimpleSpotLight light, Surface surface, inout LightingData lightingData)
+// Begin Carbonated
+void ApplySimpleSpotLight(ViewSrg::SimpleSpotLight light, Surface surface, inout LightingData lightingData, out ApplyLightingInfo outInfo)
+// was: void ApplySimpleSpotLight(ViewSrg::SimpleSpotLight light, Surface surface, inout LightingData lightingData)
+// End Carbonated
 {
+    real3 lightIntensity = 0;
+    // shadow
+    real litRatio = 1.0;
     real3 posToLight = real3(light.m_position - surface.position);
     
     real3 dirToLight = normalize(posToLight);
@@ -40,11 +52,8 @@ void ApplySimpleSpotLight(ViewSrg::SimpleSpotLight light, Surface surface, inout
         
         // Standard quadratic falloff
         d2 = max(0.001 * 0.001, d2); // clamp the light to at least 1mm away to avoid extreme values.
-        real3 lightIntensity = (real3(light.m_rgbIntensityCandelas) / d2) * radiusAttenuation;
+        lightIntensity = (real3(light.m_rgbIntensityCandelas) / d2) * radiusAttenuation;
         real3 posToLightDir = normalize(posToLight);
-
-        // shadow
-        float litRatio = 1.0;
 
 #if ENABLE_SHADOWS
         if (o_enableShadows && o_enableSimpleSpotLightShadows)
@@ -65,7 +74,9 @@ void ApplySimpleSpotLight(ViewSrg::SimpleSpotLight light, Surface surface, inout
             float4 positionInView = mul(light.m_viewProjectionMatrix, float4(surface.position, 1.0));
             positionInView /= positionInView.w;
             float2 goboUv = float2((positionInView.x + 1.0)/2.0, (positionInView.y + 1.0)/2.0);
-            lightIntensity *= ViewSrg::m_goboTextures[light.m_goboTexIndex].Sample(PassSrg::LinearSampler, goboUv);
+// Begin Carbonated
+            lightIntensity *= SampleTexture(ViewSrg::m_goboTextures[light.m_goboTexIndex], PassSrg::LinearSampler, goboUv);   
+// End Carbonated
         }
 
         if (dotWithDirection < cosInnerConeAngle) // in penumbra
@@ -85,9 +96,16 @@ void ApplySimpleSpotLight(ViewSrg::SimpleSpotLight light, Surface surface, inout
         // Specular contribution
         lightingData.specularLighting += GetSpecularLighting(surface, lightingData, lightIntensity, posToLightDir);
     }
+// Begin Carbonated
+    outInfo.m_intensity = lightIntensity;
+    outInfo.m_litRatio = litRatio;
+// End Carbonated
 }
 
-void ApplySimpleSpotLightInternal(uint lightIndex, Surface surface, inout LightingData lightingData)
+// Begin Carbonated
+void ApplySimpleSpotLightInternal(uint lightIndex, Surface surface, inout LightingData lightingData, out ApplyLightingInfo outInfo)
+// was: void ApplySimpleSpotLightInternal(uint lightIndex, Surface surface, inout LightingData lightingData)
+// End Carbonated
 {
     if (o_enableSimpleSpotLights)
     {
@@ -96,9 +114,23 @@ void ApplySimpleSpotLightInternal(uint lightIndex, Surface surface, inout Lighti
         {
             return;
         }
-        ApplySimpleSpotLight(light, surface, lightingData);
+        ApplySimpleSpotLight(light, surface, lightingData, outInfo);
     }
 }
+
+// Begin Carbonated
+void ApplySimpleSpotLight(ViewSrg::SimpleSpotLight light, Surface surface, inout LightingData lightingData)
+{
+    ApplyLightingInfo outInfo;
+    ApplySimpleSpotLight(light, surface, lightingData, outInfo);
+}
+
+void ApplySimpleSpotLightInternal(uint lightIndex, Surface surface, inout LightingData lightingData)
+{
+    ApplyLightingInfo outInfo;
+    ApplySimpleSpotLightInternal(lightIndex, surface, lightingData, outInfo);
+}
+// End Carbonated
 
 void ApplySimpleSpotLights(Surface surface, inout LightingData lightingData)
 {

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/SimpleSpotLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/SimpleSpotLight.azsli
@@ -25,9 +25,11 @@ void ApplySimpleSpotLight(ViewSrg::SimpleSpotLight light, Surface surface, inout
 // was: void ApplySimpleSpotLight(ViewSrg::SimpleSpotLight light, Surface surface, inout LightingData lightingData)
 // End Carbonated
 {
+// Begin Carbonated
     real3 lightIntensity = 0;
     // shadow
     real litRatio = 1.0;
+// End Carbonated
     real3 posToLight = real3(light.m_position - surface.position);
     
     real3 dirToLight = normalize(posToLight);

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Forward/ForwardPassSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Pipeline/Forward/ForwardPassSrg.azsli
@@ -53,7 +53,16 @@ ShaderResourceGroup PassSrg : SRG_PerPass
 
     // Whether the m_linearDepthTexture is linear depth or original depth
     // This is useful for render pipeline which doesn't have a pass to convert original depth to linear depth
-    // We can use m_linearDepthTexture for original depth and set this flag to true. 
+    // We can use m_linearDepthTexture for original depth and set this flag to true.
     // And the shaders can calculate linear depth themselves
     uint m_isOriginalDepth;
+
+// Begin Carbonated
+#if !defined(FORCE_SMALL_SRGS) || ENABLE_VOLUMETRIC_FOG
+    // Precomputed froxel volume (in-scatter RGB, transmittance A) for transparent surfaces.
+    // Only bound during the transparent pass; SRG_PerPass_WithFallback makes it optional
+    // for opaque passes that do not use it.
+    Texture3D<float4> m_froxelVolumetricFog;
+#endif
+// End Carbonated
 }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadowCalculator.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadowCalculator.azsli
@@ -6,8 +6,8 @@
  *
  */
  
-#ifndef USING_COMPUTE_SHADER_DIRECTIONAL_LIGHT
-#define USING_COMPUTE_SHADER_DIRECTIONAL_LIGHT 0
+#ifndef USING_COMPUTE_SHADER_LIGHT
+#define USING_COMPUTE_SHADER_LIGHT 0
 #endif
 
 enum class ShadowFilterMethod {None, Pcf, Esm, EsmPcf};
@@ -198,7 +198,7 @@ void DirectionalShadowCalculator::ComputeShadowCoords()
     GetShadowCascadeRange(m_shadowCoords, m_cascadeCount, size, m_minCascade, m_maxCascade);
 
 // Todo: No ddx in compute, find a way to leverage world space normal for this
-#if !USING_COMPUTE_SHADER_DIRECTIONAL_LIGHT
+#if !USING_COMPUTE_SHADER_LIGHT
     if (m_receiverShadowPlaneBiasEnable)
     {
         for(int i = 0 ; i < m_cascadeCount; ++i)
@@ -309,7 +309,7 @@ real DirectionalShadowCalculator::SamplePcfBicubic(const float3 shadowCoord, con
     param.comparisonValue = shadowCoord.z;
     param.samplerState = SceneSrg::m_hwPcfSampler;
 
-#if USING_COMPUTE_SHADER_DIRECTIONAL_LIGHT
+#if USING_COMPUTE_SHADER_LIGHT
     param.receiverPlaneDepthBias = 0;
 #else
     param.receiverPlaneDepthBias = m_receiverShadowPlaneBiasEnable ? ComputeReceiverPlaneDepthBias(m_shadowPosDX[indexOfCascade], m_shadowPosDY[indexOfCascade]) : 0;

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadowCalculator.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadowCalculator.azsli
@@ -5,10 +5,14 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
- 
+
+// Begin Carbonated
+// was: #ifndef USING_COMPUTE_SHADER_DIRECTIONAL_LIGHT
+// #define USING_COMPUTE_SHADER_DIRECTIONAL_LIGHT 0
 #ifndef USING_COMPUTE_SHADER_LIGHT
 #define USING_COMPUTE_SHADER_LIGHT 0
 #endif
+// End Carbonated
 
 enum class ShadowFilterMethod {None, Pcf, Esm, EsmPcf};
 enum class ShadowFilterSampleCount {PcfTap4, PcfTap9, PcfTap16};
@@ -198,7 +202,10 @@ void DirectionalShadowCalculator::ComputeShadowCoords()
     GetShadowCascadeRange(m_shadowCoords, m_cascadeCount, size, m_minCascade, m_maxCascade);
 
 // Todo: No ddx in compute, find a way to leverage world space normal for this
+// Begin Carbonated
+// was: #if !USING_COMPUTE_SHADER_DIRECTIONAL_LIGHT
 #if !USING_COMPUTE_SHADER_LIGHT
+// End Carbonated
     if (m_receiverShadowPlaneBiasEnable)
     {
         for(int i = 0 ; i < m_cascadeCount; ++i)
@@ -309,7 +316,10 @@ real DirectionalShadowCalculator::SamplePcfBicubic(const float3 shadowCoord, con
     param.comparisonValue = shadowCoord.z;
     param.samplerState = SceneSrg::m_hwPcfSampler;
 
+// Begin Carbonated
+// was: #if USING_COMPUTE_SHADER_DIRECTIONAL_LIGHT
 #if USING_COMPUTE_SHADER_LIGHT
+// End Carbonated
     param.receiverPlaneDepthBias = 0;
 #else
     param.receiverPlaneDepthBias = m_receiverShadowPlaneBiasEnable ? ComputeReceiverPlaneDepthBias(m_shadowPosDX[indexOfCascade], m_shadowPosDY[indexOfCascade]) : 0;

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/VolumetricFog/ApplyVolumetricFog.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/VolumetricFog/ApplyVolumetricFog.azsli
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+// Begin Carbonated
+#ifndef ENABLE_VOLUMETRIC_FOG
+#define ENABLE_VOLUMETRIC_FOG            1
+#endif
+// End Carbonated
+
+// Applies precomputed volumetric fog to a transparent surface.
+//
+// Prerequisites (the including shader must have these already set up):
+//   - PassSrg (ForwardPassSrg.azsli) — provides m_froxelVolumetricFog and LinearSampler
+//   - SceneSrg  — provides m_volumetricFogData (fog constants)
+//   - ViewSrg   — provides m_viewProjectionMatrix and m_viewMatrix
+//
+// Usage in a transparent material's lighting shader:
+//
+//   #include <Atom/Features/VolumetricFog/ApplyVolumetricFog.azsli>
+//
+//   float3 finalColor = litColor;
+//   finalColor = ApplyVolumetricFog(finalColor, surface.position);
+//
+// worldPosition — the fragment's world-space position (from the surface struct or VS output)
+// litColor      — the fully-lit surface color before fog
+// Returns       — float4: .rgb = fogged color (inScatter + litColor * transmittance)
+//                          .a  = fog transmittance [0,1] at worldPosition
+//                 For standard alpha blending, use only .rgb and keep original alpha.
+//                 For premultiplied alpha blending where the background is already fogged
+//                 (e.g. FroxelCompositePass ran before the transparent pass):
+//                   output.rgb = particleAlpha * result.rgb + litColor * result.a
+//                   output.a   = particleAlpha   (no transmittance correction needed)
+//                 When fog is disabled (m_enabled == 0) returns float4(litColor, 1.0).
+
+float4 ApplyVolumetricFog(float3 litColor, float3 worldPosition)
+{
+#if ENABLE_VOLUMETRIC_FOG
+    if (SceneSrg::m_volumetricFogData.m_enabled == 0)
+    {
+        return float4(litColor, 1.0);
+    }
+
+    // Project world position to clip space → NDC → screen UV
+    float4 clipPos  = mul(ViewSrg::m_viewProjectionMatrix, float4(worldPosition, 1.0));
+    float2 ndc      = clipPos.xy / clipPos.w;
+    // DX/Vulkan UV convention: (0,0) = top-left; NDC Y is inverted relative to UV Y
+    float2 screenUV = float2(ndc.x * 0.5 + 0.5, -ndc.y * 0.5 + 0.5);
+
+    // Linear view-space depth (positive distance along the view axis)
+    float viewZ = abs(mul(ViewSrg::m_viewMatrix, float4(worldPosition, 1.0)).z);
+
+    // Map to froxel UVW using the same log-depth distribution as FroxelUtil::GetFroxelUVW
+    float fogNear = SceneSrg::m_volumetricFogData.m_fogNear;
+    float fogFar  = SceneSrg::m_volumetricFogData.m_fogFar;
+    float zUVW    = log(max(viewZ, fogNear) / fogNear) / log(fogFar / fogNear);
+    float3 uvw    = float3(screenUV, saturate(zUVW));
+
+    // Sample the integrated froxel volume (in-scatter RGB, transmittance A)
+    float4 fog = PassSrg::m_froxelVolumetricFog.SampleLevel(PassSrg::LinearSampler, uvw, 0);
+
+    return float4(fog.rgb + litColor * fog.a, fog.a);
+#else
+    return float4(litColor, 1.0);
+#endif
+}

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/VolumetricFog/ApplyVolumetricFog.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/VolumetricFog/ApplyVolumetricFog.azsli
@@ -17,9 +17,9 @@
 // Applies precomputed volumetric fog to a transparent surface.
 //
 // Prerequisites (the including shader must have these already set up):
-//   - PassSrg (ForwardPassSrg.azsli) — provides m_froxelVolumetricFog and LinearSampler
-//   - SceneSrg  — provides m_volumetricFogData (fog constants)
-//   - ViewSrg   — provides m_viewProjectionMatrix and m_viewMatrix
+//   - PassSrg (ForwardPassSrg.azsli): provides m_froxelVolumetricFog and LinearSampler
+//   - SceneSrg: provides m_volumetricFogData (fog constants)
+//   - ViewSrg: provides m_viewProjectionMatrix and m_viewMatrix
 //
 // Usage in a transparent material's lighting shader:
 //
@@ -28,9 +28,9 @@
 //   float3 finalColor = litColor;
 //   finalColor = ApplyVolumetricFog(finalColor, surface.position);
 //
-// worldPosition — the fragment's world-space position (from the surface struct or VS output)
-// litColor      — the fully-lit surface color before fog
-// Returns       — float4: .rgb = fogged color (inScatter + litColor * transmittance)
+// worldPosition: the fragment's world-space position (from the surface struct or VS output)
+// litColor     : the fully-lit surface color before fog
+// Returns      : float4: .rgb = fogged color (inScatter + litColor * transmittance)
 //                          .a  = fog transmittance [0,1] at worldPosition
 //                 For standard alpha blending, use only .rgb and keep original alpha.
 //                 For premultiplied alpha blending where the background is already fogged

--- a/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/SceneSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/SceneSrg.azsli
@@ -13,7 +13,10 @@
 #include <Atom/Feature/Common/Assets/ShaderResourceGroups/SkyBox/SceneSrg.azsli>
 #include <Atom/Feature/Common/Assets/ShaderResourceGroups/CoreLights/SceneSrg.azsli>
 #include <Atom/Feature/Common/Assets/ShaderResourceGroups/PostProcessing/SceneSrg.azsli>
-#include <Atom/Feature/Common/Assets/ShaderResourceGroups/Weather/SceneSrg.azsli> // CARNONATED addition
+// Begin Carbonated
+#include <Atom/Feature/Common/Assets/ShaderResourceGroups/Weather/SceneSrg.azsli>
+#include <Atom/Feature/Common/Assets/ShaderResourceGroups/VolumetricFog/SceneSrg.azsli>
+// End Carbonated
 
 partial ShaderResourceGroup SceneSrg
 {

--- a/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/VolumetricFog/SceneSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/VolumetricFog/SceneSrg.azsli
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#ifndef AZ_COLLECTING_PARTIAL_SRGS
+#error Do not include this file directly. Include the main .srgi file instead.
+#endif
+
+#define MAX_SEQUENCE_LENGTH 16 // Must match VolumetricFogConstants.h
+
+partial ShaderResourceGroup SceneSrg
+{ 
+    Texture3D<float>    m_noiseTexture;
+    Sampler             m_noiseSampler
+    {
+        AddressU      = Wrap;
+        AddressV      = Wrap;
+        AddressW      = Wrap;
+        MinFilter     = Linear;
+        MagFilter     = Linear;
+        MipFilter     = Linear;
+    };
+    
+    struct VolumetricFogConstants
+    {
+        float4   m_haltonSequence[MAX_SEQUENCE_LENGTH];
+        uint3    m_froxelCount;
+        uint     m_tileSize;
+        uint     m_frameIndex;
+        uint     m_lightingChannelMask;
+        float    m_fogNear;
+        float    m_fogFar;
+        uint     m_sequenceLength;
+        float    m_blendFactor;
+        uint     m_enabled;
+        float    m_padding0;
+    };
+    VolumetricFogConstants m_volumetricFogData;
+
+    struct VolumetricFogVolumeConstants
+    {
+        float3   m_fogAlbedo;
+        float    m_phaseG;
+        float    m_ambientIntensity;
+        float    m_fogDensity;
+        float    m_fogBaseHeight;
+        float    m_fogHeightFalloff;
+        float3   m_noiseWindVelocity;
+        float    m_noiseScale;
+        float3   m_emissiveColor;
+        float    m_emissiveIntensity;
+    };
+    VolumetricFogVolumeConstants m_volumetricFogVolumeData;
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCulling.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCulling.shader
@@ -10,14 +10,5 @@
             "type" : "Compute"
         }
         ]
-    },
-    "Supervariants":
-    [
-        {
-            "Name": "",
-            "AddBuildArguments": {
-                "debug": true
-            }
-        }
-    ]
+    }
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCulling.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCulling.shader
@@ -10,6 +10,14 @@
             "type" : "Compute"
         }
         ]
-    }
-
+    },
+    "Supervariants":
+    [
+        {
+            "Name": "",
+            "AddBuildArguments": {
+                "debug": true
+            }
+        }
+    ]
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/FullscreenShadow.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/FullscreenShadow.azsl
@@ -9,7 +9,7 @@
 #define THREADS 16
 
 // Todo: test Compute Shader version with async compute and LDS optimizations
-#define USING_COMPUTE_SHADER_DIRECTIONAL_LIGHT 0
+#define USING_COMPUTE_SHADER_LIGHT 0
 
 #include <Atom/Features/SrgSemantics.azsli>
 #include <viewsrg.srgi>
@@ -17,7 +17,7 @@
 
 #include <Atom/RPI/Math.azsli>
 
-#if !USING_COMPUTE_SHADER_DIRECTIONAL_LIGHT
+#if !USING_COMPUTE_SHADER_LIGHT
     #include <Atom/Features/PostProcessing/FullscreenPixelInfo.azsli>
     #include <Atom/Features/PostProcessing/FullscreenVertex.azsli>
 #endif
@@ -65,7 +65,7 @@ ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
     Texture2DArray<float> m_directionalShadowmapsESM;
     Texture2DMS<float> m_depth;
     Texture2D<float> m_depthLinear;
-#if USING_COMPUTE_SHADER_DIRECTIONAL_LIGHT
+#if USING_COMPUTE_SHADER_LIGHT
     RWTexture2D<float> m_fullscreenShadowOutput;
 #endif
 }
@@ -74,7 +74,7 @@ ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
 
 option enum class MsaaMode { MsaaNone, Msaa2x, Msaa4x, Msaa8x, Msaa16x } o_msaaMode = MsaaMode::MsaaNone;
 
-#if USING_COMPUTE_SHADER_DIRECTIONAL_LIGHT
+#if USING_COMPUTE_SHADER_LIGHT
     void ComputeWorldNormalAndPosition(const uint2 screenPos, out float3 outPositionWS, out float3 outNormalWS)
 #else
     void ComputeWorldNormalAndPosition(VSOutput IN, out float3 outPositionWS, out float3 outNormalWS)
@@ -108,7 +108,7 @@ option enum class MsaaMode { MsaaNone, Msaa2x, Msaa4x, Msaa8x, Msaa16x } o_msaaM
             break;
     }
 
-#if USING_COMPUTE_SHADER_DIRECTIONAL_LIGHT
+#if USING_COMPUTE_SHADER_LIGHT
     const float2 screenUV  = screenPos * pixelSize + pixelSamplePosition;             // The UV value [0, 1] of the screen pixel
 #else
     const int2   screenPos = IN.m_position.xy;                     // The coordinates of the screen pixel being shaded
@@ -150,7 +150,7 @@ option enum class MsaaMode { MsaaNone, Msaa2x, Msaa4x, Msaa8x, Msaa16x } o_msaaM
     outNormalWS   = mul(ViewSrg::m_viewMatrixInverse, float4(normalVS, 0) ).xyz;
 }
 
-#if USING_COMPUTE_SHADER_DIRECTIONAL_LIGHT
+#if USING_COMPUTE_SHADER_LIGHT
 
 [numthreads(THREADS, THREADS, 1)]
 void MainCS(uint3 thread_id : SV_GroupThreadID, uint3 group_id : SV_GroupID, uint3 dispatch_id: SV_DispatchThreadID, uint linear_id : SV_GroupIndex)
@@ -160,17 +160,17 @@ void MainCS(uint3 thread_id : SV_GroupThreadID, uint3 group_id : SV_GroupID, uin
     ComputeWorldNormalAndPosition(dispatch_id.xy, positionWS, normalWS);
    
     DirectionalShadowCalculator calc;
-    calc.SetLightIndex(PassSrg::m_constantData.m_lightIndex);
-    calc.SetWorldNormal(normalWS);
-    calc.SetReceiverShadowPlaneBiasEnable(PassSrg::m_constantData.m_receiverShadowPlaneBiasEnable);
-    calc.SetFilterMode((ShadowFilterMethod)PassSrg::m_constantData.m_filterMode);
-    calc.SetFilteringSampleCount((ShadowFilterSampleCount)PassSrg::m_constantData.m_filteringSampleCountMode);
-    calc.SetBlendBetweenCascadesEnable(PassSrg::m_constantData.m_blendBetweenCascadesEnable);
+    calc.SetBlendBetweenCascadesEnable(false);
 #if ENABLE_ESM_SHADOW
-    calc.SetShadowmaps(PassSrg::m_directionalShadowmaps, PassSrg::m_directionalShadowmapsESM);
+    calc.SetShadowmaps(PassSrg::m_directionalLightShadowmap, PassSrg::m_directionalLightExponentialShadowmap);
 #else
-    calc.SetShadowmaps(PassSrg::m_directionalShadowmaps);
+    calc.SetShadowmaps(PassSrg::m_directionalLightShadowmap);
 #endif
+    calc.SetReceiverShadowPlaneBiasEnable(true);
+    calc.SetWorldNormal(0);
+    calc.SetLightIndex(index);
+    calc.SetFilterMode(ShadowFilterMethod::None);
+    calc.SetFilteringSampleCount(ShadowFilterSampleCount::PcfTap16);
     calc.SetWorldPos(positionWS);
 
     PassSrg::m_fullscreenShadowOutput[dispatch_id.xy] = calc.GetVisibility();
@@ -185,17 +185,19 @@ PSOutput MainPS(VSOutput IN)
     ComputeWorldNormalAndPosition(IN, positionWS, normalWS);
 
     DirectionalShadowCalculator calc;
-    calc.SetLightIndex(PassSrg::m_constantData.m_lightIndex);
-    calc.SetWorldNormal(normalWS);
-    calc.SetReceiverShadowPlaneBiasEnable(PassSrg::m_constantData.m_receiverShadowPlaneBiasEnable);
-    calc.SetFilterMode((ShadowFilterMethod)PassSrg::m_constantData.m_filterMode);
-    calc.SetFilteringSampleCount((ShadowFilterSampleCount)PassSrg::m_constantData.m_filteringSampleCountMode);
-    calc.SetBlendBetweenCascadesEnable(PassSrg::m_constantData.m_blendBetweenCascadesEnable);
+            calc.SetBlendBetweenCascadesEnable(false);
 #if ENABLE_ESM_SHADOW
     calc.SetShadowmaps(PassSrg::m_directionalShadowmaps, PassSrg::m_directionalShadowmapsESM);
 #else
     calc.SetShadowmaps(PassSrg::m_directionalShadowmaps);
 #endif
+            calc.SetReceiverShadowPlaneBiasEnable(true);
+            calc.SetWorldNormal(0);
+            calc.SetLightIndex(PassSrg::m_constantData.m_lightIndex);
+            calc.SetFilterMode(ShadowFilterMethod::None);
+            calc.SetFilteringSampleCount(ShadowFilterSampleCount::PcfTap16);
+
+   
     calc.SetWorldPos(positionWS);
 
     PSOutput OUT;

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/FullscreenShadow.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/FullscreenShadow.azsl
@@ -9,7 +9,10 @@
 #define THREADS 16
 
 // Todo: test Compute Shader version with async compute and LDS optimizations
+// Begin Carbonated
+// #define USING_COMPUTE_SHADER_DIRECTIONAL_LIGHT 0
 #define USING_COMPUTE_SHADER_LIGHT 0
+// End Carbonated
 
 #include <Atom/Features/SrgSemantics.azsli>
 #include <viewsrg.srgi>
@@ -17,7 +20,10 @@
 
 #include <Atom/RPI/Math.azsli>
 
+// Begin Carbonated
+// #if !USING_COMPUTE_SHADER_DIRECTIONAL_LIGHT
 #if !USING_COMPUTE_SHADER_LIGHT
+// End Carbonated
     #include <Atom/Features/PostProcessing/FullscreenPixelInfo.azsli>
     #include <Atom/Features/PostProcessing/FullscreenVertex.azsli>
 #endif
@@ -65,7 +71,10 @@ ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
     Texture2DArray<float> m_directionalShadowmapsESM;
     Texture2DMS<float> m_depth;
     Texture2D<float> m_depthLinear;
+// Begin Carbonated
+// #if USING_COMPUTE_SHADER_DIRECTIONAL_LIGHT
 #if USING_COMPUTE_SHADER_LIGHT
+// End Carbonated
     RWTexture2D<float> m_fullscreenShadowOutput;
 #endif
 }
@@ -74,7 +83,10 @@ ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
 
 option enum class MsaaMode { MsaaNone, Msaa2x, Msaa4x, Msaa8x, Msaa16x } o_msaaMode = MsaaMode::MsaaNone;
 
+// Begin Carbonated
+// #if USING_COMPUTE_SHADER_DIRECTIONAL_LIGHT
 #if USING_COMPUTE_SHADER_LIGHT
+// End Carbonated
     void ComputeWorldNormalAndPosition(const uint2 screenPos, out float3 outPositionWS, out float3 outNormalWS)
 #else
     void ComputeWorldNormalAndPosition(VSOutput IN, out float3 outPositionWS, out float3 outNormalWS)
@@ -108,7 +120,10 @@ option enum class MsaaMode { MsaaNone, Msaa2x, Msaa4x, Msaa8x, Msaa16x } o_msaaM
             break;
     }
 
+// Begin Carbonated
+// #if USING_COMPUTE_SHADER_DIRECTIONAL_LIGHT
 #if USING_COMPUTE_SHADER_LIGHT
+// End Carbonated
     const float2 screenUV  = screenPos * pixelSize + pixelSamplePosition;             // The UV value [0, 1] of the screen pixel
 #else
     const int2   screenPos = IN.m_position.xy;                     // The coordinates of the screen pixel being shaded
@@ -150,7 +165,10 @@ option enum class MsaaMode { MsaaNone, Msaa2x, Msaa4x, Msaa8x, Msaa16x } o_msaaM
     outNormalWS   = mul(ViewSrg::m_viewMatrixInverse, float4(normalVS, 0) ).xyz;
 }
 
+// Begin Carbonated
+// #if USING_COMPUTE_SHADER_DIRECTIONAL_LIGHT
 #if USING_COMPUTE_SHADER_LIGHT
+// End Carbonated
 
 [numthreads(THREADS, THREADS, 1)]
 void MainCS(uint3 thread_id : SV_GroupThreadID, uint3 group_id : SV_GroupID, uint3 dispatch_id: SV_DispatchThreadID, uint linear_id : SV_GroupIndex)

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/FullscreenShadow.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/FullscreenShadow.shader
@@ -30,13 +30,7 @@
     },
 
     "Supervariants":
-    [
-        {
-            "Name": "",
-            "AddBuildArguments": {
-                "debug": true
-            }
-        },
+    [        
         {
             "Name": "NoMSAA",
                 "AddBuildArguments" : {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/FullscreenShadow.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/FullscreenShadow.shader
@@ -32,13 +32,18 @@
     "Supervariants":
     [
         {
+            "Name": "",
+            "AddBuildArguments": {
+                "debug": true
+            }
+        },
+        {
             "Name": "NoMSAA",
                 "AddBuildArguments" : {
                 "azslc": ["--no-ms"]
             }
         }
     ]
-
     // Todo: test Compute Shader version with async compute and LDS optimizations
     // "ProgramSettings" :
     // {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelComposite.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelComposite.azsl
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <scenesrg.srgi>
+#include <viewsrg.srgi>
+#include <Atom/Features/PostProcessing/FullscreenVertex.azsli>
+#include <Atom/Features/PostProcessing/FullscreenPixelInfo.azsli>
+#include "FroxelUtil.azsli"
+
+ShaderResourceGroup PassSrg : SRG_PerPass
+{
+    Sampler LinearSampler
+    {
+        MinFilter = Linear;
+        MagFilter = Linear;
+        MipFilter = Linear;
+        AddressU = Clamp;
+        AddressV = Clamp;
+        AddressW = Clamp;
+    };
+
+    Sampler PointSampler
+    {
+        MinFilter = Point;
+        MagFilter = Point;
+        MipFilter = Point;
+        AddressU = Clamp;
+        AddressV = Clamp;
+        AddressW = Clamp;
+    };
+
+    Texture3D<float4> m_froxelIntegrated;
+    Texture2D<float> m_linearDepthTexture;
+}
+
+PSOutput MainPS(VSOutput IN)
+{
+    PSOutput OUT;
+
+    float2 screenUV   = IN.m_texCoord.xy;
+
+    float viewZ = PassSrg::m_linearDepthTexture.Sample(PassSrg::PointSampler, IN.m_texCoord).r;
+    float3 uvw      = GetFroxelUVW(screenUV, viewZ);
+    uvw = saturate(uvw);
+    
+    float4 fog = PassSrg::m_froxelIntegrated.SampleLevel(PassSrg::LinearSampler, uvw, 0);
+
+    // Output in-scatter as RGB, transmittance as A.
+    // Hardware blending applies: result = fog.rgb + sceneColor * fog.a
+    OUT.m_color = float4(fog.xyz, fog.w);
+
+    return OUT;
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelComposite.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelComposite.shader
@@ -1,0 +1,46 @@
+{
+    "Source" : "FroxelComposite.azsl",
+    "DepthStencilState" : {
+        "Depth": 
+        {
+            "Enable": false,
+            "CompareFunc" : "Always"
+        }
+    },
+    "GlobalTargetBlendState": {
+        "Enable": true,
+        "BlendSource":      "One",
+        "BlendDest":        "AlphaSource",
+        "BlendOp":          "Add",
+        "BlendAlphaSource": "Zero",
+        "BlendAlphaDest":   "One",
+        "BlendAlphaOp":     "Add"
+    },
+    "ProgramSettings": {
+        "EntryPoints": [
+        {
+            "name": "MainVS",
+            "type" : "Vertex"
+        },
+        {
+            "name": "MainPS",
+            "type" : "Fragment"
+        }
+        ]
+    },
+    "Supervariants":
+    [
+        {
+            "Name": "",
+            "AddBuildArguments": {
+                "debug": true
+            }
+        },
+        {
+            "Name": "NoMSAA",
+            "AddBuildArguments": {
+                "azslc": ["--no-ms"]
+            }
+        }
+    ]
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelComposite.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelComposite.shader
@@ -29,13 +29,7 @@
         ]
     },
     "Supervariants":
-    [
-        {
-            "Name": "",
-            "AddBuildArguments": {
-                "debug": true
-            }
-        },
+    [        
         {
             "Name": "NoMSAA",
             "AddBuildArguments": {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelInject.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelInject.azsl
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <scenesrg.srgi>
+#include <viewsrg.srgi>
+#include "FroxelUtil.azsli"
+
+ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
+{
+    RWTexture3D<float4> m_froxelVolume;
+    RWTexture3D<float4> m_froxelEmissive;
+}
+
+option bool o_enableNoiseTexture = true;
+
+[numthreads(NUM_THREADS_PER_GROUP, NUM_THREADS_PER_GROUP, 1)]
+void MainCS(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+    uint3 froxelId = dispatchThreadID;
+    if (any(froxelId >= SceneSrg::m_volumetricFogData.m_froxelCount))
+    {
+        return;
+    }
+
+    float3 positionWS = GetFroxelWorldPosition(froxelId);
+    float4 medium = CalculateMediumContribution(positionWS, SceneSrg::m_volumetricFogVolumeData, SceneSrg::m_noiseTexture, o_enableNoiseTexture);
+    PassSrg::m_froxelVolume[froxelId] = medium;
+
+    // Global emissive: density-proportional (medium.a = extinction = local fog density)
+    float3 emissive = SceneSrg::m_volumetricFogVolumeData.m_emissiveColor
+                    * SceneSrg::m_volumetricFogVolumeData.m_emissiveIntensity
+                    * medium.a;
+    PassSrg::m_froxelEmissive[froxelId] = float4(emissive, 0.0);
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelInject.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelInject.shader
@@ -10,14 +10,5 @@
                 "type" : "Compute"
             }
         ]
-    },
-    "Supervariants":
-    [
-        {
-            "Name": "",
-            "AddBuildArguments": {
-                "debug": true
-            }
-        }
-    ]
+    }
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelInject.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelInject.shader
@@ -1,0 +1,23 @@
+{
+    "Source": "FroxelInject.azsl",
+    
+    "ProgramSettings" :
+    {
+        "EntryPoints":
+        [
+            {
+                "name": "MainCS",
+                "type" : "Compute"
+            }
+        ]
+    },
+    "Supervariants":
+    [
+        {
+            "Name": "",
+            "AddBuildArguments": {
+                "debug": true
+            }
+        }
+    ]
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelIntegrate.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelIntegrate.azsl
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <scenesrg.srgi>
+#include <viewsrg.srgi>
+#include <Atom/RPI/Math.azsli>
+#include "FroxelUtil.azsli"
+
+ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
+{
+    Texture3D<float4>   m_froxelScattered;       // current-frame raw light contribution
+    Texture3D<float4>   m_froxelHistory;         // previous-frame temporally-filtered scatter (ping-pong read)
+    RWTexture3D<float4> m_froxelTemporalOutput;  // this frame's temporal result (ping-pong write, for next frame)
+    Texture3D<float4>   m_froxelMedium;          // per-froxel scattering coefficient (rgb) + extinction (a)
+    Texture3D<float4>   m_froxelEmissive;        // per-froxel emissive
+    RWTexture3D<float4> m_froxelIntegrated;      // accumulated in-scatter (rgb) + transmittance (a)
+
+    Sampler LinearSampler
+    {
+        MinFilter = Linear;
+        MagFilter = Linear;
+        MipFilter = Linear;
+        AddressU = Clamp;
+        AddressV = Clamp;
+        AddressW = Clamp;
+    };
+}
+
+// -----------------------------------------------------------------------
+// Reproject a froxel's world position into the previous frame's froxel UVW
+// -----------------------------------------------------------------------
+bool ReprojectToHistory(float3 posWS, out float3 historyUVW)
+{
+    historyUVW = 0;
+    float4 prevClip = mul(ViewSrg::m_viewProjectionPrevMatrix, float4(posWS, 1.0));
+    if (prevClip.w <= 0.0f)
+        return false;
+
+    float3 prevNDC     = prevClip.xyz / prevClip.w;
+    float2 prevScreenUV = float2(prevNDC.x * 0.5f + 0.5f, 0.5f - prevNDC.y * 0.5f);
+    float  prevDepth   = prevClip.w;
+
+    float3 prevUVW = GetFroxelUVW(prevScreenUV, prevDepth);
+    if (any(prevUVW < 0.0) || any(prevUVW > 1.0))
+        return false;
+
+    historyUVW = prevUVW;
+    return true;
+}
+
+// -----------------------------------------------------------------------
+// Compute AABB of the current-frame values in a 3x3x3 neighborhood
+// to clamp history samples and suppress ghosting
+// -----------------------------------------------------------------------
+void ComputeNeighborhoodAABB(uint3 center, out float4 minVal, out float4 maxVal)
+{
+    minVal =  1e10;
+    maxVal = -1e10;
+    for (int dz = -1; dz <= 1; ++dz)
+    for (int dy = -1; dy <= 1; ++dy)
+    for (int dx = -1; dx <= 1; ++dx)
+    {
+        int3 coord = clamp(int3(center) + int3(dx, dy, dz),
+                           int3(0, 0, 0),
+                           int3(SceneSrg::m_volumetricFogData.m_froxelCount) - 1);
+        float4 s = PassSrg::m_froxelScattered[coord];
+        minVal   = min(minVal, s);
+        maxVal   = max(maxVal, s);
+    }
+}
+
+float4 ClipToAABB(float4 history, float4 current, float4 minVal, float4 maxVal)
+{
+    float4 extents = (maxVal - minVal) * 0.5 + 1e-6;
+    float4 delta   = history - current;
+    float4 units   = delta / extents;
+    float  maxUnit = max(max(abs(units.x), abs(units.y)),
+                         max(abs(units.z), abs(units.w)));
+    if (maxUnit <= 1.0)
+        return history;
+    return clamp(history, minVal, maxVal);
+}
+
+float4 LogEncodeRGBD(float4 rgbd) { return float4(log2(max(rgbd.rgb, 1e-6)), rgbd.a); }
+float4 LogDecodeRGBD(float4 rgbd) { return float4(exp2(rgbd.rgb), rgbd.a); }
+
+// -----------------------------------------------------------------------
+// Temporal blend for a single froxel
+// -----------------------------------------------------------------------
+float4 TemporalBlend(uint3 froxelId)
+{
+    float4 current = PassSrg::m_froxelScattered[froxelId];
+
+    if (SceneSrg::m_volumetricFogData.m_frameIndex == 1)
+        return current;
+
+    float3 posWS = GetFroxelWorldPosition(froxelId);
+    float3 historyUVW;
+    if (!ReprojectToHistory(posWS, historyUVW))
+        return current;
+
+    float3 cellSize   = 1.0f / float3(SceneSrg::m_volumetricFogData.m_froxelCount);
+    float3 clampedUVW = clamp(historyUVW, cellSize * 0.5f, 1.0f - cellSize * 0.5f);
+    float4 history    = PassSrg::m_froxelHistory.SampleLevel(PassSrg::LinearSampler, clampedUVW, 0);
+
+    float4 minNeighbor, maxNeighbor;
+    ComputeNeighborhoodAABB(froxelId, minNeighbor, maxNeighbor);
+
+    float4 historyLog = LogEncodeRGBD(history);
+    float4 currentLog = LogEncodeRGBD(current);
+    float4 minLog     = LogEncodeRGBD(float4(max(minNeighbor.rgb, 1e-6), minNeighbor.a));
+    float4 maxLog     = LogEncodeRGBD(float4(max(maxNeighbor.rgb, 1e-6), maxNeighbor.a));
+    historyLog = ClipToAABB(historyLog, currentLog, minLog, maxLog);
+
+    float4 blendedLog = lerp(historyLog, currentLog, SceneSrg::m_volumetricFogData.m_blendFactor);
+    return LogDecodeRGBD(blendedLog);
+}
+
+// -----------------------------------------------------------------------
+// One thread per (x, y) froxel column; z is iterated in the loop.
+// For each slice: temporal blend first, then Beer-Lambert integration.
+// -----------------------------------------------------------------------
+[numthreads(NUM_THREADS_PER_GROUP, NUM_THREADS_PER_GROUP, 1)]
+void MainCS(uint2 tileID : SV_DispatchThreadID)
+{
+    if (any(tileID >= SceneSrg::m_volumetricFogData.m_froxelCount.xy))
+        return;
+
+    float3 accumScatter      = 0;
+    float  accumTransparency = 1.0;
+    bool   doneIntegrating   = false;
+
+    uint  froxelCountZ = SceneSrg::m_volumetricFogData.m_froxelCount.z;
+    float fogNear      = SceneSrg::m_volumetricFogData.m_fogNear;
+    float fogFar       = SceneSrg::m_volumetricFogData.m_fogFar;
+
+    for (uint z = 0; z < froxelCountZ; ++z)
+    {
+        uint3 froxelId = uint3(tileID, z);
+
+        // --- Temporal reprojection (all slices, so history is fully populated next frame) ---
+        float4 blended = TemporalBlend(froxelId);
+        PassSrg::m_froxelTemporalOutput[froxelId] = blended;
+
+        // --- Beer-Lambert integration ---
+        if (!doneIntegrating)
+        {
+            float4 medium    = PassSrg::m_froxelMedium[froxelId];
+            float3 inScatter = blended.rgb * medium.rgb;
+            float  extinction = medium.a;
+            float3 emissive  = PassSrg::m_froxelEmissive[froxelId].rgb;
+
+            float sliceDepth = SliceToViewZ(z + 1, fogNear, fogFar, froxelCountZ)
+                             - SliceToViewZ(z,     fogNear, fogFar, froxelCountZ);
+            float sliceTransparency = exp(-extinction * sliceDepth);
+            float sliceOpacity      = 1.0 - sliceTransparency;
+            float scatterFactor     = (extinction > 1e-6) ? (sliceOpacity / extinction) : sliceDepth;
+
+            accumScatter      += (inScatter + emissive) * accumTransparency * scatterFactor;
+            accumTransparency *= sliceTransparency;
+
+            if (accumTransparency < 0.001)
+            {
+                accumTransparency = 0.0;
+                doneIntegrating   = true;
+            }
+        }
+
+        PassSrg::m_froxelIntegrated[froxelId] = float4(accumScatter, accumTransparency);
+    }
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelIntegrate.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelIntegrate.azsl
@@ -61,16 +61,19 @@ void ComputeNeighborhoodAABB(uint3 center, out float4 minVal, out float4 maxVal)
 {
     minVal =  1e10;
     maxVal = -1e10;
-    for (int dz = -1; dz <= 1; ++dz)
-    for (int dy = -1; dy <= 1; ++dy)
-    for (int dx = -1; dx <= 1; ++dx)
+    int3 start = max(int3(center) - 1, 0);
+    int3 end = min(int3(center) + 1, int3(SceneSrg::m_volumetricFogData.m_froxelCount) - 1);
+    for (int z = start.z; z <= end.z; ++z)
     {
-        int3 coord = clamp(int3(center) + int3(dx, dy, dz),
-                           int3(0, 0, 0),
-                           int3(SceneSrg::m_volumetricFogData.m_froxelCount) - 1);
-        float4 s = PassSrg::m_froxelScattered[coord];
-        minVal   = min(minVal, s);
-        maxVal   = max(maxVal, s);
+        for (int y = start.y; y <= end.y; ++y)
+        {
+            for (int x = start.x; x <= end.x; ++x)
+            {
+                float4 s = PassSrg::m_froxelScattered[int3(x, y, z)];
+                minVal   = min(minVal, s);
+                maxVal   = max(maxVal, s);
+            }
+        }
     }
 }
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelIntegrate.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelIntegrate.shader
@@ -1,0 +1,24 @@
+{
+    "Source": "FroxelIntegrate.azsl",
+    
+    "ProgramSettings" :
+    {
+        "EntryPoints":
+        [
+            {
+                "name": "MainCS",
+                "type" : "Compute"
+            }
+        ]
+    },
+    "Supervariants":
+    [
+        {
+            "Name": "",
+            "AddBuildArguments": {
+                "debug": true
+            }
+        }
+    ]
+
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelIntegrate.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelIntegrate.shader
@@ -10,15 +10,5 @@
                 "type" : "Compute"
             }
         ]
-    },
-    "Supervariants":
-    [
-        {
-            "Name": "",
-            "AddBuildArguments": {
-                "debug": true
-            }
-        }
-    ]
-
+    }
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelLocalVolume.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelLocalVolume.azsl
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ * FroxelLocalVolumeRaster.azsl — local fog volume injection via rasterization
+ *
+ * One shader, one fragment output. Five blend modes are selected entirely
+ * by pipeline state (HW fixed-function blending):
+ *   - ADDITIVE:  Src + Dst        — BlendOp::Add,    factors One, One
+ *   - MULTIPLY:  Src * Dst        — BlendOp::Add,    factors ColorDest, Zero
+ *   - OVERWRITE: Src              — BlendOp::Add,    factors One, Zero
+ *   - MIN:       min(Src, Dst)    — BlendOp::Min     (factors ignored)
+ *   - MAX:       max(Src, Dst)    — BlendOp::Max     (factors ignored)
+ *
+ * Architecture:
+ *   - One draw call per blend-mode batch (volumes sorted CPU-side)
+ *   - Each volume drawn as a unit cube (box) or icosphere (sphere) proxy
+ *   - instanceCount = number of slices the volume covers
+ *   - SV_RenderTargetArrayIndex routes each instance to its Z slice
+ *   - Fragment shader writes (scattering, extinction); HW blends into V-buffer
+ */
+
+#include <scenesrg.srgi>
+#include <viewsrg.srgi>
+#include "FroxelUtil.azsli"
+
+// Volume shape types
+enum FogVolumeShape
+{
+    Box = 0,
+    Sphere
+};
+
+// --------------------------------------------------------------------------
+// Per-volume GPU data — keep packed. Must match LocalVolumeData on C++ side.
+// --------------------------------------------------------------------------
+struct LocalVolumeData
+{
+    float3 m_center;
+    uint m_shape;
+    float3 m_right;
+    float  m_extentX;
+    float3 m_up;
+    float  m_extentY;
+    float3 m_forward;
+    float  m_extentZ;
+    float3 m_rcpFadePos;
+    int    m_noiseTextureIndex;  // -1 if no noise texture
+    float3 m_rcpFadeNeg;
+    uint   m_sliceMin;
+    uint   m_sliceMax;
+    uint   m_priority;
+    uint   m_blendMode;
+    uint   m_pad0;
+    SceneSrg::VolumetricFogVolumeConstants m_volumeData;
+};
+
+// --------------------------------------------------------------------------
+// Map a volume-local position (range [-1, 1] for box, unit ball for sphere)
+// to an edge fade factor in [0, 1].
+// --------------------------------------------------------------------------
+float ComputeBoxEdgeFade(float3 localPos, float3 rcpFadePos, float3 rcpFadeNeg)
+{
+    // localPos is in [-1, 1] range.
+    // For each axis, distance to nearest face is (1 - |localPos|).
+    // Multiply by rcpFade to get the fade factor.
+    float3 fadePos = saturate((1.0 - localPos) * rcpFadePos);
+    float3 fadeNeg = saturate((1.0 + localPos) * rcpFadeNeg);
+    float3 fade    = min(fadePos, fadeNeg);
+    return fade.x * fade.y * fade.z;
+}
+
+float ComputeSphereEdgeFade(float3 localPos, float rcpFadePos)
+{
+    // For a sphere, only one falloff distance makes sense (the radial one).
+    // Use rcpFadePos.x as the fade distance.
+    float r = length(localPos);
+    return saturate((1.0 - r) * rcpFadePos);
+}
+
+// --------------------------------------------------------------------------
+// Transform a world-space point into the volume's local space.
+// For a box: returns position in [-1, 1] when inside.
+// For a sphere: returns position in unit ball when inside.
+// --------------------------------------------------------------------------
+float3 WorldToVolumeLocal(float3 posWS, LocalVolumeData volume)
+{
+    float3 toPos = posWS - volume.m_center;
+    float3 localPos;
+    localPos.x = dot(toPos, volume.m_right)   / max(volume.m_extentX, 1e-5);
+    localPos.y = dot(toPos, volume.m_up)      / max(volume.m_extentY, 1e-5);
+    localPos.z = dot(toPos, volume.m_forward) / max(volume.m_extentZ, 1e-5);
+    return localPos;
+}
+
+// --------------------------------------------------------------------------
+// Test if a local-space position is inside the volume's actual shape.
+// --------------------------------------------------------------------------
+bool IsInsideVolume(float3 localPos, uint shape)
+{
+    if (shape == FogVolumeShape::Box)
+    {
+        return all(abs(localPos) <= 1.0);
+    }
+    else // FogVolumeShape::Sphere
+    {
+        return dot(localPos, localPos) <= 1.0;
+    }
+}
+
+// --------------------------------------------------------------------------
+// Compute the volume's contribution at a froxel center.
+// Returns scattering (rgb) and extinction (a). Returns 0 if outside.
+// --------------------------------------------------------------------------
+bool EvaluateVolume(float3 froxelWS, float3 cameraWS, LocalVolumeData volume, Texture3D<float> noiseTexture, out float4 contribution)
+{
+    float3 localPos = WorldToVolumeLocal(froxelWS, volume);
+
+    if (!IsInsideVolume(localPos, volume.m_shape))
+    {
+        contribution = 0;
+        return false;
+    }
+
+    // Edge fade based on shape
+    float edgeFade;
+    if (volume.m_shape == FogVolumeShape::Box)
+    {
+        edgeFade = ComputeBoxEdgeFade(localPos, volume.m_rcpFadePos, volume.m_rcpFadeNeg);
+    }
+    else
+    {
+        edgeFade = ComputeSphereEdgeFade(localPos, volume.m_rcpFadePos.x);
+    }
+
+    contribution = CalculateMediumContribution(froxelWS, volume.m_volumeData, noiseTexture, volume.m_noiseTextureIndex >= 0);
+    contribution *= edgeFade;
+    return true;
+}
+
+ShaderResourceGroup PassSrg : SRG_PerPass
+{
+    Buffer<float3>          m_proxyVertices[2];
+    Buffer<uint>            m_proxyIndices[2];
+    StructuredBuffer<LocalVolumeData> m_volumes;
+    Buffer<uint2>           m_instanceToVolumeSlice;
+    Texture3D<float>        m_noiseTextures[];
+};
+
+struct VSOutput
+{
+    float4 m_position        : SV_Position;
+    nointerpolation uint m_volumeIndex   : VOLUME_INDEX;
+    nointerpolation uint m_sliceIndex    : SLICE_INDEX;
+    nointerpolation uint m_rtArrayIndex  : SV_RenderTargetArrayIndex;
+};
+
+VSOutput MainVS(uint vertexId   : SV_VertexID,
+                uint instanceId : SV_InstanceID)
+{
+    VSOutput output;
+
+    uint2 mapping    = PassSrg::m_instanceToVolumeSlice[instanceId];
+    uint volumeIndex = mapping.x;
+    uint sliceIndex  = mapping.y;
+
+    LocalVolumeData volume = PassSrg::m_volumes[volumeIndex];
+    StructuredBuffer<float3> vertices;
+    StructuredBuffer<uint> indices;
+
+    uint actualVertexIndex = PassSrg::m_proxyIndices[volume.m_shape][vertexId];
+    float3 localVertex     = PassSrg::m_proxyVertices[volume.m_shape][actualVertexIndex];
+
+    // Transform proxy vertex by the OBB basis to get the actual world-space corner.
+    // Same transform works for box (vertices in [-1, 1]) and sphere (vertices on unit ball).
+    float3 worldVertex = volume.m_center
+                       + localVertex.x * volume.m_right   * volume.m_extentX
+                       + localVertex.y * volume.m_up      * volume.m_extentY
+                       + localVertex.z * volume.m_forward * volume.m_extentZ;
+
+    output.m_position     = mul(ViewSrg::m_viewProjectionMatrix, float4(worldVertex, 1.0));
+    output.m_volumeIndex  = volumeIndex;
+    output.m_sliceIndex   = sliceIndex;
+    output.m_rtArrayIndex = sliceIndex;
+    return output;
+}
+
+// --------------------------------------------------------------------------
+// Fragment shader — mode-agnostic. Writes (scattering, extinction).
+// Blend mode is applied by HW fixed-function blending.
+//
+// For OVERWRITE on froxels OUTSIDE the volume, we must NOT clobber existing fog.
+// The cleanest way: discard fragments outside the actual OBB/sphere. This
+// prevents the rasterizer from invoking the blend at those pixels at all.
+// (For ADDITIVE/MIN/MAX, writing zero would also work — but for OVERWRITE,
+// writing zero would erase existing fog. discard is the universal fix.)
+// --------------------------------------------------------------------------
+struct PSOutput
+{
+    float4 m_color    : SV_Target0;  // RGB = scattering, A = extinction
+    float4 m_emissive : SV_Target1;  // RGB = emissive, A = unused
+};
+
+PSOutput MainPS(VSOutput input)
+{
+    PSOutput output;
+
+    LocalVolumeData volume = PassSrg::m_volumes[input.m_volumeIndex];
+
+    // Reconstruct froxel center world position
+    uint3 froxelId  = uint3(uint2(input.m_position.xy), input.m_sliceIndex);
+    float3 froxelWS = GetFroxelWorldPosition(froxelId);
+
+    float4 contribution = 0;
+    bool isValid = EvaluateVolume(  froxelWS,
+                                     ViewSrg::m_worldPosition.xyz,
+                                     volume,
+                                     PassSrg::m_noiseTextures[volume.m_noiseTextureIndex],
+                                     contribution);
+
+    if (!isValid)
+    {
+        discard;
+    }
+
+    output.m_color = contribution;
+    // Emissive: density + edge-fade weighted (contribution.a = extinction × edgeFade).
+    // Written to RT1 and blended additively so contributions from multiple volumes accumulate.
+    output.m_emissive = float4(
+        volume.m_volumeData.m_emissiveColor * volume.m_volumeData.m_emissiveIntensity * contribution.a,
+        0.0);
+    return output;
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelLocalVolume.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelLocalVolume.azsl
@@ -4,15 +4,15 @@
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
- * FroxelLocalVolumeRaster.azsl — local fog volume injection via rasterization
+ * FroxelLocalVolumeRaster.azsl: local fog volume injection via rasterization
  *
  * One shader, one fragment output. Five blend modes are selected entirely
  * by pipeline state (HW fixed-function blending):
- *   - ADDITIVE:  Src + Dst        — BlendOp::Add,    factors One, One
- *   - MULTIPLY:  Src * Dst        — BlendOp::Add,    factors ColorDest, Zero
- *   - OVERWRITE: Src              — BlendOp::Add,    factors One, Zero
- *   - MIN:       min(Src, Dst)    — BlendOp::Min     (factors ignored)
- *   - MAX:       max(Src, Dst)    — BlendOp::Max     (factors ignored)
+ *   - ADDITIVE:  Src + Dst        : BlendOp::Add,    factors One, One
+ *   - MULTIPLY:  Src * Dst        : BlendOp::Add,    factors ColorDest, Zero
+ *   - OVERWRITE: Src              : BlendOp::Add,    factors One, Zero
+ *   - MIN:       min(Src, Dst)    : BlendOp::Min     (factors ignored)
+ *   - MAX:       max(Src, Dst)    : BlendOp::Max     (factors ignored)
  *
  * Architecture:
  *   - One draw call per blend-mode batch (volumes sorted CPU-side)
@@ -34,7 +34,7 @@ enum FogVolumeShape
 };
 
 // --------------------------------------------------------------------------
-// Per-volume GPU data — keep packed. Must match LocalVolumeData on C++ side.
+// Per-volume GPU data, keep packed. Must match LocalVolumeData on C++ side.
 // --------------------------------------------------------------------------
 struct LocalVolumeData
 {
@@ -188,13 +188,13 @@ VSOutput MainVS(uint vertexId   : SV_VertexID,
 }
 
 // --------------------------------------------------------------------------
-// Fragment shader — mode-agnostic. Writes (scattering, extinction).
+// Fragment shader mode-agnostic. Writes (scattering, extinction).
 // Blend mode is applied by HW fixed-function blending.
 //
 // For OVERWRITE on froxels OUTSIDE the volume, we must NOT clobber existing fog.
 // The cleanest way: discard fragments outside the actual OBB/sphere. This
 // prevents the rasterizer from invoking the blend at those pixels at all.
-// (For ADDITIVE/MIN/MAX, writing zero would also work — but for OVERWRITE,
+// (For ADDITIVE/MIN/MAX, writing zero would also work but for OVERWRITE,
 // writing zero would erase existing fog. discard is the universal fix.)
 // --------------------------------------------------------------------------
 struct PSOutput

--- a/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelLocalVolume.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelLocalVolume.shader
@@ -24,14 +24,5 @@
         ] 
     },
 
-    "DrawList" : "froxelLocalVolume",
-    "Supervariants":
-    [
-        {
-            "Name": "",
-            "AddBuildArguments": {
-                "debug": true
-            }
-        }
-    ]
+    "DrawList" : "froxelLocalVolume"
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelLocalVolume.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelLocalVolume.shader
@@ -1,0 +1,37 @@
+{
+    "Source" : "FroxelLocalVolume.azsl",
+
+    "RasterState": { "CullMode": "None" },
+
+     "DepthStencilState" : { 
+        "Depth" : { 
+            "Enable" : false 
+        }
+    },
+
+    "ProgramSettings" : 
+    {
+        "EntryPoints":
+        [
+            {
+                "name": "MainVS",
+                "type" : "Vertex"
+            },
+            {
+              "name": "MainPS",
+              "type": "Fragment"
+            }
+        ] 
+    },
+
+    "DrawList" : "froxelLocalVolume",
+    "Supervariants":
+    [
+        {
+            "Name": "",
+            "AddBuildArguments": {
+                "debug": true
+            }
+        }
+    ]
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelScatter.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelScatter.azsl
@@ -1,0 +1,336 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#define USING_COMPUTE_SHADER_LIGHT 1
+
+#ifndef ENABLE_ESM_SHADOW
+#define ENABLE_ESM_SHADOW               1
+#endif
+
+#define ENABLE_TRANSMISSION 0
+#define ENABLE_FULLSCREEN_SHADOW 0
+#define ENABLE_BRDF_MAP 0
+
+#include <scenesrg.srgi>
+#include <viewsrg.srgi>
+#include <Atom/Features/LightCulling/LightCullingTileIterator.azsli>
+#include <Atom/RPI/Math.azsli>
+#include "FroxelUtil.azsli"
+
+ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
+{
+    RWTexture3D<float4> m_froxelScatterResult;
+
+    Texture2D<uint4> m_tileLightData;
+    StructuredBuffer<uint> m_lightListRemapped;
+
+    Sampler LinearSampler
+    {
+        MinFilter = Linear;
+        MagFilter = Linear;
+        MipFilter = Linear;
+        AddressU = Clamp;
+        AddressV = Clamp;
+        AddressW = Clamp;
+    };
+
+    Sampler PointSampler
+    {
+        MinFilter = Point;
+        MagFilter = Point;
+        MipFilter = Point;
+        AddressU = Clamp;
+        AddressV = Clamp;
+        AddressW = Clamp;
+    };
+
+    Texture2DArray<float> m_directionalLightShadowmap;
+    Texture2DArray<float> m_directionalLightExponentialShadowmap;
+    Texture2D<float> m_fullscreenShadow;
+    Texture2DArray<float> m_projectedShadowmaps;
+    Texture2DArray<float>   m_projectedExponentialShadowmap;
+    Texture2D m_brdfMap;
+}
+
+#include <Atom/Features/PBR/Surfaces/StandardSurface.azsli>
+#include <Atom/Features/PBR/Lighting/LightingData.azsli>
+
+enum FogCullLightType
+{
+    SimplePointLight,
+    PointLight,
+    SimpleSpot,
+    DiskLight,
+    CapsuleLight,
+    QuadLight,
+    PolygonLight
+};
+
+real3 GetDiffuseLighting(Surface surface, LightingData lightingData, real3 lightIntensity, real3 dirToLight)
+{
+    return 0; 
+}
+
+real3 GetSpecularLighting(Surface surface, LightingData lightingData, const real3 lightIntensity, const real3 dirToLight)
+{
+    return 0;
+}
+
+#include <Atom/Features/PBR/Lights/Lights.azsli>
+
+static const float3 FogNormal = float3(0, 0, 1);
+
+float HenyeyGreenstein(float cosTheta)
+{
+    float g  = SceneSrg::m_volumetricFogVolumeData.m_phaseG;
+    float g2    = g * g;
+    float denom = 1.0 + g2 - 2.0 * g * cosTheta;
+    return (1.0 - g2) / (4.0 * PI * pow(denom, 1.5));
+}
+
+void CalculatePhaseAndAttenuation(float3 lightPosWS, float3 posWS, float extintion, out float phase, out float light_attenuation)
+{
+    light_attenuation = 0;
+    phase = 0;
+    float3 toLight = lightPosWS - posWS;
+    float distToLight = length(toLight);
+    if (distToLight > 0)
+    {
+        float3 L = toLight / max(distToLight, 1e-5);
+        float3 V = normalize(posWS - ViewSrg::m_worldPosition.xyz);
+        // cos(theta) between L and V for phase function
+        float cosTheta = dot(L, V);
+
+        // Henyey-Greenstein phase function
+        phase = HenyeyGreenstein(cosTheta);
+        light_attenuation = exp(-extintion * distToLight);
+    }
+}
+
+float3 ApplyFogDirectionalLights(
+    inout Surface surface,
+    inout LightingData lightingData,
+    float extintion,
+    float4 screenUv)
+{
+    float3 inScattering = 0;
+    for (int index = 0; index < SceneSrg::m_directionalLightCount; index++)
+    {
+        SceneSrg::DirectionalLight light = SceneSrg::m_directionalLights[index];
+
+        float phase, light_attenuation;
+        CalculatePhaseAndAttenuation(surface.position -light.m_direction, surface.position, extintion, phase, light_attenuation);
+
+        float opticalDepth = 1.0f;
+        light_attenuation = exp(-extintion * opticalDepth);
+
+        ApplyLightingInfo outInfo;
+        outInfo.Init();
+        ApplyDirectionalLight(index, surface, lightingData, screenUv, outInfo);
+        // ---- In-scattering ---------------------------------------------------
+        inScattering += outInfo.m_intensity * light_attenuation * phase * outInfo.m_litRatio;
+    }
+    return inScattering;
+}
+
+float3 ApplyLightsByType(
+    FogCullLightType type,
+    Surface surface,
+    inout LightingData lightingData,
+    float extintion)
+{
+    float3 inScattering = 0;
+    lightingData.tileIterator.LoadAdvance();    
+    while( !lightingData.tileIterator.IsDone() ) 
+    { 
+        uint lightIndex = lightingData.tileIterator.GetValue(); 
+        lightingData.tileIterator.LoadAdvance();
+
+        float3 lightPosWS = 0;
+        ApplyLightingInfo outInfo;
+        outInfo.Init();
+        switch(type)
+        {
+            case FogCullLightType::SimplePointLight:
+                lightPosWS = ViewSrg::m_simplePointLights[lightIndex].m_position;
+                ApplySimplePointLightInternal(lightIndex, surface, lightingData, outInfo);
+                break;
+            case FogCullLightType::PointLight:
+            {
+                ViewSrg::PointLight light = ViewSrg::m_pointLights[lightIndex];
+                float3 lightDir = normalize(surface.position - light.m_position);
+                lightPosWS = light.m_position + lightDir * light.m_bulbRadius;
+                ApplyPointLightInternal(lightIndex, surface, lightingData, outInfo);
+                break;
+            }
+            case FogCullLightType::SimpleSpot:
+                lightPosWS = ViewSrg::m_simpleSpotLights[lightIndex].m_position;
+                ApplySimpleSpotLightInternal(lightIndex, surface, lightingData, outInfo);
+                break;
+            case FogCullLightType::DiskLight:
+            {
+                ViewSrg::DiskLight light = ViewSrg::m_diskLights[lightIndex];
+                float3 posToLight = light.m_position - surface.position;
+                float3 B = light.m_position - dot(posToLight, -light.m_direction) * (-light.m_direction);
+                float3 centerToB = B - light.m_position;
+                float lateralDistance = length(centerToB);
+                lightPosWS = light.m_position + normalize(centerToB) * min(lateralDistance, light.m_diskRadius);
+                ApplyDiskLightInternal(lightIndex, surface, lightingData, outInfo);
+                break;
+            }
+            case FogCullLightType::CapsuleLight:
+            {
+                ViewSrg::CapsuleLight light = ViewSrg::m_capsuleLights[lightIndex];
+                float lightLength = light.m_length;
+                float3 startPoint = light.m_startPoint;
+                
+                float3 surfaceToStart = startPoint - surface.position;
+                float closestPointDistance = dot(-surfaceToStart, light.m_direction);
+                closestPointDistance = clamp(closestPointDistance, 0.0f, lightLength);
+
+                float3 dirToClosestPoint = surfaceToStart + closestPointDistance * light.m_direction;
+                lightPosWS = surface.position + dirToClosestPoint;
+                ApplyCapsuleLightInternal(lightIndex, surface, lightingData, outInfo);
+                break;
+            }
+            case FogCullLightType::QuadLight:
+            {
+                ViewSrg::QuadLight light = ViewSrg::m_quadLights[lightIndex];
+                lightPosWS = ClosestPointRect(surface.position, light.m_position, light.m_leftDir, light.m_upDir, float2(light.m_halfWidth, light.m_halfHeight));
+                ApplyQuadLightInternal(lightIndex, surface, lightingData, outInfo);
+                break;
+            }
+            case FogCullLightType::PolygonLight:
+                // Just use the light position as the light source. Calculating a "proper" source point is too expensive.
+                lightPosWS = ViewSrg::m_polygonLights[lightIndex].m_position;
+                ApplyPoylgonLight(ViewSrg::m_polygonLights[lightIndex], surface, lightingData, outInfo);
+                break;
+        }
+
+        float phase, light_attenuation;
+        CalculatePhaseAndAttenuation(lightPosWS, surface.position, extintion, phase, light_attenuation);
+        
+        // ---- In-scattering ---------------------------------------------------
+        inScattering += outInfo.m_intensity * light_attenuation * phase * outInfo.m_litRatio;
+    }
+    return inScattering;
+}
+
+float3 SampleIBL(float3 dir)
+{
+    float3 iblIrradianceDir = MultiplyVectorQuaternion(dir, SceneSrg::m_iblOrientation);
+    float3 iblCubemapCoords = GetCubemapCoords(iblIrradianceDir);
+    return SceneSrg::m_diffuseEnvMap.SampleLevel(SceneSrg::m_samplerEnv, iblCubemapCoords, 0).rgb;
+}
+
+float3 EvaluateAmbientFog(float3 positionWS)
+{
+    // Approximate spherical ambient for fog
+    // Two samples, weighted by typical sky/ground solid angle ratio
+    float3 skyColor    = SampleIBL(float3(0, 0, 1));
+    float3 groundColor = SampleIBL(float3(0, 0, -1));
+
+    float  iblExposureScale  = pow(2.0f, SceneSrg::m_iblExposure);
+
+    // froxelWS.z is world height (assuming Z-up, adjust for your convention)
+    float groundHeight = 0.0;
+    float heightAboveGround = max(positionWS.z - groundHeight, 0.0);
+
+    // At ground level: 50/50 sky/ground. At height: sky dominates.
+    // Exponential blend — 5m above ground is already ~80% sky
+    float groundFactor = exp(-heightAboveGround * 0.2);
+    float skyFactor    = 1.0 - groundFactor * 0.5;       // sky never below 0.5
+
+    float3 ambientFog = skyColor * skyFactor + groundColor * groundFactor * 0.5;
+    return ambientFog * iblExposureScale;
+}
+
+void SkipLightGroup(inout LightCullingTileIterator tileIterator)
+{
+    tileIterator.LoadAdvance();    
+    while( !tileIterator.IsDone() ) 
+    { 
+        tileIterator.LoadAdvance();
+    }
+}
+
+[numthreads(NUM_THREADS_PER_GROUP, NUM_THREADS_PER_GROUP, 1)]
+void MainCS(uint3 froxelId : SV_DispatchThreadID)
+{
+    if (any(froxelId >= SceneSrg::m_volumetricFogData.m_froxelCount))
+    {
+        return;
+    }
+
+    float extinction = SceneSrg::m_volumetricFogVolumeData.m_fogDensity;
+
+    if (extinction < 1e-6)
+    {
+        PassSrg::m_froxelScatterResult[froxelId] = float4(0, 0, 0, 0);
+        return;
+    }
+
+    uint jitterIdx    = (SceneSrg::m_volumetricFogData.m_frameIndex) % SceneSrg::m_volumetricFogData.m_sequenceLength;
+    float3 jitter     = SceneSrg::m_volumetricFogData.m_haltonSequence[jitterIdx].xyz;
+
+    // --- XY: jitter in normalized froxel UV space ---
+    // froxelUV is the center of the froxel tile in [0,1] screen UV
+    float2 froxelCenter = float2(froxelId.xy) + 0.5;
+    float2 jitterFroxelCenter = froxelCenter + jitter.xy;
+    float2 jitteredUV   = jitterFroxelCenter / float2(SceneSrg::m_volumetricFogData.m_froxelCount.xy);
+
+    // --- Z: jitter in linear depth ---
+    float sliceNear     = SliceToViewZ(froxelId.z,     SceneSrg::m_volumetricFogData.m_fogNear, SceneSrg::m_volumetricFogData.m_fogFar, SceneSrg::m_volumetricFogData.m_froxelCount.z);
+    float sliceFar      = SliceToViewZ(froxelId.z + 1, SceneSrg::m_volumetricFogData.m_fogNear, SceneSrg::m_volumetricFogData.m_fogFar, SceneSrg::m_volumetricFogData.m_froxelCount.z);
+    float sliceCenter   = (sliceNear + sliceFar) * 0.5f;
+    float sliceThick    = sliceFar - sliceNear;
+    float jitteredDepth = sliceCenter + jitter.z * sliceThick;
+
+    // Froxel center in screen UV
+    float3 jitterPositionVS = ViewSrg::GetViewSpacePosition(jitteredUV, jitteredDepth);
+    jitterPositionVS.z = -jitterPositionVS.z;
+
+    // Transform to world space for density sampling
+    float3 jitteredPosWS = mul(ViewSrg::m_viewMatrixInverse, float4(jitterPositionVS, 1.0)).xyz;
+
+    float3 inScatter = 0;
+    float2 screenPos = float2(froxelId.xy) * SceneSrg::m_volumetricFogData.m_tileSize  + 0.5;  // Pixel center
+    float4 svPosition = float4(screenPos, 0, sliceCenter);
+
+    Surface surface = (Surface)0;
+    surface.position = jitteredPosWS;
+    surface.normal = FogNormal;
+    surface.vertexNormal = FogNormal;
+
+    LightingData lightingData;
+    lightingData.tileIterator.Init(svPosition, PassSrg::m_lightListRemapped, PassSrg::m_tileLightData);
+    lightingData.lightingChannels = SceneSrg::m_volumetricFogData.m_lightingChannelMask;
+
+    // Ambient / directional (not in light list, always evaluated)
+    inScatter += ApplyFogDirectionalLights(surface, lightingData, extinction, svPosition);
+
+    if (SceneSrg::m_volumetricFogVolumeData.m_ambientIntensity > 0)
+    {
+        // Ambient IBL contribution — scatteringCoeff is applied in FroxelIntegrate, not here
+        float3 ambientIBL = EvaluateAmbientFog(surface.position);
+        inScatter += ambientIBL * SceneSrg::m_volumetricFogVolumeData.m_ambientIntensity;
+    }
+
+    // Skip Decals group
+    SkipLightGroup(lightingData.tileIterator);
+    lightingData.Init(surface.position, surface.normal, surface.roughnessLinear, ViewSrg::m_worldPosition.xyz);
+    inScatter += ApplyLightsByType(FogCullLightType::SimplePointLight, surface, lightingData, extinction);
+    inScatter += ApplyLightsByType(FogCullLightType::SimpleSpot, surface, lightingData, extinction);
+    inScatter += ApplyLightsByType(FogCullLightType::PointLight, surface, lightingData, extinction);
+    inScatter += ApplyLightsByType(FogCullLightType::DiskLight, surface, lightingData, extinction);
+    inScatter += ApplyLightsByType(FogCullLightType::CapsuleLight, surface, lightingData, extinction);
+    inScatter += ApplyLightsByType(FogCullLightType::QuadLight, surface, lightingData, extinction);
+    inScatter += ApplyLightsByType(FogCullLightType::PolygonLight, surface, lightingData, extinction);
+
+    PassSrg::m_froxelScatterResult[froxelId] = float4(inScatter, 0);
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelScatter.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelScatter.azsl
@@ -242,7 +242,7 @@ float3 EvaluateAmbientFog(float3 positionWS)
     float heightAboveGround = max(positionWS.z - groundHeight, 0.0);
 
     // At ground level: 50/50 sky/ground. At height: sky dominates.
-    // Exponential blend — 5m above ground is already ~80% sky
+    // Exponential blend. 5m above ground is already ~80% sky
     float groundFactor = exp(-heightAboveGround * 0.2);
     float skyFactor    = 1.0 - groundFactor * 0.5;       // sky never below 0.5
 
@@ -316,7 +316,7 @@ void MainCS(uint3 froxelId : SV_DispatchThreadID)
 
     if (SceneSrg::m_volumetricFogVolumeData.m_ambientIntensity > 0)
     {
-        // Ambient IBL contribution — scatteringCoeff is applied in FroxelIntegrate, not here
+        // Ambient IBL contribution; scatteringCoeff is applied in FroxelIntegrate, not here
         float3 ambientIBL = EvaluateAmbientFog(surface.position);
         inScatter += ambientIBL * SceneSrg::m_volumetricFogVolumeData.m_ambientIntensity;
     }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelScatter.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelScatter.shader
@@ -10,14 +10,5 @@
                 "type" : "Compute"
             }
         ]
-    },
-    "Supervariants":
-    [
-        {
-            "Name": "",
-            "AddBuildArguments": {
-                "debug": true
-            }
-        }
-    ]
+    }
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelScatter.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelScatter.shader
@@ -1,0 +1,23 @@
+{
+    "Source": "FroxelScatter.azsl",
+    
+    "ProgramSettings" :
+    {
+        "EntryPoints":
+        [
+            {
+                "name": "MainCS",
+                "type" : "Compute"
+            }
+        ]
+    },
+    "Supervariants":
+    [
+        {
+            "Name": "",
+            "AddBuildArguments": {
+                "debug": true
+            }
+        }
+    ]
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelUtil.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelUtil.azsli
@@ -43,7 +43,7 @@ float3 GetFroxelWorldPosition(uint3 froxelId)
 
 float3 GetFroxelUVW(float2 screenUV, float viewZ)
 {
-    // Map to froxel UVW — XY from screen UV, Z from view depth
+    // Map to froxel UVW. XY from screen UV, Z from view depth
     float  fogRange = SceneSrg::m_volumetricFogData.m_fogFar - SceneSrg::m_volumetricFogData.m_fogNear;
     float  zNorm    = saturate((abs(viewZ) - SceneSrg::m_volumetricFogData.m_fogNear) / fogRange);
     // Invert the log mapping to find the correct froxel slice
@@ -95,14 +95,14 @@ float SampleNoiseOctave(float3 positionWS, float scale, float3 scroll, Texture3D
 //   - The result captures both large fog banks and fine wisps
 //
 // Two techniques prevent repeating column artifacts from tiling:
-//   1. Per-octave constant offsets — shift each octave into a different
+//   1. Per-octave constant offsets. Shift each octave into a different
 //      region of the tiling texture so their tile boundaries don't overlap.
-//   2. Per-octave axis permutation (yzx / zxy) — rotates the sampling
+//   2. Per-octave axis permutation (yzx / zxy). Rotates the sampling
 //      domain by ~120°/240° so the "column" direction differs per octave.
 //      Zero trig cost: just swizzles.
 //
-// positionWS  — world-space center of the froxel
-// time        — current time in seconds
+// positionWS  : world-space center of the froxel
+// time        : current time in seconds
 float SampleNoise(float3 positionWS, float time, SceneSrg::VolumetricFogVolumeConstants volumeData, Texture3D<float> noiseTexture)
 {
     const float  BASE_SCALE = volumeData.m_noiseScale;
@@ -113,19 +113,19 @@ float SampleNoise(float3 positionWS, float time, SceneSrg::VolumetricFogVolumeCo
     static const float3 OFFSET_2 = float3( 17.73,  43.31,  31.97);
     static const float3 OFFSET_3 = float3( 83.13,  11.71,  67.57);
 
-    // ---- Octave 1 — large scale fog banks (most influence) --------------
+    // ---- Octave 1: large scale fog banks (most influence) --------------
     float3 pos0    = positionWS;           // XYZ
     float3 scroll0 = WIND * 1.0 + OFFSET_1;
     float  n0      = SampleNoiseOctave(pos0, BASE_SCALE * 1.0, scroll0, noiseTexture);
 
-    // ---- Octave 2 — medium detail ---------------------------------------
+    // ---- Octave 2: medium detail ---------------------------------------
     // Domain permutation YZX rotates the column direction ~120°, breaking
     // alignment with octave 1 at zero cost.
     float3 pos1    = positionWS.yzx;
     float3 scroll1 = WIND * 1.4 + OFFSET_2;
     float  n1      = SampleNoiseOctave(pos1, BASE_SCALE * 2.0, scroll1, noiseTexture);
 
-    // ---- Octave 3 — fine wisps ------------------------------------------
+    // ---- Octave 3: fine wisps ------------------------------------------
     // Domain permutation ZXY rotates a further ~120° (~240° from octave 1).
     float3 pos2    = positionWS.zxy;
     float3 scroll2 = WIND * 1.8 + OFFSET_3;
@@ -137,13 +137,13 @@ float SampleNoise(float3 positionWS, float time, SceneSrg::VolumetricFogVolumeCo
                 + n1 * 0.3
                 + n2 * 0.2;
 
-    // Clamp to [0,1] — negative values would create negative density
+    // Clamp to [0,1]. Negative values would create negative density
     return saturate(noise);
 }
 
 float4 CalculateMediumContribution(float3 positionWS, SceneSrg::VolumetricFogVolumeConstants volumeData, Texture3D<float> noiseTexture, bool useNoiseTexture)
 {
-    // Sample fog density — combine height fog + noise
+    // Sample fog density. Combine height fog + noise
     float heightFog = exp(-max(0, positionWS.z - volumeData.m_fogBaseHeight) * volumeData.m_fogHeightFalloff);
 
     float noise = 1.0f;
@@ -157,7 +157,7 @@ float4 CalculateMediumContribution(float3 positionWS, SceneSrg::VolumetricFogVol
     //   σ_t (extinction) = density
     //   σ_s (scattering) = albedo × density  (per-channel)
     //   σ_a (absorption) = (1 - albedo) × density  (implicit)
-    // Artists control fog appearance with just two values — albedo and density — without
+    // Artists control fog appearance with just two values, albedo and density, without
     // needing to reason about raw scattering/absorption coefficients.
     float3 scattering = density * volumeData.m_fogAlbedo;
     float  extinction = density;

--- a/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelUtil.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelUtil.azsli
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#define NUM_THREADS_PER_GROUP 16
+#define LIGHT_CULLING_TILE_SIZE 16
+
+// Match the log distribution from LightCullingTilePrepare
+float SliceToViewZ(uint slice, float fogNear, float fogFar, uint sliceCount)
+{
+    float t = float(slice) / float(sliceCount);
+    return fogNear * pow(fogFar / fogNear, t);  // exponential distribution
+}
+
+float3 GetFroxelViewPosition(uint3 froxelId)
+{
+    uint3 froxelCount = SceneSrg::m_volumetricFogData.m_froxelCount;
+    // Reconstruct world-space position of froxel center
+    // Use the same unprojectZ constants as LightCullingTilePrepare
+    float zNear = SliceToViewZ(froxelId.z,     SceneSrg::m_volumetricFogData.m_fogNear, SceneSrg::m_volumetricFogData.m_fogFar, froxelCount.z);
+    float zFar  = SliceToViewZ(froxelId.z + 1, SceneSrg::m_volumetricFogData.m_fogNear, SceneSrg::m_volumetricFogData.m_fogFar, froxelCount.z);
+    float zCenter = (zNear + zFar) * 0.5;
+
+    // Froxel center in screen UV
+    float2 uv = (float2(froxelId.xy) + 0.5) / float2(froxelCount.x, froxelCount.y);
+    float3 positionVS = ViewSrg::GetViewSpacePosition(uv, zCenter);
+    positionVS.z = -positionVS.z;
+    return positionVS;
+}
+
+float3 GetFroxelWorldPosition(uint3 froxelId)
+{
+    float3 positionVS = GetFroxelViewPosition(froxelId);    
+    float3 positionWS = mul(ViewSrg::m_viewMatrixInverse, float4(positionVS, 1.0)).xyz;
+    return positionWS;
+}
+
+float3 GetFroxelUVW(float2 screenUV, float viewZ)
+{
+    // Map to froxel UVW — XY from screen UV, Z from view depth
+    float  fogRange = SceneSrg::m_volumetricFogData.m_fogFar - SceneSrg::m_volumetricFogData.m_fogNear;
+    float  zNorm    = saturate((abs(viewZ) - SceneSrg::m_volumetricFogData.m_fogNear) / fogRange);
+    // Invert the log mapping to find the correct froxel slice
+    float  zUVW     = log(max(abs(viewZ), SceneSrg::m_volumetricFogData.m_fogNear) / SceneSrg::m_volumetricFogData.m_fogNear)
+                    / log(SceneSrg::m_volumetricFogData.m_fogFar / SceneSrg::m_volumetricFogData.m_fogNear);
+    float3 uvw      = float3(screenUV, saturate(zUVW));
+    return uvw;
+}
+
+// --------------------------------------------------------------------------
+// View-space depth at a given froxel slice (slice center).
+// Used by VS to position the proxy mesh quad at the correct depth per instance.
+// --------------------------------------------------------------------------
+float SliceCenterToViewZ(uint slice)
+{
+    float zNear = SliceToViewZ(slice,     SceneSrg::m_volumetricFogData.m_fogNear,
+                                          SceneSrg::m_volumetricFogData.m_fogFar,
+                                          SceneSrg::m_volumetricFogData.m_froxelCount.z);
+    float zFar  = SliceToViewZ(slice + 1, SceneSrg::m_volumetricFogData.m_fogNear,
+                                          SceneSrg::m_volumetricFogData.m_fogFar,
+                                          SceneSrg::m_volumetricFogData.m_froxelCount.z);
+    return (zNear + zFar) * 0.5;
+}
+
+// -----------------------------------------------------------------------
+// Noise helpers
+// -----------------------------------------------------------------------
+float SampleNoise3D(float3 worldPos, Texture3D<float> noiseTexture)
+{
+    float n = noiseTexture.SampleLevel(SceneSrg::m_noiseSampler, worldPos.xyz, 0).r;
+    return n;
+}
+
+// Samples one octave of the 3D noise texture in world space.
+// The noise texture is a tiling Texture3D<float> with values in [0,1].
+float SampleNoiseOctave(float3 positionWS, float scale, float3 scroll, Texture3D<float> noiseTexture)
+{
+    // Scroll the noise in world space using wind vector × time
+    float3 uvw = positionWS * scale + scroll;
+    return SampleNoise3D(uvw, noiseTexture);
+}
+
+// Samples multiple octaves of noise and combines them into a single
+// density modulator in [0,1].
+//
+// Uses fractional Brownian motion (fBm):
+//   - Each octave doubles the frequency (finer detail)
+//   - Each octave halves the amplitude (less contribution)
+//   - The result captures both large fog banks and fine wisps
+//
+// Two techniques prevent repeating column artifacts from tiling:
+//   1. Per-octave constant offsets — shift each octave into a different
+//      region of the tiling texture so their tile boundaries don't overlap.
+//   2. Per-octave axis permutation (yzx / zxy) — rotates the sampling
+//      domain by ~120°/240° so the "column" direction differs per octave.
+//      Zero trig cost: just swizzles.
+//
+// positionWS  — world-space center of the froxel
+// time        — current time in seconds
+float SampleNoise(float3 positionWS, float time, SceneSrg::VolumetricFogVolumeConstants volumeData, Texture3D<float> noiseTexture)
+{
+    const float  BASE_SCALE = volumeData.m_noiseScale;
+    const float3 WIND       = -volumeData.m_noiseWindVelocity * time;
+
+    // Large irrational offsets so each octave samples a different tile region.
+    static const float3 OFFSET_1 = float3(  0.00,   0.00,   0.00);
+    static const float3 OFFSET_2 = float3( 17.73,  43.31,  31.97);
+    static const float3 OFFSET_3 = float3( 83.13,  11.71,  67.57);
+
+    // ---- Octave 1 — large scale fog banks (most influence) --------------
+    float3 pos0    = positionWS;           // XYZ
+    float3 scroll0 = WIND * 1.0 + OFFSET_1;
+    float  n0      = SampleNoiseOctave(pos0, BASE_SCALE * 1.0, scroll0, noiseTexture);
+
+    // ---- Octave 2 — medium detail ---------------------------------------
+    // Domain permutation YZX rotates the column direction ~120°, breaking
+    // alignment with octave 1 at zero cost.
+    float3 pos1    = positionWS.yzx;
+    float3 scroll1 = WIND * 1.4 + OFFSET_2;
+    float  n1      = SampleNoiseOctave(pos1, BASE_SCALE * 2.0, scroll1, noiseTexture);
+
+    // ---- Octave 3 — fine wisps ------------------------------------------
+    // Domain permutation ZXY rotates a further ~120° (~240° from octave 1).
+    float3 pos2    = positionWS.zxy;
+    float3 scroll2 = WIND * 1.8 + OFFSET_3;
+    float  n2      = SampleNoiseOctave(pos2, BASE_SCALE * 4.0, scroll2, noiseTexture);
+
+    // ---- Combine octaves with decreasing weights ------------------------
+    // Weights sum to 1.0: 0.5 + 0.3 + 0.2
+    float noise = n0 * 0.5
+                + n1 * 0.3
+                + n2 * 0.2;
+
+    // Clamp to [0,1] — negative values would create negative density
+    return saturate(noise);
+}
+
+float4 CalculateMediumContribution(float3 positionWS, SceneSrg::VolumetricFogVolumeConstants volumeData, Texture3D<float> noiseTexture, bool useNoiseTexture)
+{
+    // Sample fog density — combine height fog + noise
+    float heightFog = exp(-max(0, positionWS.z - volumeData.m_fogBaseHeight) * volumeData.m_fogHeightFalloff);
+
+    float noise = 1.0f;
+    if (useNoiseTexture)
+    {
+        noise = SampleNoise(positionWS, SceneSrg::m_time, volumeData, noiseTexture);
+    }
+    float density = heightFog * noise * volumeData.m_fogDensity;
+
+    // Single-scattering albedo model:
+    //   σ_t (extinction) = density
+    //   σ_s (scattering) = albedo × density  (per-channel)
+    //   σ_a (absorption) = (1 - albedo) × density  (implicit)
+    // Artists control fog appearance with just two values — albedo and density — without
+    // needing to reason about raw scattering/absorption coefficients.
+    float3 scattering = density * volumeData.m_fogAlbedo;
+    float  extinction = density;
+    return float4(scattering, extinction);
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelUtil.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/FroxelUtil.azsli
@@ -105,31 +105,31 @@ float SampleNoiseOctave(float3 positionWS, float scale, float3 scroll, Texture3D
 // time        : current time in seconds
 float SampleNoise(float3 positionWS, float time, SceneSrg::VolumetricFogVolumeConstants volumeData, Texture3D<float> noiseTexture)
 {
-    const float  BASE_SCALE = volumeData.m_noiseScale;
-    const float3 WIND       = -volumeData.m_noiseWindVelocity * time;
+    const float  baseScale = volumeData.m_noiseScale;
+    const float3 wind       = -volumeData.m_noiseWindVelocity * time;
 
     // Large irrational offsets so each octave samples a different tile region.
-    static const float3 OFFSET_1 = float3(  0.00,   0.00,   0.00);
-    static const float3 OFFSET_2 = float3( 17.73,  43.31,  31.97);
-    static const float3 OFFSET_3 = float3( 83.13,  11.71,  67.57);
+    static const float3 offset1 = float3(  0.00,   0.00,   0.00);
+    static const float3 offset2 = float3( 17.73,  43.31,  31.97);
+    static const float3 offset3 = float3( 83.13,  11.71,  67.57);
 
     // ---- Octave 1: large scale fog banks (most influence) --------------
     float3 pos0    = positionWS;           // XYZ
-    float3 scroll0 = WIND * 1.0 + OFFSET_1;
-    float  n0      = SampleNoiseOctave(pos0, BASE_SCALE * 1.0, scroll0, noiseTexture);
+    float3 scroll0 = wind * 1.0 + offset1;
+    float  n0      = SampleNoiseOctave(pos0, baseScale * 1.0, scroll0, noiseTexture);
 
     // ---- Octave 2: medium detail ---------------------------------------
     // Domain permutation YZX rotates the column direction ~120°, breaking
     // alignment with octave 1 at zero cost.
     float3 pos1    = positionWS.yzx;
-    float3 scroll1 = WIND * 1.4 + OFFSET_2;
-    float  n1      = SampleNoiseOctave(pos1, BASE_SCALE * 2.0, scroll1, noiseTexture);
+    float3 scroll1 = wind * 1.4 + offset2;
+    float  n1      = SampleNoiseOctave(pos1, baseScale * 2.0, scroll1, noiseTexture);
 
     // ---- Octave 3: fine wisps ------------------------------------------
     // Domain permutation ZXY rotates a further ~120° (~240° from octave 1).
     float3 pos2    = positionWS.zxy;
-    float3 scroll2 = WIND * 1.8 + OFFSET_3;
-    float  n2      = SampleNoiseOctave(pos2, BASE_SCALE * 4.0, scroll2, noiseTexture);
+    float3 scroll2 = wind * 1.8 + offset3;
+    float  n2      = SampleNoiseOctave(pos2, baseScale * 4.0, scroll2, noiseTexture);
 
     // ---- Combine octaves with decreasing weights ------------------------
     // Weights sum to 1.0: 0.5 + 0.3 + 0.2

--- a/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/VolumetricFogMaxTransparent.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/VolumetricFogMaxTransparent.shader
@@ -20,14 +20,5 @@
         ] 
     },
 
-    "DrawList" : "depthTransparentMax",
-    "Supervariants":
-    [
-        {
-            "Name": "",
-            "AddBuildArguments": {
-                "debug": true
-            }
-        }
-    ]
+    "DrawList" : "depthTransparentMax"
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/VolumetricFogMaxTransparent.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/VolumetricFogMaxTransparent.shader
@@ -1,0 +1,33 @@
+{
+    "Source" : "VolumetricFogMinMaxTransparent.azsl",
+
+    "RasterState": { "CullMode": "None" },
+
+     "DepthStencilState" : { 
+        // Note that we assuming reversed depth buffer, which normally means we 
+        // are rendering with GreaterEqual. But in our case we want to render the maximum values (furthest) from the camera.
+        "Depth" : { "Enable" : true, "CompareFunc" : "LessEqual" }
+    },
+
+    "ProgramSettings" : 
+    {
+        "EntryPoints":
+        [
+            {
+                "name": "MainVS",
+                "type" : "Vertex"
+            }
+        ] 
+    },
+
+    "DrawList" : "depthTransparentMax",
+    "Supervariants":
+    [
+        {
+            "Name": "",
+            "AddBuildArguments": {
+                "debug": true
+            }
+        }
+    ]
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/VolumetricFogMinMaxTransparent.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/VolumetricFogMinMaxTransparent.azsl
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <viewsrg.srgi>
+#include <Atom/Features/PostProcessing/FullscreenVertexUtil.azsli>
+
+struct VSInput
+{
+    uint m_vertexID : SV_VertexID;
+};
+ 
+struct VSDepthOutput
+{
+    precise float4 m_position : SV_Position;
+};
+
+rootconstant float m_viewZ;
+// Generates a fullscreen triangle from pipeline provided vertex id 
+VSDepthOutput MainVS(VSInput input)
+{
+    VSDepthOutput OUT;
+    float4 ndcXY = GetVertexPositionAndTexCoords(input.m_vertexID);
+    float4 ndcZ = mul(ViewSrg::m_projectionMatrix, float4(0, 0, -m_viewZ, 1.0));
+    OUT.m_position = float4(ndcXY.x, ndcXY.y, ndcZ.z/ndcZ.w, 1.0);
+    OUT.m_position.z = clamp(OUT.m_position.z, 0, 1);
+    return OUT;
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/VolumetricFogMinTransparent.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/VolumetricFogMinTransparent.shader
@@ -18,14 +18,5 @@
         ] 
     },
 
-    "DrawList" : "depthTransparentMin",
-    "Supervariants":
-    [
-        {
-            "Name": "",
-            "AddBuildArguments": {
-                "debug": true
-            }
-        }
-    ]
+    "DrawList" : "depthTransparentMin"
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/VolumetricFogMinTransparent.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/VolumetricFog/VolumetricFogMinTransparent.shader
@@ -1,0 +1,31 @@
+{
+    "Source" : "VolumetricFogMinMaxTransparent.azsl",
+
+    "RasterState": { "CullMode": "None" },
+
+    "DepthStencilState" : { 
+        "Depth" : { "Enable" : true, "CompareFunc" : "GreaterEqual" }
+    },
+
+    "ProgramSettings" : 
+    {
+        "EntryPoints":
+        [
+            {
+                "name": "MainVS",
+                "type" : "Vertex"
+            }
+        ] 
+    },
+
+    "DrawList" : "depthTransparentMin",
+    "Supervariants":
+    [
+        {
+            "Name": "",
+            "AddBuildArguments": {
+                "debug": true
+            }
+        }
+    ]
+}

--- a/Gems/Atom/Feature/Common/Assets/Textures/VolumetricFog/fogNoise.dds
+++ b/Gems/Atom/Feature/Common/Assets/Textures/VolumetricFog/fogNoise.dds
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:200815d1d9989d0251a675e25f10062f3396d8452750f56a5ecb9448f1e46ffc
+size 2396932

--- a/Gems/Atom/Feature/Common/Assets/Textures/VolumetricFog/fogNoise.dds.assetinfo
+++ b/Gems/Atom/Feature/Common/Assets/Textures/VolumetricFog/fogNoise.dds.assetinfo
@@ -1,0 +1,96 @@
+<ObjectStream version="3">
+	<Class name="TextureSettings" version="2" type="{980132FF-C450-425D-8AE0-BD96A8486177}">
+		<Class name="AZ::Uuid" field="PresetID" value="{00000000-0000-0000-0000-000000000000}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+		<Class name="Name" field="Preset" value="Greyscale" type="{3D2B920C-9EFD-40D5-AAE0-DF131C3D4931}"/>
+		<Class name="unsigned int" field="SizeReduceLevel" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+		<Class name="bool" field="EngineReduce" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+		<Class name="bool" field="EnableMipmap" value="true" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+		<Class name="unsigned int" field="MipMapGenEval" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+		<Class name="ImageProcessingAtom::MipGenType" field="MipMapGenType" value="1" type="{8524F650-1417-44DA-BBB0-C707A7A1A709}"/>
+		<Class name="bool" field="MaintainAlphaCoverage" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+		<Class name="AZStd::vector&lt;unsigned int, allocator&gt;" field="MipMapAlphaAdjustments" type="{3349AACD-BE04-50BC-9478-528BF2ACFD55}">
+			<Class name="unsigned int" field="element" value="50" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="unsigned int" field="element" value="50" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="unsigned int" field="element" value="50" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="unsigned int" field="element" value="50" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="unsigned int" field="element" value="50" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="unsigned int" field="element" value="50" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+		</Class>
+		<Class name="AZStd::map&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;" field="PlatformSpecificOverrides" type="{74E4843B-0924-583D-8C6E-A37B09BD51FE}">
+			<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;" field="element" type="{CAC4E67F-D626-5452-A057-ACB57D53F549}">
+				<Class name="AZStd::string" field="value1" value="android" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="DataPatch" field="value2" type="{BFF7A3F5-9014-4000-92C7-9B2BC7913DA9}">
+					<Class name="AZ::Uuid" field="m_targetClassId" value="{980132FF-C450-425D-8AE0-BD96A8486177}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+					<Class name="unsigned int" field="m_targetClassVersion" value="2" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+					<Class name="AZStd::unordered_map&lt;AddressType, AZStd::any, AZStd::hash&lt;AddressType&gt;, AZStd::equal_to&lt;AddressType&gt;, allocator&gt;" field="m_patch" type="{CEA836FC-77E0-5E46-BD0F-2E5A39D845E9}"/>
+				</Class>
+			</Class>
+			<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;" field="element" type="{CAC4E67F-D626-5452-A057-ACB57D53F549}">
+				<Class name="AZStd::string" field="value1" value="ios" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="DataPatch" field="value2" type="{BFF7A3F5-9014-4000-92C7-9B2BC7913DA9}">
+					<Class name="AZ::Uuid" field="m_targetClassId" value="{980132FF-C450-425D-8AE0-BD96A8486177}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+					<Class name="unsigned int" field="m_targetClassVersion" value="2" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+					<Class name="AZStd::unordered_map&lt;AddressType, AZStd::any, AZStd::hash&lt;AddressType&gt;, AZStd::equal_to&lt;AddressType&gt;, allocator&gt;" field="m_patch" type="{CEA836FC-77E0-5E46-BD0F-2E5A39D845E9}">
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="AZStd::map&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;({74E4843B-0924-583D-8C6E-A37B09BD51FE})::PlatformSpecificOverrides·0/AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;({CAC4E67F-D626-5452-A057-ACB57D53F549})#0·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;" field="element" type="{CAC4E67F-D626-5452-A057-ACB57D53F549}">
+				<Class name="AZStd::string" field="value1" value="linux" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="DataPatch" field="value2" type="{BFF7A3F5-9014-4000-92C7-9B2BC7913DA9}">
+					<Class name="AZ::Uuid" field="m_targetClassId" value="{980132FF-C450-425D-8AE0-BD96A8486177}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+					<Class name="unsigned int" field="m_targetClassVersion" value="2" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+					<Class name="AZStd::unordered_map&lt;AddressType, AZStd::any, AZStd::hash&lt;AddressType&gt;, AZStd::equal_to&lt;AddressType&gt;, allocator&gt;" field="m_patch" type="{CEA836FC-77E0-5E46-BD0F-2E5A39D845E9}">
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="AZStd::map&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;({74E4843B-0924-583D-8C6E-A37B09BD51FE})::PlatformSpecificOverrides·0/AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;({CAC4E67F-D626-5452-A057-ACB57D53F549})#1·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}"/>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="AZStd::map&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;({74E4843B-0924-583D-8C6E-A37B09BD51FE})::PlatformSpecificOverrides·0/AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;({CAC4E67F-D626-5452-A057-ACB57D53F549})#0·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;" field="element" type="{CAC4E67F-D626-5452-A057-ACB57D53F549}">
+				<Class name="AZStd::string" field="value1" value="mac" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="DataPatch" field="value2" type="{BFF7A3F5-9014-4000-92C7-9B2BC7913DA9}">
+					<Class name="AZ::Uuid" field="m_targetClassId" value="{980132FF-C450-425D-8AE0-BD96A8486177}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+					<Class name="unsigned int" field="m_targetClassVersion" value="2" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+					<Class name="AZStd::unordered_map&lt;AddressType, AZStd::any, AZStd::hash&lt;AddressType&gt;, AZStd::equal_to&lt;AddressType&gt;, allocator&gt;" field="m_patch" type="{CEA836FC-77E0-5E46-BD0F-2E5A39D845E9}">
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="AZStd::map&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;({74E4843B-0924-583D-8C6E-A37B09BD51FE})::PlatformSpecificOverrides·0/AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;({CAC4E67F-D626-5452-A057-ACB57D53F549})#1·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}"/>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="AZStd::map&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;({74E4843B-0924-583D-8C6E-A37B09BD51FE})::PlatformSpecificOverrides·0/AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;({CAC4E67F-D626-5452-A057-ACB57D53F549})#0·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}"/>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="AZStd::map&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;({74E4843B-0924-583D-8C6E-A37B09BD51FE})::PlatformSpecificOverrides·0/AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;({CAC4E67F-D626-5452-A057-ACB57D53F549})#2·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;" field="element" type="{CAC4E67F-D626-5452-A057-ACB57D53F549}">
+				<Class name="AZStd::string" field="value1" value="pc" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="DataPatch" field="value2" type="{BFF7A3F5-9014-4000-92C7-9B2BC7913DA9}">
+					<Class name="AZ::Uuid" field="m_targetClassId" value="{980132FF-C450-425D-8AE0-BD96A8486177}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+					<Class name="unsigned int" field="m_targetClassVersion" value="2" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+					<Class name="AZStd::unordered_map&lt;AddressType, AZStd::any, AZStd::hash&lt;AddressType&gt;, AZStd::equal_to&lt;AddressType&gt;, allocator&gt;" field="m_patch" type="{CEA836FC-77E0-5E46-BD0F-2E5A39D845E9}"/>
+				</Class>
+			</Class>
+		</Class>
+		<Class name="AZStd::string" field="OverridingPlatform" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		<Class name="AZStd::set&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;" field="Tags" type="{166F208E-DE97-53FE-B349-BDD9FE9B8693}"/>
+		<Class name="FlipbookSettings" field="Flipbook" type="{334D20DF-3D5D-42D7-B60F-C5AF7A00CB23}">
+			<Class name="unsigned int" field="Columns" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="unsigned int" field="Rows" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+		</Class>
+	</Class>
+</ObjectStream>
+

--- a/Gems/Atom/Feature/Common/Assets/Textures/VolumetricFog/fogNoise1.png
+++ b/Gems/Atom/Feature/Common/Assets/Textures/VolumetricFog/fogNoise1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2808f4ab7544b047d4519ad21a22f93269dfef2860309932c35f01ed9902ae5
+size 9956628

--- a/Gems/Atom/Feature/Common/Assets/Textures/VolumetricFog/fogNoise1.png.assetinfo
+++ b/Gems/Atom/Feature/Common/Assets/Textures/VolumetricFog/fogNoise1.png.assetinfo
@@ -1,0 +1,145 @@
+<ObjectStream version="3">
+	<Class name="TextureSettings" version="2" type="{980132FF-C450-425D-8AE0-BD96A8486177}">
+		<Class name="AZ::Uuid" field="PresetID" value="{00000000-0000-0000-0000-000000000000}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+		<Class name="Name" field="Preset" value="Greyscale" type="{3D2B920C-9EFD-40D5-AAE0-DF131C3D4931}"/>
+		<Class name="unsigned int" field="SizeReduceLevel" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+		<Class name="bool" field="EngineReduce" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+		<Class name="bool" field="EnableMipmap" value="true" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+		<Class name="unsigned int" field="MipMapGenEval" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+		<Class name="ImageProcessingAtom::MipGenType" field="MipMapGenType" value="1" type="{8524F650-1417-44DA-BBB0-C707A7A1A709}"/>
+		<Class name="bool" field="MaintainAlphaCoverage" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+		<Class name="AZStd::vector&lt;unsigned int, allocator&gt;" field="MipMapAlphaAdjustments" type="{3349AACD-BE04-50BC-9478-528BF2ACFD55}">
+			<Class name="unsigned int" field="element" value="50" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="unsigned int" field="element" value="50" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="unsigned int" field="element" value="50" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="unsigned int" field="element" value="50" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="unsigned int" field="element" value="50" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="unsigned int" field="element" value="50" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+		</Class>
+		<Class name="AZStd::map&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;" field="PlatformSpecificOverrides" type="{74E4843B-0924-583D-8C6E-A37B09BD51FE}">
+			<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;" field="element" type="{CAC4E67F-D626-5452-A057-ACB57D53F549}">
+				<Class name="AZStd::string" field="value1" value="android" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="DataPatch" field="value2" type="{BFF7A3F5-9014-4000-92C7-9B2BC7913DA9}">
+					<Class name="AZ::Uuid" field="m_targetClassId" value="{980132FF-C450-425D-8AE0-BD96A8486177}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+					<Class name="unsigned int" field="m_targetClassVersion" value="2" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+					<Class name="AZStd::unordered_map&lt;AddressType, AZStd::any, AZStd::hash&lt;AddressType&gt;, AZStd::equal_to&lt;AddressType&gt;, allocator&gt;" field="m_patch" type="{CEA836FC-77E0-5E46-BD0F-2E5A39D845E9}">
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="FlipbookSettings({334D20DF-3D5D-42D7-B60F-C5AF7A00CB23})::Flipbook·0/unsigned int({43DA906B-7DEF-4CA8-9790-854106D3F983})::Columns·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+								<Class name="unsigned int" field="m_data" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+							</Class>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="FlipbookSettings({334D20DF-3D5D-42D7-B60F-C5AF7A00CB23})::Flipbook·0/unsigned int({43DA906B-7DEF-4CA8-9790-854106D3F983})::Rows·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+								<Class name="unsigned int" field="m_data" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+							</Class>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;" field="element" type="{CAC4E67F-D626-5452-A057-ACB57D53F549}">
+				<Class name="AZStd::string" field="value1" value="ios" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="DataPatch" field="value2" type="{BFF7A3F5-9014-4000-92C7-9B2BC7913DA9}">
+					<Class name="AZ::Uuid" field="m_targetClassId" value="{980132FF-C450-425D-8AE0-BD96A8486177}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+					<Class name="unsigned int" field="m_targetClassVersion" value="2" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+					<Class name="AZStd::unordered_map&lt;AddressType, AZStd::any, AZStd::hash&lt;AddressType&gt;, AZStd::equal_to&lt;AddressType&gt;, allocator&gt;" field="m_patch" type="{CEA836FC-77E0-5E46-BD0F-2E5A39D845E9}">
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="FlipbookSettings({334D20DF-3D5D-42D7-B60F-C5AF7A00CB23})::Flipbook·0/unsigned int({43DA906B-7DEF-4CA8-9790-854106D3F983})::Columns·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+								<Class name="unsigned int" field="m_data" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+							</Class>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="FlipbookSettings({334D20DF-3D5D-42D7-B60F-C5AF7A00CB23})::Flipbook·0/unsigned int({43DA906B-7DEF-4CA8-9790-854106D3F983})::Rows·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+								<Class name="unsigned int" field="m_data" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+							</Class>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="AZStd::map&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;({74E4843B-0924-583D-8C6E-A37B09BD51FE})::PlatformSpecificOverrides·0/AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;({CAC4E67F-D626-5452-A057-ACB57D53F549})#0·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;" field="element" type="{CAC4E67F-D626-5452-A057-ACB57D53F549}">
+				<Class name="AZStd::string" field="value1" value="linux" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="DataPatch" field="value2" type="{BFF7A3F5-9014-4000-92C7-9B2BC7913DA9}">
+					<Class name="AZ::Uuid" field="m_targetClassId" value="{980132FF-C450-425D-8AE0-BD96A8486177}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+					<Class name="unsigned int" field="m_targetClassVersion" value="2" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+					<Class name="AZStd::unordered_map&lt;AddressType, AZStd::any, AZStd::hash&lt;AddressType&gt;, AZStd::equal_to&lt;AddressType&gt;, allocator&gt;" field="m_patch" type="{CEA836FC-77E0-5E46-BD0F-2E5A39D845E9}">
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="FlipbookSettings({334D20DF-3D5D-42D7-B60F-C5AF7A00CB23})::Flipbook·0/unsigned int({43DA906B-7DEF-4CA8-9790-854106D3F983})::Columns·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+								<Class name="unsigned int" field="m_data" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+							</Class>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="FlipbookSettings({334D20DF-3D5D-42D7-B60F-C5AF7A00CB23})::Flipbook·0/unsigned int({43DA906B-7DEF-4CA8-9790-854106D3F983})::Rows·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+								<Class name="unsigned int" field="m_data" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+							</Class>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="AZStd::map&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;({74E4843B-0924-583D-8C6E-A37B09BD51FE})::PlatformSpecificOverrides·0/AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;({CAC4E67F-D626-5452-A057-ACB57D53F549})#1·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}"/>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="AZStd::map&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;({74E4843B-0924-583D-8C6E-A37B09BD51FE})::PlatformSpecificOverrides·0/AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;({CAC4E67F-D626-5452-A057-ACB57D53F549})#0·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;" field="element" type="{CAC4E67F-D626-5452-A057-ACB57D53F549}">
+				<Class name="AZStd::string" field="value1" value="mac" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="DataPatch" field="value2" type="{BFF7A3F5-9014-4000-92C7-9B2BC7913DA9}">
+					<Class name="AZ::Uuid" field="m_targetClassId" value="{980132FF-C450-425D-8AE0-BD96A8486177}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+					<Class name="unsigned int" field="m_targetClassVersion" value="2" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+					<Class name="AZStd::unordered_map&lt;AddressType, AZStd::any, AZStd::hash&lt;AddressType&gt;, AZStd::equal_to&lt;AddressType&gt;, allocator&gt;" field="m_patch" type="{CEA836FC-77E0-5E46-BD0F-2E5A39D845E9}">
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="FlipbookSettings({334D20DF-3D5D-42D7-B60F-C5AF7A00CB23})::Flipbook·0/unsigned int({43DA906B-7DEF-4CA8-9790-854106D3F983})::Columns·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+								<Class name="unsigned int" field="m_data" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+							</Class>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="FlipbookSettings({334D20DF-3D5D-42D7-B60F-C5AF7A00CB23})::Flipbook·0/unsigned int({43DA906B-7DEF-4CA8-9790-854106D3F983})::Rows·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+								<Class name="unsigned int" field="m_data" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+							</Class>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="AZStd::map&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;({74E4843B-0924-583D-8C6E-A37B09BD51FE})::PlatformSpecificOverrides·0/AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;({CAC4E67F-D626-5452-A057-ACB57D53F549})#2·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}"/>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="AZStd::map&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;({74E4843B-0924-583D-8C6E-A37B09BD51FE})::PlatformSpecificOverrides·0/AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;({CAC4E67F-D626-5452-A057-ACB57D53F549})#0·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}"/>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="AZStd::map&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;({74E4843B-0924-583D-8C6E-A37B09BD51FE})::PlatformSpecificOverrides·0/AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;({CAC4E67F-D626-5452-A057-ACB57D53F549})#1·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;" field="element" type="{CAC4E67F-D626-5452-A057-ACB57D53F549}">
+				<Class name="AZStd::string" field="value1" value="pc" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="DataPatch" field="value2" type="{BFF7A3F5-9014-4000-92C7-9B2BC7913DA9}">
+					<Class name="AZ::Uuid" field="m_targetClassId" value="{980132FF-C450-425D-8AE0-BD96A8486177}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+					<Class name="unsigned int" field="m_targetClassVersion" value="2" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+					<Class name="AZStd::unordered_map&lt;AddressType, AZStd::any, AZStd::hash&lt;AddressType&gt;, AZStd::equal_to&lt;AddressType&gt;, allocator&gt;" field="m_patch" type="{CEA836FC-77E0-5E46-BD0F-2E5A39D845E9}"/>
+				</Class>
+			</Class>
+		</Class>
+		<Class name="AZStd::string" field="OverridingPlatform" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		<Class name="AZStd::set&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;" field="Tags" type="{166F208E-DE97-53FE-B349-BDD9FE9B8693}"/>
+		<Class name="FlipbookSettings" field="Flipbook" type="{334D20DF-3D5D-42D7-B60F-C5AF7A00CB23}">
+			<Class name="unsigned int" field="Columns" value="16" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="unsigned int" field="Rows" value="16" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+		</Class>
+	</Class>
+</ObjectStream>
+

--- a/Gems/Atom/Feature/Common/Assets/Textures/VolumetricFog/fogNoise2.png
+++ b/Gems/Atom/Feature/Common/Assets/Textures/VolumetricFog/fogNoise2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff6b4d7ceb409ef2b949417f1f52a7b5136b45f1b6ea389e37cd3b31c340d48b
+size 18220788

--- a/Gems/Atom/Feature/Common/Assets/Textures/VolumetricFog/fogNoise2.png.assetinfo
+++ b/Gems/Atom/Feature/Common/Assets/Textures/VolumetricFog/fogNoise2.png.assetinfo
@@ -1,0 +1,145 @@
+<ObjectStream version="3">
+	<Class name="TextureSettings" version="2" type="{980132FF-C450-425D-8AE0-BD96A8486177}">
+		<Class name="AZ::Uuid" field="PresetID" value="{00000000-0000-0000-0000-000000000000}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+		<Class name="Name" field="Preset" value="Greyscale" type="{3D2B920C-9EFD-40D5-AAE0-DF131C3D4931}"/>
+		<Class name="unsigned int" field="SizeReduceLevel" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+		<Class name="bool" field="EngineReduce" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+		<Class name="bool" field="EnableMipmap" value="true" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+		<Class name="unsigned int" field="MipMapGenEval" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+		<Class name="ImageProcessingAtom::MipGenType" field="MipMapGenType" value="1" type="{8524F650-1417-44DA-BBB0-C707A7A1A709}"/>
+		<Class name="bool" field="MaintainAlphaCoverage" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+		<Class name="AZStd::vector&lt;unsigned int, allocator&gt;" field="MipMapAlphaAdjustments" type="{3349AACD-BE04-50BC-9478-528BF2ACFD55}">
+			<Class name="unsigned int" field="element" value="50" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="unsigned int" field="element" value="50" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="unsigned int" field="element" value="50" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="unsigned int" field="element" value="50" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="unsigned int" field="element" value="50" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="unsigned int" field="element" value="50" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+		</Class>
+		<Class name="AZStd::map&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;" field="PlatformSpecificOverrides" type="{74E4843B-0924-583D-8C6E-A37B09BD51FE}">
+			<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;" field="element" type="{CAC4E67F-D626-5452-A057-ACB57D53F549}">
+				<Class name="AZStd::string" field="value1" value="android" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="DataPatch" field="value2" type="{BFF7A3F5-9014-4000-92C7-9B2BC7913DA9}">
+					<Class name="AZ::Uuid" field="m_targetClassId" value="{980132FF-C450-425D-8AE0-BD96A8486177}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+					<Class name="unsigned int" field="m_targetClassVersion" value="2" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+					<Class name="AZStd::unordered_map&lt;AddressType, AZStd::any, AZStd::hash&lt;AddressType&gt;, AZStd::equal_to&lt;AddressType&gt;, allocator&gt;" field="m_patch" type="{CEA836FC-77E0-5E46-BD0F-2E5A39D845E9}">
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="FlipbookSettings({334D20DF-3D5D-42D7-B60F-C5AF7A00CB23})::Flipbook·0/unsigned int({43DA906B-7DEF-4CA8-9790-854106D3F983})::Columns·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+								<Class name="unsigned int" field="m_data" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+							</Class>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="FlipbookSettings({334D20DF-3D5D-42D7-B60F-C5AF7A00CB23})::Flipbook·0/unsigned int({43DA906B-7DEF-4CA8-9790-854106D3F983})::Rows·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+								<Class name="unsigned int" field="m_data" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+							</Class>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;" field="element" type="{CAC4E67F-D626-5452-A057-ACB57D53F549}">
+				<Class name="AZStd::string" field="value1" value="ios" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="DataPatch" field="value2" type="{BFF7A3F5-9014-4000-92C7-9B2BC7913DA9}">
+					<Class name="AZ::Uuid" field="m_targetClassId" value="{980132FF-C450-425D-8AE0-BD96A8486177}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+					<Class name="unsigned int" field="m_targetClassVersion" value="2" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+					<Class name="AZStd::unordered_map&lt;AddressType, AZStd::any, AZStd::hash&lt;AddressType&gt;, AZStd::equal_to&lt;AddressType&gt;, allocator&gt;" field="m_patch" type="{CEA836FC-77E0-5E46-BD0F-2E5A39D845E9}">
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="FlipbookSettings({334D20DF-3D5D-42D7-B60F-C5AF7A00CB23})::Flipbook·0/unsigned int({43DA906B-7DEF-4CA8-9790-854106D3F983})::Columns·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+								<Class name="unsigned int" field="m_data" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+							</Class>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="FlipbookSettings({334D20DF-3D5D-42D7-B60F-C5AF7A00CB23})::Flipbook·0/unsigned int({43DA906B-7DEF-4CA8-9790-854106D3F983})::Rows·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+								<Class name="unsigned int" field="m_data" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+							</Class>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="AZStd::map&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;({74E4843B-0924-583D-8C6E-A37B09BD51FE})::PlatformSpecificOverrides·0/AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;({CAC4E67F-D626-5452-A057-ACB57D53F549})#0·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;" field="element" type="{CAC4E67F-D626-5452-A057-ACB57D53F549}">
+				<Class name="AZStd::string" field="value1" value="linux" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="DataPatch" field="value2" type="{BFF7A3F5-9014-4000-92C7-9B2BC7913DA9}">
+					<Class name="AZ::Uuid" field="m_targetClassId" value="{980132FF-C450-425D-8AE0-BD96A8486177}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+					<Class name="unsigned int" field="m_targetClassVersion" value="2" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+					<Class name="AZStd::unordered_map&lt;AddressType, AZStd::any, AZStd::hash&lt;AddressType&gt;, AZStd::equal_to&lt;AddressType&gt;, allocator&gt;" field="m_patch" type="{CEA836FC-77E0-5E46-BD0F-2E5A39D845E9}">
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="FlipbookSettings({334D20DF-3D5D-42D7-B60F-C5AF7A00CB23})::Flipbook·0/unsigned int({43DA906B-7DEF-4CA8-9790-854106D3F983})::Columns·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+								<Class name="unsigned int" field="m_data" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+							</Class>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="FlipbookSettings({334D20DF-3D5D-42D7-B60F-C5AF7A00CB23})::Flipbook·0/unsigned int({43DA906B-7DEF-4CA8-9790-854106D3F983})::Rows·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+								<Class name="unsigned int" field="m_data" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+							</Class>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="AZStd::map&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;({74E4843B-0924-583D-8C6E-A37B09BD51FE})::PlatformSpecificOverrides·0/AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;({CAC4E67F-D626-5452-A057-ACB57D53F549})#1·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}"/>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="AZStd::map&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;({74E4843B-0924-583D-8C6E-A37B09BD51FE})::PlatformSpecificOverrides·0/AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;({CAC4E67F-D626-5452-A057-ACB57D53F549})#0·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;" field="element" type="{CAC4E67F-D626-5452-A057-ACB57D53F549}">
+				<Class name="AZStd::string" field="value1" value="mac" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="DataPatch" field="value2" type="{BFF7A3F5-9014-4000-92C7-9B2BC7913DA9}">
+					<Class name="AZ::Uuid" field="m_targetClassId" value="{980132FF-C450-425D-8AE0-BD96A8486177}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+					<Class name="unsigned int" field="m_targetClassVersion" value="2" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+					<Class name="AZStd::unordered_map&lt;AddressType, AZStd::any, AZStd::hash&lt;AddressType&gt;, AZStd::equal_to&lt;AddressType&gt;, allocator&gt;" field="m_patch" type="{CEA836FC-77E0-5E46-BD0F-2E5A39D845E9}">
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="FlipbookSettings({334D20DF-3D5D-42D7-B60F-C5AF7A00CB23})::Flipbook·0/unsigned int({43DA906B-7DEF-4CA8-9790-854106D3F983})::Columns·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+								<Class name="unsigned int" field="m_data" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+							</Class>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="FlipbookSettings({334D20DF-3D5D-42D7-B60F-C5AF7A00CB23})::Flipbook·0/unsigned int({43DA906B-7DEF-4CA8-9790-854106D3F983})::Rows·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+								<Class name="unsigned int" field="m_data" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+							</Class>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="AZStd::map&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;({74E4843B-0924-583D-8C6E-A37B09BD51FE})::PlatformSpecificOverrides·0/AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;({CAC4E67F-D626-5452-A057-ACB57D53F549})#2·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}"/>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="AZStd::map&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;({74E4843B-0924-583D-8C6E-A37B09BD51FE})::PlatformSpecificOverrides·0/AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;({CAC4E67F-D626-5452-A057-ACB57D53F549})#0·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}"/>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="AZStd::map&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;({74E4843B-0924-583D-8C6E-A37B09BD51FE})::PlatformSpecificOverrides·0/AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;({CAC4E67F-D626-5452-A057-ACB57D53F549})#1·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;" field="element" type="{CAC4E67F-D626-5452-A057-ACB57D53F549}">
+				<Class name="AZStd::string" field="value1" value="pc" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="DataPatch" field="value2" type="{BFF7A3F5-9014-4000-92C7-9B2BC7913DA9}">
+					<Class name="AZ::Uuid" field="m_targetClassId" value="{980132FF-C450-425D-8AE0-BD96A8486177}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+					<Class name="unsigned int" field="m_targetClassVersion" value="2" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+					<Class name="AZStd::unordered_map&lt;AddressType, AZStd::any, AZStd::hash&lt;AddressType&gt;, AZStd::equal_to&lt;AddressType&gt;, allocator&gt;" field="m_patch" type="{CEA836FC-77E0-5E46-BD0F-2E5A39D845E9}"/>
+				</Class>
+			</Class>
+		</Class>
+		<Class name="AZStd::string" field="OverridingPlatform" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		<Class name="AZStd::set&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;" field="Tags" type="{166F208E-DE97-53FE-B349-BDD9FE9B8693}"/>
+		<Class name="FlipbookSettings" field="Flipbook" type="{334D20DF-3D5D-42D7-B60F-C5AF7A00CB23}">
+			<Class name="unsigned int" field="Columns" value="16" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="unsigned int" field="Rows" value="16" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+		</Class>
+	</Class>
+</ObjectStream>
+

--- a/Gems/Atom/Feature/Common/Assets/Textures/VolumetricFog/fogNoise3.png
+++ b/Gems/Atom/Feature/Common/Assets/Textures/VolumetricFog/fogNoise3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1262c1393f51993fd2c54eeee443f70b17af8d70d24ea886ef69e96b5b6ae34d
+size 10498413

--- a/Gems/Atom/Feature/Common/Assets/Textures/VolumetricFog/fogNoise3.png.assetinfo
+++ b/Gems/Atom/Feature/Common/Assets/Textures/VolumetricFog/fogNoise3.png.assetinfo
@@ -1,0 +1,145 @@
+<ObjectStream version="3">
+	<Class name="TextureSettings" version="2" type="{980132FF-C450-425D-8AE0-BD96A8486177}">
+		<Class name="AZ::Uuid" field="PresetID" value="{00000000-0000-0000-0000-000000000000}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+		<Class name="Name" field="Preset" value="Greyscale" type="{3D2B920C-9EFD-40D5-AAE0-DF131C3D4931}"/>
+		<Class name="unsigned int" field="SizeReduceLevel" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+		<Class name="bool" field="EngineReduce" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+		<Class name="bool" field="EnableMipmap" value="true" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+		<Class name="unsigned int" field="MipMapGenEval" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+		<Class name="ImageProcessingAtom::MipGenType" field="MipMapGenType" value="1" type="{8524F650-1417-44DA-BBB0-C707A7A1A709}"/>
+		<Class name="bool" field="MaintainAlphaCoverage" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
+		<Class name="AZStd::vector&lt;unsigned int, allocator&gt;" field="MipMapAlphaAdjustments" type="{3349AACD-BE04-50BC-9478-528BF2ACFD55}">
+			<Class name="unsigned int" field="element" value="50" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="unsigned int" field="element" value="50" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="unsigned int" field="element" value="50" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="unsigned int" field="element" value="50" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="unsigned int" field="element" value="50" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="unsigned int" field="element" value="50" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+		</Class>
+		<Class name="AZStd::map&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;" field="PlatformSpecificOverrides" type="{74E4843B-0924-583D-8C6E-A37B09BD51FE}">
+			<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;" field="element" type="{CAC4E67F-D626-5452-A057-ACB57D53F549}">
+				<Class name="AZStd::string" field="value1" value="android" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="DataPatch" field="value2" type="{BFF7A3F5-9014-4000-92C7-9B2BC7913DA9}">
+					<Class name="AZ::Uuid" field="m_targetClassId" value="{980132FF-C450-425D-8AE0-BD96A8486177}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+					<Class name="unsigned int" field="m_targetClassVersion" value="2" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+					<Class name="AZStd::unordered_map&lt;AddressType, AZStd::any, AZStd::hash&lt;AddressType&gt;, AZStd::equal_to&lt;AddressType&gt;, allocator&gt;" field="m_patch" type="{CEA836FC-77E0-5E46-BD0F-2E5A39D845E9}">
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="FlipbookSettings({334D20DF-3D5D-42D7-B60F-C5AF7A00CB23})::Flipbook·0/unsigned int({43DA906B-7DEF-4CA8-9790-854106D3F983})::Columns·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+								<Class name="unsigned int" field="m_data" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+							</Class>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="FlipbookSettings({334D20DF-3D5D-42D7-B60F-C5AF7A00CB23})::Flipbook·0/unsigned int({43DA906B-7DEF-4CA8-9790-854106D3F983})::Rows·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+								<Class name="unsigned int" field="m_data" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+							</Class>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;" field="element" type="{CAC4E67F-D626-5452-A057-ACB57D53F549}">
+				<Class name="AZStd::string" field="value1" value="ios" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="DataPatch" field="value2" type="{BFF7A3F5-9014-4000-92C7-9B2BC7913DA9}">
+					<Class name="AZ::Uuid" field="m_targetClassId" value="{980132FF-C450-425D-8AE0-BD96A8486177}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+					<Class name="unsigned int" field="m_targetClassVersion" value="2" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+					<Class name="AZStd::unordered_map&lt;AddressType, AZStd::any, AZStd::hash&lt;AddressType&gt;, AZStd::equal_to&lt;AddressType&gt;, allocator&gt;" field="m_patch" type="{CEA836FC-77E0-5E46-BD0F-2E5A39D845E9}">
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="FlipbookSettings({334D20DF-3D5D-42D7-B60F-C5AF7A00CB23})::Flipbook·0/unsigned int({43DA906B-7DEF-4CA8-9790-854106D3F983})::Columns·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+								<Class name="unsigned int" field="m_data" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+							</Class>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="FlipbookSettings({334D20DF-3D5D-42D7-B60F-C5AF7A00CB23})::Flipbook·0/unsigned int({43DA906B-7DEF-4CA8-9790-854106D3F983})::Rows·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+								<Class name="unsigned int" field="m_data" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+							</Class>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="AZStd::map&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;({74E4843B-0924-583D-8C6E-A37B09BD51FE})::PlatformSpecificOverrides·0/AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;({CAC4E67F-D626-5452-A057-ACB57D53F549})#0·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;" field="element" type="{CAC4E67F-D626-5452-A057-ACB57D53F549}">
+				<Class name="AZStd::string" field="value1" value="linux" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="DataPatch" field="value2" type="{BFF7A3F5-9014-4000-92C7-9B2BC7913DA9}">
+					<Class name="AZ::Uuid" field="m_targetClassId" value="{980132FF-C450-425D-8AE0-BD96A8486177}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+					<Class name="unsigned int" field="m_targetClassVersion" value="2" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+					<Class name="AZStd::unordered_map&lt;AddressType, AZStd::any, AZStd::hash&lt;AddressType&gt;, AZStd::equal_to&lt;AddressType&gt;, allocator&gt;" field="m_patch" type="{CEA836FC-77E0-5E46-BD0F-2E5A39D845E9}">
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="FlipbookSettings({334D20DF-3D5D-42D7-B60F-C5AF7A00CB23})::Flipbook·0/unsigned int({43DA906B-7DEF-4CA8-9790-854106D3F983})::Columns·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+								<Class name="unsigned int" field="m_data" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+							</Class>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="FlipbookSettings({334D20DF-3D5D-42D7-B60F-C5AF7A00CB23})::Flipbook·0/unsigned int({43DA906B-7DEF-4CA8-9790-854106D3F983})::Rows·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+								<Class name="unsigned int" field="m_data" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+							</Class>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="AZStd::map&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;({74E4843B-0924-583D-8C6E-A37B09BD51FE})::PlatformSpecificOverrides·0/AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;({CAC4E67F-D626-5452-A057-ACB57D53F549})#1·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}"/>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="AZStd::map&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;({74E4843B-0924-583D-8C6E-A37B09BD51FE})::PlatformSpecificOverrides·0/AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;({CAC4E67F-D626-5452-A057-ACB57D53F549})#0·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;" field="element" type="{CAC4E67F-D626-5452-A057-ACB57D53F549}">
+				<Class name="AZStd::string" field="value1" value="mac" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="DataPatch" field="value2" type="{BFF7A3F5-9014-4000-92C7-9B2BC7913DA9}">
+					<Class name="AZ::Uuid" field="m_targetClassId" value="{980132FF-C450-425D-8AE0-BD96A8486177}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+					<Class name="unsigned int" field="m_targetClassVersion" value="2" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+					<Class name="AZStd::unordered_map&lt;AddressType, AZStd::any, AZStd::hash&lt;AddressType&gt;, AZStd::equal_to&lt;AddressType&gt;, allocator&gt;" field="m_patch" type="{CEA836FC-77E0-5E46-BD0F-2E5A39D845E9}">
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="FlipbookSettings({334D20DF-3D5D-42D7-B60F-C5AF7A00CB23})::Flipbook·0/unsigned int({43DA906B-7DEF-4CA8-9790-854106D3F983})::Columns·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+								<Class name="unsigned int" field="m_data" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+							</Class>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="FlipbookSettings({334D20DF-3D5D-42D7-B60F-C5AF7A00CB23})::Flipbook·0/unsigned int({43DA906B-7DEF-4CA8-9790-854106D3F983})::Rows·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}">
+								<Class name="unsigned int" field="m_data" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+							</Class>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="AZStd::map&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;({74E4843B-0924-583D-8C6E-A37B09BD51FE})::PlatformSpecificOverrides·0/AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;({CAC4E67F-D626-5452-A057-ACB57D53F549})#2·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}"/>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="AZStd::map&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;({74E4843B-0924-583D-8C6E-A37B09BD51FE})::PlatformSpecificOverrides·0/AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;({CAC4E67F-D626-5452-A057-ACB57D53F549})#0·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}"/>
+						</Class>
+						<Class name="AZStd::pair&lt;AddressType, AZStd::any&gt;" field="element" type="{FED51EB4-F646-51FF-9646-9852CF90F353}">
+							<Class name="AddressType" field="value1" value="AZStd::map&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;({74E4843B-0924-583D-8C6E-A37B09BD51FE})::PlatformSpecificOverrides·0/AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;({CAC4E67F-D626-5452-A057-ACB57D53F549})#1·0/" version="1" type="{90752F2D-CBD3-4EE9-9CDD-447E797C8408}"/>
+							<Class name="AZStd::any" field="value2" type="{03924488-C7F4-4D6D-948B-ABC2D1AE2FD3}"/>
+						</Class>
+					</Class>
+				</Class>
+			</Class>
+			<Class name="AZStd::pair&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, DataPatch&gt;" field="element" type="{CAC4E67F-D626-5452-A057-ACB57D53F549}">
+				<Class name="AZStd::string" field="value1" value="pc" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+				<Class name="DataPatch" field="value2" type="{BFF7A3F5-9014-4000-92C7-9B2BC7913DA9}">
+					<Class name="AZ::Uuid" field="m_targetClassId" value="{980132FF-C450-425D-8AE0-BD96A8486177}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+					<Class name="unsigned int" field="m_targetClassVersion" value="2" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+					<Class name="AZStd::unordered_map&lt;AddressType, AZStd::any, AZStd::hash&lt;AddressType&gt;, AZStd::equal_to&lt;AddressType&gt;, allocator&gt;" field="m_patch" type="{CEA836FC-77E0-5E46-BD0F-2E5A39D845E9}"/>
+				</Class>
+			</Class>
+		</Class>
+		<Class name="AZStd::string" field="OverridingPlatform" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		<Class name="AZStd::set&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;, AZStd::less&lt;AZStd::basic_string&lt;char, AZStd::char_traits&lt;char&gt;, allocator&gt;&gt;, allocator&gt;" field="Tags" type="{166F208E-DE97-53FE-B349-BDD9FE9B8693}"/>
+		<Class name="FlipbookSettings" field="Flipbook" type="{334D20DF-3D5D-42D7-B60F-C5AF7A00CB23}">
+			<Class name="unsigned int" field="Columns" value="16" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="unsigned int" field="Rows" value="16" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+		</Class>
+	</Class>
+</ObjectStream>
+

--- a/Gems/Atom/Feature/Common/Assets/atom_feature_common_asset_files.cmake
+++ b/Gems/Atom/Feature/Common/Assets/atom_feature_common_asset_files.cmake
@@ -341,8 +341,10 @@ set(FILES
     ShaderResourceGroups/PostProcessing/SceneSrg.azsli
     ShaderResourceGroups/PostProcessing/ViewSrg.azsli
     ShaderResourceGroups/SkyBox/SceneSrg.azsli
-    # CARBONATED for Weather GEM
+#if defined(CARBONATED)
     ShaderResourceGroups/Weather/SceneSrg.azsli
+    ShaderResourceGroups/VolumetricFog/SceneSrg.azsli
+#endif
     Shaders/ForwardPassSrg.azsl
     Shaders/ForwardPassSrg.shader
     Shaders/AuxGeom/AuxGeomObject.azsl

--- a/Gems/Atom/Feature/Common/Assets/atom_feature_common_asset_files.cmake
+++ b/Gems/Atom/Feature/Common/Assets/atom_feature_common_asset_files.cmake
@@ -341,10 +341,10 @@ set(FILES
     ShaderResourceGroups/PostProcessing/SceneSrg.azsli
     ShaderResourceGroups/PostProcessing/ViewSrg.azsli
     ShaderResourceGroups/SkyBox/SceneSrg.azsli
-#if defined(CARBONATED)
+# Begin Carbonated
     ShaderResourceGroups/Weather/SceneSrg.azsli
     ShaderResourceGroups/VolumetricFog/SceneSrg.azsli
-#endif
+# End Carbonated
     Shaders/ForwardPassSrg.azsl
     Shaders/ForwardPassSrg.shader
     Shaders/AuxGeom/AuxGeomObject.azsl

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/ParamMacros/EndParams.inl
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/ParamMacros/EndParams.inl
@@ -15,6 +15,9 @@
 #undef AZ_GFX_VEC3_PARAM
 #undef AZ_GFX_VEC4_PARAM
 #undef AZ_GFX_TEXTURE2D_PARAM
+#if defined(CARBONATED)
+#undef AZ_GFX_TEXTURE_ASSET_PARAM
+#endif
 
 // Un-define overrides...
 #undef AZ_GFX_ANY_PARAM_BOOL_OVERRIDE

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/ParamMacros/MapParamCommon.inl
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/ParamMacros/MapParamCommon.inl
@@ -33,3 +33,8 @@
 #define AZ_GFX_TEXTURE2D_PARAM(Name, MemberName, DefaultValue)                                          \
         AZ_GFX_COMMON_PARAM(AZStd::string, Name, MemberName, DefaultValue)                              \
 
+// Begin CARBONATED
+#define AZ_GFX_TEXTURE_ASSET_PARAM(Name, MemberName, DefaultValue)                                      \
+        AZ_GFX_COMMON_PARAM(Data::Asset<AZ::RPI::StreamingImageAsset>, Name, MemberName, DefaultValue)  \
+// End CARBONATED
+

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/ParamMacros/MapParamEmpty.inl
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/ParamMacros/MapParamEmpty.inl
@@ -16,5 +16,8 @@
 #define AZ_GFX_VEC3_PARAM(Name, MemberName, DefaultValue)
 #define AZ_GFX_VEC4_PARAM(Name, MemberName, DefaultValue)
 #define AZ_GFX_TEXTURE2D_PARAM(Name, MemberName, DefaultValue)
+#if defined(CARBONATED)
+#define AZ_GFX_TEXTURE_ASSET_PARAM(Name, MemberName, DefaultValue)
+#endif
 
 #define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/FogVolumeFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/FogVolumeFeatureProcessorInterface.h
@@ -17,8 +17,11 @@
 
 namespace AZ::Render
 {
-    using FogVolumeHandle = RHI::Handle<uint16_t, class FogVolumeTag>;
+    // opaque handle returned by AcquireVolume, invalidated after ReleaseVolume
+    using FogVolumeHandle = RHI::Handle<uint16_t, class FogVolumeTag>; 
 
+    //! Manages the array of local fog volumes (box/sphere shapes that override fog
+    //! parameters inside them) and their GPU buffer.
     class FogVolumeFeatureProcessorInterface
         : public RPI::FeatureProcessor
     {
@@ -27,9 +30,13 @@ namespace AZ::Render
 
         using VolumeHandle = FogVolumeHandle;
 
+        //! Allocates a new GPU-backed fog volume slot; returns an invalid handle if the budget is full.
         virtual VolumeHandle AcquireVolume() = 0;
+        //! Frees the slot and zeroes the handle.
         virtual bool ReleaseVolume(VolumeHandle& handle) = 0;
+        //! Sets the world transform used to position the volume proxy mesh in the froxel injection pass.
         virtual void SetVolumeTransform(VolumeHandle handle, const AZ::Transform& transform) = 0;
+        //! Sets the half-extents of the box volume in world units; ignored for sphere shapes.
         virtual void SetVolumeExtents(VolumeHandle handle, const AZ::Vector3& halfExtents) = 0;
 
         // Auto-gen per-property volume setters: SetVolume<Name>(handle, val)

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/FogVolumeFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/FogVolumeFeatureProcessorInterface.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Atom/Feature/VolumetricFog/VolumetricFogConstants.h>
+#include <Atom/RPI.Public/FeatureProcessor.h>
+#include <Atom/RPI.Reflect/Image/StreamingImageAsset.h>
+#include <AzCore/Math/Color.h>
+#include <AzCore/Math/Transform.h>
+#include <AzCore/Math/Vector3.h>
+
+namespace AZ::Render
+{
+    using FogVolumeHandle = RHI::Handle<uint16_t, class FogVolumeTag>;
+
+    class FogVolumeFeatureProcessorInterface
+        : public RPI::FeatureProcessor
+    {
+    public:
+        AZ_RTTI(AZ::Render::FogVolumeFeatureProcessorInterface, "{5F8B3C7A-2D4E-4F9B-A6C1-8E0D5B3F7A2C}");
+
+        using VolumeHandle = FogVolumeHandle;
+
+        virtual VolumeHandle AcquireVolume() = 0;
+        virtual bool ReleaseVolume(VolumeHandle& handle) = 0;
+        virtual void SetVolumeTransform(VolumeHandle handle, const AZ::Transform& transform) = 0;
+        virtual void SetVolumeExtents(VolumeHandle handle, const AZ::Vector3& halfExtents) = 0;
+
+        // Auto-gen per-property volume setters: SetVolume<Name>(handle, val)
+#define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)  \
+        virtual void SetVolume##Name(VolumeHandle handle, ValueType val) = 0;
+
+#include <Atom/Feature/ParamMacros/MapParamCommon.inl>
+#include <Atom/Feature/VolumetricFog/FogVolumeParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+    };
+} // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/FogVolumeParams.inl
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/FogVolumeParams.inl
@@ -10,9 +10,9 @@
 // PARAM(NAME, MEMBER_NAME, DEFAULT_VALUE, ...)
 // Requires FogVolumeBlendMode from VolumetricFogConstants.h to be in scope.
 
-AZ_GFX_COMMON_PARAM(FogVolumeShape,     Shape,               m_shape,               FogVolumeShape::Unknown)
-AZ_GFX_COMMON_PARAM(FogVolumeBlendMode, BlendMode, m_blendMode, FogVolumeBlendMode::Additive)
-AZ_GFX_VEC3_PARAM(EdgeFade, m_edgeFade, AZ::Vector3(0.1f))
-AZ_GFX_UINT32_PARAM(Priority, m_priority, 0)
+AZ_GFX_COMMON_PARAM(FogVolumeShape,     Shape,     m_shape,     FogVolumeShape::Unknown)         // Box or Sphere (determines which proxy mesh is rasterized)
+AZ_GFX_COMMON_PARAM(FogVolumeBlendMode, BlendMode, m_blendMode, FogVolumeBlendMode::Additive)    // how this volume's density composites over the global fog
+AZ_GFX_VEC3_PARAM(EdgeFade, m_edgeFade, AZ::Vector3(0.1f))                                       // per-axis distance (normalized 0–1) for a smooth fade at each face boundary
+AZ_GFX_UINT32_PARAM(Priority, m_priority, 0)                                                      // sort key; higher priority volumes are injected last (draw-order within the same BlendMode batch)
 #include <Atom/Feature/VolumetricFog/VolumetricFogVolumeParams.inl>
 #include <Atom/Feature/VolumetricFog/VolumetricFogVolumeSRGConstants.inl>

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/FogVolumeParams.inl
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/FogVolumeParams.inl
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+// Macros below are of the form:
+// PARAM(NAME, MEMBER_NAME, DEFAULT_VALUE, ...)
+// Requires FogVolumeBlendMode from VolumetricFogConstants.h to be in scope.
+
+AZ_GFX_COMMON_PARAM(FogVolumeShape,     Shape,               m_shape,               FogVolumeShape::Unknown)
+AZ_GFX_COMMON_PARAM(FogVolumeBlendMode, BlendMode, m_blendMode, FogVolumeBlendMode::Additive)
+AZ_GFX_VEC3_PARAM(EdgeFade, m_edgeFade, AZ::Vector3(0.1f))
+AZ_GFX_UINT32_PARAM(Priority, m_priority, 0)
+#include <Atom/Feature/VolumetricFog/VolumetricFogVolumeParams.inl>
+#include <Atom/Feature/VolumetricFog/VolumetricFogVolumeSRGConstants.inl>

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/FogVolumeParams.inl
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/FogVolumeParams.inl
@@ -12,7 +12,7 @@
 
 AZ_GFX_COMMON_PARAM(FogVolumeShape,     Shape,     m_shape,     FogVolumeShape::Unknown)         // Box or Sphere (determines which proxy mesh is rasterized)
 AZ_GFX_COMMON_PARAM(FogVolumeBlendMode, BlendMode, m_blendMode, FogVolumeBlendMode::Additive)    // how this volume's density composites over the global fog
-AZ_GFX_VEC3_PARAM(EdgeFade, m_edgeFade, AZ::Vector3(0.1f))                                       // per-axis distance (normalized 0–1) for a smooth fade at each face boundary
+AZ_GFX_VEC3_PARAM(EdgeFade, m_edgeFade, AZ::Vector3(0.1f))                                       // per-axis distance (normalized 0-1) for a smooth fade at each face boundary
 AZ_GFX_UINT32_PARAM(Priority, m_priority, 0)                                                      // sort key; higher priority volumes are injected last (draw-order within the same BlendMode batch)
 #include <Atom/Feature/VolumetricFog/VolumetricFogVolumeParams.inl>
 #include <Atom/Feature/VolumetricFog/VolumetricFogVolumeSRGConstants.inl>

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogConstants.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogConstants.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/base.h>
+#include <AzCore/Preprocessor/Enum.h>
+
+namespace AZ::Render
+{
+    AZ_ENUM_CLASS_WITH_UNDERLYING_TYPE(VolumetricFogQuality, uint32_t,
+        Low,
+        Mid,
+        High);
+
+    // Must match value in Scenesrg.azsli
+    constexpr uint32_t VolumetricFogMaxSequenceLength = 16;
+
+    // Must match the shader defines in FroxelLocalVolumeCommon.azsli
+    AZ_ENUM_CLASS_WITH_UNDERLYING_TYPE(FogVolumeBlendMode, uint32_t,
+        Additive,
+        Multiply,
+        Overwrite,
+        Min,
+        Max);
+
+    AZ_ENUM_CLASS_WITH_UNDERLYING_TYPE(FogVolumeShape, uint32_t,
+        Box,
+        Sphere,
+        Unknown);
+
+    // Volumetric Fog scene volume constants
+    struct VolumetricFogVolumeConstants
+    {
+#define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue) ValueType MemberName;
+
+#include <Atom/Feature/ParamMacros/MapAllCommon.inl>
+
+#undef AZ_GFX_VEC3_PARAM
+#define AZ_GFX_VEC3_PARAM(Name, MemberName, DefaultValue) AZStd::array<float, 3> MemberName;
+
+#include <Atom/Feature/VolumetricFog/VolumetricFogVolumeSRGConstants.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+
+    };
+}

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogConstants.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogConstants.h
@@ -13,28 +13,32 @@
 
 namespace AZ::Render
 {
+    //! Controls froxel grid resolution — Low is coarser/faster, High is finer/slower.
+    //! Match VolumetricFogUtils::ToFroxelSize() for the actual tile sizes.
     AZ_ENUM_CLASS_WITH_UNDERLYING_TYPE(VolumetricFogQuality, uint32_t,
         Low,
         Mid,
         High);
 
-    // Must match value in Scenesrg.azsli
-    constexpr uint32_t VolumetricFogMaxSequenceLength = 16;
+    constexpr uint32_t VolumetricFogMaxSequenceLength = 16; // max length of the Halton jitter sequence; must match HLSL constant in SceneSrg.azsli
 
-    // Must match the shader defines in FroxelLocalVolumeCommon.azsli
+    //! How a local fog volume combines its density with underlying fog.
+    //! Must match the shader defines in FroxelLocalVolumeCommon.azsli.
     AZ_ENUM_CLASS_WITH_UNDERLYING_TYPE(FogVolumeBlendMode, uint32_t,
-        Additive,
-        Multiply,
-        Overwrite,
-        Min,
-        Max);
+        Additive,  // density is added on top of existing fog
+        Multiply,  // density is multiplied with existing fog
+        Overwrite, // density replaces existing fog entirely
+        Min,       // takes the lesser of the two densities
+        Max);      // takes the greater of the two densities
 
+    //! Shape of the proxy mesh used to rasterize the volume into the froxel grid.
     AZ_ENUM_CLASS_WITH_UNDERLYING_TYPE(FogVolumeShape, uint32_t,
         Box,
         Sphere,
         Unknown);
 
-    // Volumetric Fog scene volume constants
+    //! GPU-layout struct uploaded to the scene SRG for per-volume shader constants;
+    //! layout must stay in sync with FroxelLocalVolumeCommon.azsli.
     struct VolumetricFogVolumeConstants
     {
 #define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue) ValueType MemberName;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogConstants.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogConstants.h
@@ -13,7 +13,7 @@
 
 namespace AZ::Render
 {
-    //! Controls froxel grid resolution — Low is coarser/faster, High is finer/slower.
+    //! Controls froxel grid resolution. Low is coarser/faster, High is finer/slower.
     //! Match VolumetricFogUtils::ToFroxelSize() for the actual tile sizes.
     AZ_ENUM_CLASS_WITH_UNDERLYING_TYPE(VolumetricFogQuality, uint32_t,
         Low,

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogFeatureProcessorInterface.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Atom/RPI.Public/FeatureProcessor.h>
+#include <Atom/Feature/VolumetricFog/VolumetricFogConstants.h>
+#include <Atom/Feature/VolumetricFog/VolumetricFogSettings.h>
+#include <Atom/Feature/LightingChannel/LightingChannelConfiguration.h>
+#include <AzCore/Asset/AssetCommon.h>
+#include <AzCore/Math/Color.h>
+#include <AzCore/Math/Transform.h>
+#include <AzCore/Math/Vector3.h>
+
+namespace AZ::Render
+{
+    class VolumetricFogFeatureProcessorInterface
+        : public RPI::FeatureProcessor
+    {
+    public:
+        AZ_RTTI(AZ::Render::VolumetricFogFeatureProcessorInterface, "{B95F37FC-DF37-4F48-AE57-9A8AC6E3BE95}");
+
+        virtual const VolumetricFogSettings& GetSettings() const = 0;
+
+        // Generate global fog getters and setters.
+#include <Atom/Feature/ParamMacros/StartParamFunctionsVirtual.inl>
+#include <Atom/Feature/VolumetricFog/VolumetricFogParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+    };
+} // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogFeatureProcessorInterface.h
@@ -19,12 +19,15 @@
 
 namespace AZ::Render
 {
+    //! Public interface for querying and mutating the scene-wide (global) volumetric fog
+    //! One froxel volume covering the whole view (camera) frustum.
     class VolumetricFogFeatureProcessorInterface
         : public RPI::FeatureProcessor
     {
     public:
         AZ_RTTI(AZ::Render::VolumetricFogFeatureProcessorInterface, "{B95F37FC-DF37-4F48-AE57-9A8AC6E3BE95}");
 
+        //! Returns the current fog settings snapshot
         virtual const VolumetricFogSettings& GetSettings() const = 0;
 
         // Generate global fog getters and setters.

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogParams.inl
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogParams.inl
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+// Macros below are of the form:
+// PARAM(NAME, MEMBER_NAME, DEFAULT_VALUE, ...)
+
+AZ_GFX_BOOL_PARAM(Enable, m_enabled, true)
+AZ_GFX_COMMON_PARAM(Render::VolumetricFogQuality, FogQuality, m_quality, VolumetricFogQuality::Mid)
+AZ_GFX_COMMON_PARAM(Render::LightingChannelConfiguration, LightingChannels, m_lightingChannelConfig, Render::LightingChannelConfiguration())
+#include <Atom/Feature/VolumetricFog/VolumetricFogSRGConstants.inl>
+#include <Atom/Feature/VolumetricFog/VolumetricFogVolumeParams.inl>
+#include <Atom/Feature/VolumetricFog/VolumetricFogVolumeSRGConstants.inl>

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogParams.inl
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogParams.inl
@@ -9,9 +9,9 @@
 // Macros below are of the form:
 // PARAM(NAME, MEMBER_NAME, DEFAULT_VALUE, ...)
 
-AZ_GFX_BOOL_PARAM(Enable, m_enabled, true)
-AZ_GFX_COMMON_PARAM(Render::VolumetricFogQuality, FogQuality, m_quality, VolumetricFogQuality::Mid)
-AZ_GFX_COMMON_PARAM(Render::LightingChannelConfiguration, LightingChannels, m_lightingChannelConfig, Render::LightingChannelConfiguration())
+AZ_GFX_BOOL_PARAM(Enable, m_enabled, true)                                                                                                  // master toggle; when false the pass hierarchy is disabled
+AZ_GFX_COMMON_PARAM(Render::VolumetricFogQuality, FogQuality, m_quality, VolumetricFogQuality::Mid)                                        // froxel resolution preset (see VolumetricFogQuality)
+AZ_GFX_COMMON_PARAM(Render::LightingChannelConfiguration, LightingChannels, m_lightingChannelConfig, Render::LightingChannelConfiguration()) // which lighting layers contribute to in-scattering
 #include <Atom/Feature/VolumetricFog/VolumetricFogSRGConstants.inl>
 #include <Atom/Feature/VolumetricFog/VolumetricFogVolumeParams.inl>
 #include <Atom/Feature/VolumetricFog/VolumetricFogVolumeSRGConstants.inl>

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogSRGConstants.inl
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogSRGConstants.inl
@@ -11,5 +11,5 @@
 
 AZ_GFX_FLOAT_PARAM(FogStartDistance, m_fogNear, 1.0f)               // near clip of the froxel volume; fog is invisible before this depth
 AZ_GFX_FLOAT_PARAM(FogEndDistance, m_fogFar, 200.0f)                // far clip of the froxel volume; slices are distributed logarithmically between Near and Far
-AZ_GFX_UINT32_PARAM(FogSequenceLength, m_sequenceLength, 8)         // number of Halton jitter frames used for temporal anti-aliasing (1–16); more frames = smoother TAA but slower convergence after camera cuts
+AZ_GFX_UINT32_PARAM(FogSequenceLength, m_sequenceLength, 8)         // number of Halton jitter frames used for temporal anti-aliasing (1-16); more frames = smoother TAA but slower convergence after camera cuts
 AZ_GFX_FLOAT_PARAM(TemporalBlendPercentage, m_blendPercentage, 4)   // fraction of the current frame blended into history each frame (low = more history weight = smoother but ghostier)

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogSRGConstants.inl
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogSRGConstants.inl
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+// Macros below are of the form:
+// PARAM(NAME, MEMBER_NAME, DEFAULT_VALUE, ...)
+
+AZ_GFX_FLOAT_PARAM(FogStartDistance, m_fogNear, 1.0f)
+AZ_GFX_FLOAT_PARAM(FogEndDistance, m_fogFar, 200.0f)
+AZ_GFX_UINT32_PARAM(FogSequenceLength, m_sequenceLength, 8)
+AZ_GFX_FLOAT_PARAM(TemporalBlendPercentage, m_blendPercentage, 4)

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogSRGConstants.inl
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogSRGConstants.inl
@@ -9,7 +9,7 @@
 // Macros below are of the form:
 // PARAM(NAME, MEMBER_NAME, DEFAULT_VALUE, ...)
 
-AZ_GFX_FLOAT_PARAM(FogStartDistance, m_fogNear, 1.0f)
-AZ_GFX_FLOAT_PARAM(FogEndDistance, m_fogFar, 200.0f)
-AZ_GFX_UINT32_PARAM(FogSequenceLength, m_sequenceLength, 8)
-AZ_GFX_FLOAT_PARAM(TemporalBlendPercentage, m_blendPercentage, 4)
+AZ_GFX_FLOAT_PARAM(FogStartDistance, m_fogNear, 1.0f)               // near clip of the froxel volume; fog is invisible before this depth
+AZ_GFX_FLOAT_PARAM(FogEndDistance, m_fogFar, 200.0f)                // far clip of the froxel volume; slices are distributed logarithmically between Near and Far
+AZ_GFX_UINT32_PARAM(FogSequenceLength, m_sequenceLength, 8)         // number of Halton jitter frames used for temporal anti-aliasing (1–16); more frames = smoother TAA but slower convergence after camera cuts
+AZ_GFX_FLOAT_PARAM(TemporalBlendPercentage, m_blendPercentage, 4)   // fraction of the current frame blended into history each frame (low = more history weight = smoother but ghostier)

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogSettings.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogSettings.h
@@ -16,6 +16,8 @@
 
 namespace AZ::Render
 {
+    //! POD settings bag that mirrors the VolumetricFogParams
+    //! The feature processor stores one of these and exposes it via GetSettings().
     class VolumetricFogSettings final
     {
     public:

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogSettings.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogSettings.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/RTTI/ReflectContext.h>
+#include <AzCore/Asset/AssetCommon.h>
+#include <Atom/Feature/VolumetricFog/VolumetricFogConstants.h>
+#include <Atom/Feature/LightingChannel/LightingChannelConfiguration.h>
+#include <Atom/RPI.Reflect/Image/StreamingImageAsset.h>
+
+namespace AZ::Render
+{
+    class VolumetricFogSettings final
+    {
+    public:
+        AZ_RTTI(AZ::Render::VolumetricFogSettings, "{501C7191-7EE8-4101-9A93-EB918C99D9EE}");
+        AZ_CLASS_ALLOCATOR(VolumetricFogSettings, SystemAllocator);
+
+        VolumetricFogSettings() = default;
+        ~VolumetricFogSettings() = default;
+
+        // Generate members...
+#include <Atom/Feature/ParamMacros/StartParamMembers.inl>
+#include <Atom/Feature/VolumetricFog/VolumetricFogParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+    };
+
+}

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogVolumeParams.inl
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogVolumeParams.inl
@@ -9,4 +9,4 @@
 // Macros below are of the form:
 // PARAM(NAME, MEMBER_NAME, DEFAULT_VALUE, ...)
 
-AZ_GFX_TEXTURE_ASSET_PARAM(NoiseTexture, m_noiseTexture, {})
+AZ_GFX_TEXTURE_ASSET_PARAM(NoiseTexture, m_noiseTexture, {}) // optional 3D tiling noise texture; when absent, noise sampling is skipped

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogVolumeParams.inl
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogVolumeParams.inl
@@ -9,4 +9,9 @@
 // Macros below are of the form:
 // PARAM(NAME, MEMBER_NAME, DEFAULT_VALUE, ...)
 
-AZ_GFX_TEXTURE_ASSET_PARAM(NoiseTexture, m_noiseTexture, {}) // optional 3D tiling noise texture; when absent, noise sampling is skipped
+AZ_GFX_TEXTURE_ASSET_PARAM(
+    NoiseTexture,
+    m_noiseTexture,
+    Data::Asset<AZ::RPI::StreamingImageAsset>(Data::AssetId(
+        "{5AB3C089-DCE0-54EA-83AA-6118ED561449}", AZ::RPI::StreamingImageAsset::GetImageAssetSubId()), // "textures/volumetricfog/fognoise.dds.streamingimage"
+        azrtti_typeid<AZ::RPI::StreamingImageAsset>())) // optional 3D tiling noise texture; when absent, noise sampling is skipped

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogVolumeParams.inl
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogVolumeParams.inl
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+// Macros below are of the form:
+// PARAM(NAME, MEMBER_NAME, DEFAULT_VALUE, ...)
+
+AZ_GFX_TEXTURE_ASSET_PARAM(NoiseTexture, m_noiseTexture, {})

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogVolumeSRGConstants.inl
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogVolumeSRGConstants.inl
@@ -9,13 +9,13 @@
 // Macros below are of the form:
 // PARAM(NAME, MEMBER_NAME, DEFAULT_VALUE, ...)
 
-AZ_GFX_VEC3_PARAM(FogAlbedo, m_fogAlbedo, Vector3(0.85, 0.90, 1.0))
-AZ_GFX_FLOAT_PARAM(PhaseG, m_phaseG, 0.6f)
-AZ_GFX_FLOAT_PARAM(AmbientIntensity, m_ambientIntensity, 0.8f)
-AZ_GFX_FLOAT_PARAM(FogDensity, m_fogDensity, 0.17f)
-AZ_GFX_FLOAT_PARAM(FogBaseHeight, m_fogBaseHeight, 0.0f)
-AZ_GFX_FLOAT_PARAM(FogHeightFalloff, m_fogHeightFalloff, 0.22f)
-AZ_GFX_VEC3_PARAM(FogNoiseWindVelocity, m_noiseWindVelocity, Vector3(0.7f, 0.0f, 0.0f))
-AZ_GFX_FLOAT_PARAM(FogNoiseScale, m_noiseScale, 0.1f)
-AZ_GFX_VEC3_PARAM(FogEmissiveColor, m_emissiveColor, Vector3(0.0f, 0.0f, 0.0f))
-AZ_GFX_FLOAT_PARAM(FogEmissiveIntensity, m_emissiveIntensity, 0.0f)
+AZ_GFX_VEC3_PARAM(FogAlbedo, m_fogAlbedo, Vector3(0.85, 0.90, 1.0))                            // single-scattering albedo (RGB); 1.0 = pure white scatter, 0.0 = pure absorption
+AZ_GFX_FLOAT_PARAM(PhaseG, m_phaseG, 0.6f)                                                     // Henyey-Greenstein asymmetry parameter (−1 = full back-scatter, 0 = isotropic, 1 = full forward-scatter)
+AZ_GFX_FLOAT_PARAM(AmbientIntensity, m_ambientIntensity, 0.8f)                                 // scale applied to IBL irradiance sampled from the diffuse cubemap
+AZ_GFX_FLOAT_PARAM(FogDensity, m_fogDensity, 0.17f)                                            // extinction coefficient σ_t; linearly scales scattering and absorption
+AZ_GFX_FLOAT_PARAM(FogBaseHeight, m_fogBaseHeight, 0.0f)                                       // world-space Z below which height fog reaches full density
+AZ_GFX_FLOAT_PARAM(FogHeightFalloff, m_fogHeightFalloff, 0.22f)                                // exponential falloff rate above FogBaseHeight (higher = thinner fog at altitude)
+AZ_GFX_VEC3_PARAM(FogNoiseWindVelocity, m_noiseWindVelocity, Vector3(0.7f, 0.0f, 0.0f))       // world-space scroll velocity applied to the 3D noise texture each frame
+AZ_GFX_FLOAT_PARAM(FogNoiseScale, m_noiseScale, 0.1f)                                          // spatial frequency of the 3D noise in world units
+AZ_GFX_VEC3_PARAM(FogEmissiveColor, m_emissiveColor, Vector3(0.0f, 0.0f, 0.0f))               // optional self-emission color added before Beer-Lambert integration
+AZ_GFX_FLOAT_PARAM(FogEmissiveIntensity, m_emissiveIntensity, 0.0f)                            // intensity multiplier for self-emission; zero disables the emissive term

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogVolumeSRGConstants.inl
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogVolumeSRGConstants.inl
@@ -10,9 +10,9 @@
 // PARAM(NAME, MEMBER_NAME, DEFAULT_VALUE, ...)
 
 AZ_GFX_VEC3_PARAM(FogAlbedo, m_fogAlbedo, Vector3(0.85, 0.90, 1.0))                            // single-scattering albedo (RGB); 1.0 = pure white scatter, 0.0 = pure absorption
-AZ_GFX_FLOAT_PARAM(PhaseG, m_phaseG, 0.6f)                                                     // Henyey-Greenstein asymmetry parameter (−1 = full back-scatter, 0 = isotropic, 1 = full forward-scatter)
+AZ_GFX_FLOAT_PARAM(PhaseG, m_phaseG, 0.6f)                                                     // Henyey-Greenstein asymmetry parameter (-1 = full back-scatter, 0 = isotropic, 1 = full forward-scatter)
 AZ_GFX_FLOAT_PARAM(AmbientIntensity, m_ambientIntensity, 0.8f)                                 // scale applied to IBL irradiance sampled from the diffuse cubemap
-AZ_GFX_FLOAT_PARAM(FogDensity, m_fogDensity, 0.17f)                                            // extinction coefficient σ_t; linearly scales scattering and absorption
+AZ_GFX_FLOAT_PARAM(FogDensity, m_fogDensity, 0.17f)                                            // extinction coefficient sigma_t; linearly scales scattering and absorption
 AZ_GFX_FLOAT_PARAM(FogBaseHeight, m_fogBaseHeight, 0.0f)                                       // world-space Z below which height fog reaches full density
 AZ_GFX_FLOAT_PARAM(FogHeightFalloff, m_fogHeightFalloff, 0.22f)                                // exponential falloff rate above FogBaseHeight (higher = thinner fog at altitude)
 AZ_GFX_VEC3_PARAM(FogNoiseWindVelocity, m_noiseWindVelocity, Vector3(0.7f, 0.0f, 0.0f))       // world-space scroll velocity applied to the 3D noise texture each frame

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogVolumeSRGConstants.inl
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/VolumetricFog/VolumetricFogVolumeSRGConstants.inl
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+// Macros below are of the form:
+// PARAM(NAME, MEMBER_NAME, DEFAULT_VALUE, ...)
+
+AZ_GFX_VEC3_PARAM(FogAlbedo, m_fogAlbedo, Vector3(0.85, 0.90, 1.0))
+AZ_GFX_FLOAT_PARAM(PhaseG, m_phaseG, 0.6f)
+AZ_GFX_FLOAT_PARAM(AmbientIntensity, m_ambientIntensity, 0.8f)
+AZ_GFX_FLOAT_PARAM(FogDensity, m_fogDensity, 0.17f)
+AZ_GFX_FLOAT_PARAM(FogBaseHeight, m_fogBaseHeight, 0.0f)
+AZ_GFX_FLOAT_PARAM(FogHeightFalloff, m_fogHeightFalloff, 0.22f)
+AZ_GFX_VEC3_PARAM(FogNoiseWindVelocity, m_noiseWindVelocity, Vector3(0.7f, 0.0f, 0.0f))
+AZ_GFX_FLOAT_PARAM(FogNoiseScale, m_noiseScale, 0.1f)
+AZ_GFX_VEC3_PARAM(FogEmissiveColor, m_emissiveColor, Vector3(0.0f, 0.0f, 0.0f))
+AZ_GFX_FLOAT_PARAM(FogEmissiveIntensity, m_emissiveIntensity, 0.0f)

--- a/Gems/Atom/Feature/Common/Code/Source/CommonSystemComponent.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CommonSystemComponent.cpp
@@ -349,7 +349,7 @@ namespace AZ
 #if defined(CARBONATED)
             // Add Silhouette JFA passes
             passSystem->AddPassCreator(Name("SilhouetteJFAStepParentPass"), &SilhouetteJFAStepParentPass::Create);
-			// Volumetric Fog
+            // Volumetric Fog
             passSystem->AddPassCreator(Name("FroxelPass"), &FroxelPass::Create);
             passSystem->AddPassCreator(Name("FroxelIntegratePass"), &FroxelIntegratePass::Create);
 #endif

--- a/Gems/Atom/Feature/Common/Code/Source/CommonSystemComponent.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CommonSystemComponent.cpp
@@ -85,6 +85,12 @@
 #include <SkyBox/SkyBoxFeatureProcessor.h>
 #include <SplashScreen/SplashScreenFeatureProcessor.h>
 #include <SplashScreen/SplashScreenPass.h>
+#if defined(CARBONATED)
+#include <VolumetricFog/VolumetricFogFeatureProcessor.h>
+#include <VolumetricFog/FogVolumeFeatureProcessor.h>
+#include <VolumetricFog/FroxelPass.h>
+#include <VolumetricFog/FroxelIntegratePass.h>
+#endif
 
 #include <Atom/RPI.Public/Pass/PassSystemInterface.h>
 
@@ -151,13 +157,15 @@ namespace AZ
             RenderDebugFeatureProcessor::Reflect(context);
             SplashScreenFeatureProcessor::Reflect(context);
             SplashScreenSettings::Reflect(context);
-
             LightingPreset::Reflect(context);
             ModelPreset::Reflect(context);
             RayTracingFeatureProcessor::Reflect(context);
             OcclusionCullingPlaneFeatureProcessor::Reflect(context);
             LightingChannelConfiguration::Reflect(context);
-
+#if defined(CARBONATED)
+            VolumetricFogFeatureProcessor::Reflect(context);
+            FogVolumeFeatureProcessor::Reflect(context);
+#endif
             if (SerializeContext* serialize = azrtti_cast<SerializeContext*>(context))
             {
                 serialize->Class<CommonSystemComponent, Component>()
@@ -219,6 +227,12 @@ namespace AZ
                 AZ::RPI::FeatureProcessorFactory::Get()->RegisterFeatureProcessorWithInterface<OcclusionCullingPlaneFeatureProcessor, OcclusionCullingPlaneFeatureProcessorInterface>();
                 AZ::RPI::FeatureProcessorFactory::Get()->RegisterFeatureProcessor<SplashScreenFeatureProcessor>();
                 AZ::RPI::FeatureProcessorFactory::Get()->RegisterFeatureProcessor<SilhouetteFeatureProcessor>();
+#if defined(CARBONATED)
+                AZ::RPI::FeatureProcessorFactory::Get()
+                    ->RegisterFeatureProcessorWithInterface<VolumetricFogFeatureProcessor, VolumetricFogFeatureProcessorInterface>();
+                AZ::RPI::FeatureProcessorFactory::Get()
+                    ->RegisterFeatureProcessorWithInterface<FogVolumeFeatureProcessor, FogVolumeFeatureProcessorInterface>();
+#endif
             }
 
             AZ::RPI::FeatureProcessorFactory::Get()->RegisterFeatureProcessorWithInterface<AuxGeomFeatureProcessor, RPI::AuxGeomFeatureProcessorInterface>();
@@ -335,7 +349,11 @@ namespace AZ
 #if defined(CARBONATED)
             // Add Silhouette JFA passes
             passSystem->AddPassCreator(Name("SilhouetteJFAStepParentPass"), &SilhouetteJFAStepParentPass::Create);
+			// Volumetric Fog
+            passSystem->AddPassCreator(Name("FroxelPass"), &FroxelPass::Create);
+            passSystem->AddPassCreator(Name("FroxelIntegratePass"), &FroxelIntegratePass::Create);
 #endif
+
             // setup handler for load pass template mappings
             m_loadTemplatesHandler = RPI::PassSystemInterface::OnReadyLoadTemplatesEvent::Handler([this]() { this->LoadPassTemplateMappings(); });
             RPI::PassSystemInterface::Get()->ConnectEvent(m_loadTemplatesHandler);
@@ -368,6 +386,10 @@ namespace AZ
                 AZ::RPI::FeatureProcessorFactory::Get()->UnregisterFeatureProcessor<RenderDebugFeatureProcessor>();
                 AZ::RPI::FeatureProcessorFactory::Get()->UnregisterFeatureProcessor<SplashScreenFeatureProcessor>();
                 AZ::RPI::FeatureProcessorFactory::Get()->UnregisterFeatureProcessor<SilhouetteFeatureProcessor>();
+#if defined(CARBONATED)
+                AZ::RPI::FeatureProcessorFactory::Get()->UnregisterFeatureProcessor<VolumetricFogFeatureProcessor>();
+                AZ::RPI::FeatureProcessorFactory::Get()->UnregisterFeatureProcessor<FogVolumeFeatureProcessor>();
+#endif
             }
 
             AZ::RPI::FeatureProcessorFactory::Get()->UnregisterFeatureProcessor<MeshFeatureProcessor>();

--- a/Gems/Atom/Feature/Common/Code/Source/LightingChannel/LightingChannelConfiguration.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/LightingChannel/LightingChannelConfiguration.cpp
@@ -10,6 +10,9 @@
 
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/EditContext.h>
+#if defined(CARBONATED)
+#include <AzCore/RTTI/BehaviorContext.h>
+#endif
 
 namespace AZ
 {
@@ -40,6 +43,13 @@ namespace AZ
                      ;
                 }
             }
+
+#if defined(CARBONATED)
+            if (auto* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+            {
+                behaviorContext->Class<LightingChannelConfiguration>();
+            }
+#endif
         }
 
         void LightingChannelConfiguration::SetLightingChannelMask(const uint32_t mask)

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
@@ -506,8 +506,8 @@ namespace AZ
             // without invalidating the indices held here in the m_meshBufferIndices and m_materialTextureIndices lists.
             
             // mesh buffer and material texture resource lists, accessed by the shader through an unbounded array
-            RayTracingResourceList<RHI::BufferView> m_meshBuffers;
-            RayTracingResourceList<const RHI::ImageView> m_materialTextures;
+            RayTracingResourceList<RHI::BufferView*> m_meshBuffers;
+            RayTracingResourceList<const RHI::ImageView*> m_materialTextures;
 #endif
 
             // RayTracingIndexList implements an internal freelist chain stored inside the list itself, allowing entries to be

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
@@ -506,8 +506,13 @@ namespace AZ
             // without invalidating the indices held here in the m_meshBufferIndices and m_materialTextureIndices lists.
             
             // mesh buffer and material texture resource lists, accessed by the shader through an unbounded array
+#if defined(CARBONATED)
             RayTracingResourceList<RHI::BufferView*> m_meshBuffers;
             RayTracingResourceList<const RHI::ImageView*> m_materialTextures;
+#else
+            RayTracingResourceList<RHI::BufferView> m_meshBuffers;
+            RayTracingResourceList<const RHI::ImageView> m_materialTextures;
+#endif
 #endif
 
             // RayTracingIndexList implements an internal freelist chain stored inside the list itself, allowing entries to be

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingResourceList.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingResourceList.h
@@ -9,7 +9,11 @@
 #pragma once
 
 #include <AzCore/std/containers/vector.h>
+#if defined(CARBONATED)
+#include <AzCore/std/containers/unordered_map.h>
+#else
 #include <AzCore/std/containers/map.h>
+#endif
 #include <AzCore/Casting/numeric_cast.h>
 #include <RayTracing/RayTracingIndexList.h>
 
@@ -31,7 +35,11 @@ namespace AZ
         {
         public:
 
+#if defined(CARBONATED)
+            using ResourceVector = AZStd::vector<TResource>;
+#else
             using ResourceVector = AZStd::vector<const TResource*>;
+#endif
             using IndexVector = AZStd::vector<uint32_t>;
 
             RayTracingResourceList() = default;
@@ -39,11 +47,19 @@ namespace AZ
 
             // adds a resource to the list, or increments the reference count, and returns the index of the resource
             // Note: the index returned is an indirection index, meaning it is stable when other entries are removed
+#if defined(CARBONATED)
+            uint32_t AddResource(TResource resource);
+#else
             uint32_t AddResource(const TResource* resource);
+#endif
 
             // removes a resource from the list, or decrements the reference count
             // Note: removing a resource will not affect any previously returned indices for other resources
+#if defined(CARBONATED)
+            void RemoveResource(TResource resource);
+#else
             void RemoveResource(const TResource* resource);
+#endif
 
             // returns the resource list
             ResourceVector& GetResourceList() { return m_resources; }
@@ -68,7 +84,11 @@ namespace AZ
                 uint32_t m_count = 0;
             };
 
+#if defined(CARBONATED)
+            using ResourceMap = AZStd::unordered_map<TResource, IndexMapEntry>;
+#else
             using ResourceMap = AZStd::map<const TResource*, IndexMapEntry>;
+#endif
 
             ResourceVector m_resources;
             ResourceMap m_resourceMap;
@@ -76,9 +96,13 @@ namespace AZ
         };
 
         template<class TResource>
+#if defined(CARBONATED)
+        uint32_t RayTracingResourceList<TResource>::AddResource(TResource resource)
+#else
         uint32_t RayTracingResourceList<TResource>::AddResource(const TResource* resource)
+#endif
         {
-            if (resource == nullptr)
+            if (!resource)
             {
                 return InvalidIndex;
             }
@@ -111,9 +135,13 @@ namespace AZ
         }
 
         template<class TResource>
+#if defined(CARBONATED)
+        void RayTracingResourceList<TResource>::RemoveResource(TResource resource)
+#else
         void RayTracingResourceList<TResource>::RemoveResource(const TResource* resource)
+#endif
         {
-            if (resource == nullptr)
+            if (!resource)
             {
                 return;
             }

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FogVolumeFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FogVolumeFeatureProcessor.cpp
@@ -180,7 +180,7 @@ namespace AZ::Render
         Data::AssetBus::MultiHandler::BusDisconnect();
 
         m_noiseImageImages.clear();
-        m_noiseImageAssetsId.Reset();
+        m_noiseImageAssets.Reset();
         m_rasterPass = nullptr;
         m_drawPackets.clear();
         m_pipelineStates.fill(nullptr);
@@ -264,7 +264,7 @@ namespace AZ::Render
             AZStd::back_inserter(rhiImages),
             [](const Data::Instance<RPI::StreamingImage>& rpiImage)
             {
-                return rpiImage->GetImageView();
+                return rpiImage ? rpiImage->GetImageView() : nullptr;
             });
         passSrg->SetImageViewUnboundedArray(m_noiseTextureArrayIndex, rhiImages);
 
@@ -365,29 +365,31 @@ namespace AZ::Render
     void FogVolumeFeatureProcessor::SetVolumeNoiseTexture(
         VolumeHandle handle, Data::Asset<AZ::RPI::StreamingImageAsset> val)
     {
+        // This is a workaround because on certain cases the subId of the StreamingImageAsset doesn't load and it's 0
+        Data::AssetId id(val.GetId().m_guid, RPI::StreamingImageAsset::GetImageAssetSubId());
+        auto textureAsset = AZ::Data::AssetManager::Instance().GetAsset<RPI::StreamingImageAsset>(id, AZ::Data::AssetLoadBehavior::PreLoad);                                                                  \
         auto& state = m_volumeStates.GetData(handle.GetIndex());
-        const auto& indirectionList = m_noiseImageAssetsId.GetIndirectionList();
+        const auto& indirectionList = m_noiseImageAssets.GetIndirectionList();
         if (state.m_noiseTextureIndex >= 0 && state.m_noiseTextureIndex < static_cast<int>(indirectionList.size()))
         {
             uint32_t resourceIndex = indirectionList[state.m_noiseTextureIndex];
-            const auto& assetId = m_noiseImageAssetsId.GetResourceList()[resourceIndex];
-            if (assetId == val.GetId())
+            const auto& asset = m_noiseImageAssets.GetResourceList()[resourceIndex];
+            if (asset == textureAsset)
             {
                 return;
             }
 
-            m_noiseImageAssetsId.RemoveResource(assetId);
+            m_noiseImageAssets.RemoveResource(textureAsset);
         }
 
         int index = -1;
-        if (val.GetId().IsValid())
+        if (textureAsset.GetId().IsValid())
         {
-            index = static_cast<int>(m_noiseImageAssetsId.AddResource(val.GetId()));
-            if (!val.IsReady() && !val.IsLoading())
+            index = static_cast<int>(m_noiseImageAssets.AddResource(textureAsset));
+            if (!textureAsset.IsReady() && !textureAsset.IsLoading())
             {
-                val.QueueLoad();
+                textureAsset.QueueLoad();
             }
-
         }
         state.m_noiseTextureIndex = index;
 
@@ -815,13 +817,16 @@ namespace AZ::Render
 
     void FogVolumeFeatureProcessor::BuildNoiseTextureArray()
     {
-        const auto& resourceList = m_noiseImageAssetsId.GetResourceList();
-        const auto& indirectionLis = m_noiseImageAssetsId.GetIndirectionList();
+        const auto& resourceList = m_noiseImageAssets.GetResourceList();
+        const auto& indirectionLis = m_noiseImageAssets.GetIndirectionList();
+        AZStd::vector<Data::Instance<RPI::StreamingImage>> images(resourceList.size(), nullptr);
         for (auto& volume : m_currentFrameVolumes)
         {
-            if (volume.m_noiseTextureIndex >= 0 && volume.m_noiseTextureIndex < indirectionLis.size())
+            if (volume.m_noiseTextureIndex >= 0 && volume.m_noiseTextureIndex < indirectionLis.size() &&
+                resourceList[indirectionLis[volume.m_noiseTextureIndex]].IsReady())
             {
                 volume.m_noiseTextureIndex = indirectionLis[volume.m_noiseTextureIndex];
+                images[volume.m_noiseTextureIndex] = RPI::StreamingImage::FindOrCreate(resourceList[volume.m_noiseTextureIndex]);
             }
             else
             {
@@ -829,21 +834,6 @@ namespace AZ::Render
             }
         }
 
-        AZStd::vector<Data::Instance<RPI::StreamingImage>> images(resourceList.size(), nullptr);
-        for (uint32_t i = 0; i < resourceList.size(); ++i)
-        {
-            const AZ::Data::AssetId& assetId = resourceList[i];
-            if (assetId.IsValid())
-            {
-                auto textureAsset = AZ::Data::AssetManager::Instance().GetAsset<AZ::RPI::StreamingImageAsset>(
-                    assetId, AZ::Data::AssetLoadBehavior::PreLoad);
-                if (textureAsset.IsReady())
-                {
-                    images[i] = RPI::StreamingImage::FindOrCreate(textureAsset);
-                    continue;
-                }
-            }
-        }
         m_noiseImageImages = AZStd::move(images);
     }
 

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FogVolumeFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FogVolumeFeatureProcessor.cpp
@@ -509,7 +509,7 @@ namespace AZ::Render
         positions.clear();
         positions.reserve(numVertices);
 
-        // 1st pole vertex (top, along +Z — up axis in O3DE)
+        // 1st pole vertex (top, along +Z. Up axis in O3DE)
         positions.push_back(PosType{ 0.0f, 0.0f, radius });
 
         for (uint32_t ring = 1; ring < numRings - numberOfPoles + 2; ++ring)

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FogVolumeFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FogVolumeFeatureProcessor.cpp
@@ -204,6 +204,16 @@ namespace AZ::Render
             return;
         }
 
+        RPI::Pass* pass = m_rasterPass;
+        while (!pass)
+        {
+            if (!pass->IsEnabled())
+            {
+                return;
+            }
+            pass = pass->GetParent();
+        }
+
         // Find the first view with the froxelLocalVolume draw list tag to use for slice computation.
         RPI::ViewPtr computeView;
         for (const auto& view : packet.m_views)
@@ -322,6 +332,7 @@ namespace AZ::Render
         {
             return false;
         }
+        SetVolumeNoiseTexture(handle, {});
         m_volumeStates.RemoveIndex(handle.GetIndex());
         handle.Reset();
         return true;
@@ -352,7 +363,7 @@ namespace AZ::Render
 #include <Atom/Feature/ParamMacros/EndParams.inl>
 
     void FogVolumeFeatureProcessor::SetVolumeNoiseTexture(
-        VolumeHandle handle, [[maybe_unused]] Data::Asset<AZ::RPI::StreamingImageAsset> val)
+        VolumeHandle handle, Data::Asset<AZ::RPI::StreamingImageAsset> val)
     {
         auto& state = m_volumeStates.GetData(handle.GetIndex());
         const auto& indirectionList = m_noiseImageAssetsId.GetIndirectionList();

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FogVolumeFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FogVolumeFeatureProcessor.cpp
@@ -829,10 +829,9 @@ namespace AZ::Render
             }
         }
 
-        m_noiseImageImages.resize(resourceList.size());
+        AZStd::vector<Data::Instance<RPI::StreamingImage>> images(resourceList.size(), nullptr);
         for (uint32_t i = 0; i < resourceList.size(); ++i)
         {
-            m_noiseImageImages[i] = nullptr;
             const AZ::Data::AssetId& assetId = resourceList[i];
             if (assetId.IsValid())
             {
@@ -840,11 +839,12 @@ namespace AZ::Render
                     assetId, AZ::Data::AssetLoadBehavior::PreLoad);
                 if (textureAsset.IsReady())
                 {
-                    m_noiseImageImages[i] = RPI::StreamingImage::FindOrCreate(textureAsset);
+                    images[i] = RPI::StreamingImage::FindOrCreate(textureAsset);
                     continue;
                 }
             }
-        }        
+        }
+        m_noiseImageImages = AZStd::move(images);
     }
 
     // -------------------------------------------------------------------------

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FogVolumeFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FogVolumeFeatureProcessor.cpp
@@ -1,0 +1,890 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <VolumetricFog/FogVolumeFeatureProcessor.h>
+#include <VolumetricFog/VolumetricFogUtils.h>
+#include <Atom/Feature/VolumetricFog/VolumetricFogFeatureProcessorInterface.h>
+
+#include <Atom/RHI/DrawItem.h>
+#include <Atom/RHI/DrawPacketBuilder.h>
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/RHISystemInterface.h>
+
+#include <Atom/RPI.Public/Buffer/BufferSystemInterface.h>
+#include <Atom/RPI.Public/Pass/PassFilter.h>
+#include <Atom/RPI.Public/Pass/PassSystemInterface.h>
+#include <Atom/RPI.Public/Pass/PassUtils.h>
+#include <Atom/RPI.Public/RenderPipeline.h>
+#include <Atom/RPI.Public/Scene.h>
+#include <Atom/RPI.Public/Shader/Shader.h>
+#include <Atom/RPI.Public/View.h>
+#include <Atom/RPI.Reflect/Asset/AssetUtils.h>
+#include <Atom/RPI.Reflect/Model/ModelAsset.h>
+#include <Atom/RPI.Reflect/Model/ModelLodAsset.h>
+#include <Atom/RPI.Public/RPIUtils.h>
+
+#include <AzCore/Math/Frustum.h>
+#include <AzCore/Math/Aabb.h>
+#include <AzCore/Math/Obb.h>
+#include <AzCore/Math/ShapeIntersection.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Jobs/JobCompletion.h>
+#include <AzCore/Jobs/JobFunction.h>
+
+namespace AZ::Render
+{
+    namespace
+    {
+        constexpr float CUBE_VERTICES[8 * 3] = {
+            -1, -1, -1,   +1, -1, -1,   +1, +1, -1,   -1, +1, -1,
+            -1, -1, +1,   +1, -1, +1,   +1, +1, +1,   -1, +1, +1,
+        };
+        constexpr uint32_t CUBE_INDICES[36] = {
+            0, 2, 1,  0, 3, 2,   4, 5, 6,  4, 6, 7,
+            0, 1, 5,  0, 5, 4,   2, 3, 7,  2, 7, 6,
+            0, 4, 7,  0, 7, 3,   1, 2, 6,  1, 6, 5,
+        };
+
+        struct SliceRange { uint32_t min; uint32_t max; };
+
+        SliceRange ComputeSliceRange(const AZ::Aabb& worldAabb,
+                                     const AZ::Transform& viewMatrix,
+                                     float fogNear, float fogFar, uint32_t sliceCount)
+        {
+            const AZ::Vector3 mn = worldAabb.GetMin();
+            const AZ::Vector3 mx = worldAabb.GetMax();
+            const AZ::Vector3 corners[8] = {
+                {mn.GetX(), mn.GetY(), mn.GetZ()}, {mx.GetX(), mn.GetY(), mn.GetZ()},
+                {mn.GetX(), mx.GetY(), mn.GetZ()}, {mx.GetX(), mx.GetY(), mn.GetZ()},
+                {mn.GetX(), mn.GetY(), mx.GetZ()}, {mx.GetX(), mn.GetY(), mx.GetZ()},
+                {mn.GetX(), mx.GetY(), mx.GetZ()}, {mx.GetX(), mx.GetY(), mx.GetZ()},
+            };
+
+            const AZ::Vector3 cameraPos     = viewMatrix.GetTranslation();
+            const AZ::Vector3 cameraForward = viewMatrix.GetBasisY(); // Y is forward in O3DE (Z-up)
+
+            float minVZ = std::numeric_limits<float>::max();
+            float maxVZ = std::numeric_limits<float>::lowest();
+            for (const auto& c : corners)
+            {
+                const float vz = (c - cameraPos).Dot(cameraForward);
+                minVZ = AZ::GetMin(minVZ, vz);
+                maxVZ = AZ::GetMax(maxVZ, vz);
+            }
+
+            minVZ = AZ::GetMax(minVZ, fogNear);
+            maxVZ = AZ::GetMin(maxVZ, fogFar);
+            if (minVZ >= maxVZ)
+            {
+                return { 0, 0 };
+            }
+
+            const float logRange = std::log(fogFar / fogNear);
+            auto viewZToSlice = [&](float vz) {
+                return sliceCount * std::log(AZ::GetMax(vz, fogNear) / fogNear) / logRange;
+            };
+
+            const uint32_t sliceMin = AZ::GetClamp(
+                static_cast<int32_t>(std::floor(viewZToSlice(minVZ))),
+                0, static_cast<int32_t>(sliceCount) - 1);
+            const uint32_t sliceMax = AZ::GetClamp(
+                static_cast<int32_t>(std::ceil(viewZToSlice(maxVZ))),
+                0, static_cast<int32_t>(sliceCount) - 1);
+            return { sliceMin, sliceMax };
+        }
+
+        RHI::TargetBlendState GetBlendState(FogVolumeBlendMode mode)
+        {
+            RHI::TargetBlendState blend;
+            blend.m_enable = true;
+
+            switch (mode)
+            {
+            case FogVolumeBlendMode::Additive:
+                blend.m_blendOp         = RHI::BlendOp::Add;
+                blend.m_blendSource     = RHI::BlendFactor::One;
+                blend.m_blendDest       = RHI::BlendFactor::One;
+                blend.m_blendAlphaOp    = RHI::BlendOp::Add;
+                blend.m_blendAlphaSource = RHI::BlendFactor::One;
+                blend.m_blendAlphaDest  = RHI::BlendFactor::One;
+                break;
+            case FogVolumeBlendMode::Multiply:
+                blend.m_blendOp         = RHI::BlendOp::Add;
+                blend.m_blendSource     = RHI::BlendFactor::ColorDest;
+                blend.m_blendDest       = RHI::BlendFactor::Zero;
+                blend.m_blendAlphaOp    = RHI::BlendOp::Add;
+                blend.m_blendAlphaSource = RHI::BlendFactor::AlphaDest;
+                blend.m_blendAlphaDest  = RHI::BlendFactor::Zero;
+                break;
+            case FogVolumeBlendMode::Overwrite:
+                blend.m_blendOp         = RHI::BlendOp::Add;
+                blend.m_blendSource     = RHI::BlendFactor::One;
+                blend.m_blendDest       = RHI::BlendFactor::Zero;
+                blend.m_blendAlphaOp    = RHI::BlendOp::Add;
+                blend.m_blendAlphaSource = RHI::BlendFactor::One;
+                blend.m_blendAlphaDest  = RHI::BlendFactor::Zero;
+                break;
+            case FogVolumeBlendMode::Min:
+                blend.m_blendOp         = RHI::BlendOp::Minimum;
+                blend.m_blendSource     = RHI::BlendFactor::One;
+                blend.m_blendDest       = RHI::BlendFactor::One;
+                blend.m_blendAlphaOp    = RHI::BlendOp::Minimum;
+                blend.m_blendAlphaSource = RHI::BlendFactor::One;
+                blend.m_blendAlphaDest  = RHI::BlendFactor::One;
+                break;
+            case FogVolumeBlendMode::Max:
+                blend.m_blendOp         = RHI::BlendOp::Maximum;
+                blend.m_blendSource     = RHI::BlendFactor::One;
+                blend.m_blendDest       = RHI::BlendFactor::One;
+                blend.m_blendAlphaOp    = RHI::BlendOp::Maximum;
+                blend.m_blendAlphaSource = RHI::BlendFactor::One;
+                blend.m_blendAlphaDest  = RHI::BlendFactor::One;
+                break;
+            default:
+                AZ_Assert(false, "Unknown FogVolumeBlendMode");
+                break;
+            }
+            return blend;
+        }
+    } // anonymous namespace
+
+    void FogVolumeFeatureProcessor::Reflect(ReflectContext* context)
+    {
+        if (auto* sc = azrtti_cast<SerializeContext*>(context))
+        {
+            sc->Class<FogVolumeFeatureProcessor, FeatureProcessor>()
+                ->Version(0);
+        }
+    }
+
+    void FogVolumeFeatureProcessor::Activate()
+    {
+        auto* rhiSystem = RHI::RHISystemInterface::Get();
+        m_drawListTag = rhiSystem->GetDrawListTagRegistry()->AcquireTag(AZ::Name("froxelLocalVolume"));
+
+        // Build the proxy mesh GPU buffers once at activation; SRG bindings happen
+        // in OnRenderPipelineChanged() after we locate the RasterPass.
+        BuildProxyMeshBuffers();
+
+        EnableSceneNotification();
+    }
+
+    void FogVolumeFeatureProcessor::Deactivate()
+    {
+        DisableSceneNotification();
+        Data::AssetBus::MultiHandler::BusDisconnect();
+
+        m_noiseImageImages.clear();
+        m_noiseImageAssetsId.Reset();
+        m_rasterPass = nullptr;
+        m_drawPackets.clear();
+        m_pipelineStates.fill(nullptr);
+        m_shader = nullptr;
+        m_vertexBuffers.fill(nullptr);
+        m_indexBuffers.fill(nullptr);
+        m_volumeBuffer = nullptr;
+        m_instanceMappingBuffer = nullptr;
+        m_volumeBufferCapacity = 0;
+        m_instanceMappingCapacity = 0;
+    }
+
+    void FogVolumeFeatureProcessor::Simulate([[maybe_unused]] const SimulatePacket& packet)
+    {
+    }
+
+    void FogVolumeFeatureProcessor::Render(const RenderPacket& packet)
+    {
+        if (m_volumeStates.GetDataCount() == 0 || !m_rasterPass || !m_shader)
+        {
+            return;
+        }
+
+        // Find the first view with the froxelLocalVolume draw list tag to use for slice computation.
+        RPI::ViewPtr computeView;
+        for (const auto& view : packet.m_views)
+        {
+            if (view->HasDrawListTag(m_drawListTag))
+            {
+                computeView = view;
+                break;
+            }
+        }
+        if (!computeView)
+        {
+            return;
+        }
+
+        // Get global fog settings needed for froxel slice computation.
+        auto* vfFP = GetParentScene()->GetFeatureProcessor<VolumetricFogFeatureProcessorInterface>();
+        if (!vfFP)
+        {
+            return;
+        }
+        const float fogNear    = vfFP->GetFogStartDistance();
+        const float fogFar     = vfFP->GetFogEndDistance();
+        const uint32_t sliceCount = VolumetricFog::ToFroxelSize(vfFP->GetFogQuality()).m_depth;
+
+        // Build this frame's packed GPU data from the current CPU state.
+        ComputeSliceRanges(computeView, fogNear, fogFar, sliceCount);
+
+        // Sort volumes and partition into batches, then build instance-mapping.
+        SortAndPartitionVolumes();
+        BuildInstanceMappingBuffer();
+        BuildNoiseTextureArray();
+        UploadVolumeBuffer();
+
+        // Push all buffers into the pass SRG. The pass compiles the SRG itself in
+        // CompileResources(), so we must not call Compile() here.
+        RPI::ShaderResourceGroup* passSrg = m_rasterPass->GetShaderResourceGroup();
+        passSrg->SetBufferArray(m_verticesBufferIndex, m_vertexBuffers);
+        passSrg->SetBufferArray(m_indicesBufferIndex, m_indexBuffers);
+        passSrg->SetBuffer(m_volumesBufferIndex,        m_volumeBuffer);
+        passSrg->SetBuffer(m_instanceMappingBufferIndex, m_instanceMappingBuffer);
+
+        AZStd::vector<const RHI::ImageView*> rhiImages;
+        rhiImages.reserve(m_noiseImageImages.size());
+        AZStd::transform(
+            m_noiseImageImages.begin(),
+            m_noiseImageImages.end(),
+            AZStd::back_inserter(rhiImages),
+            [](const Data::Instance<RPI::StreamingImage>& rpiImage)
+            {
+                return rpiImage->GetImageView();
+            });
+        passSrg->SetImageViewUnboundedArray(m_noiseTextureArrayIndex, rhiImages);
+
+        // Build one draw packet per non-empty batch. The pass SRG is bound at the
+        // pass level by the pass infrastructure, so draw packets carry no SRG.
+        m_drawPackets.clear();
+        for (const auto& batch : m_batches)
+        {
+            if (batch.m_instanceCount == 0)
+            {
+                continue;
+            }
+
+            RHI::DrawLinear drawArgs;
+            drawArgs.m_vertexCount = m_indexBuffers[static_cast<uint32_t>(batch.m_shape)]->GetBufferViewDescriptor().m_elementCount;
+            drawArgs.m_instanceCount  = batch.m_instanceCount;
+            drawArgs.m_vertexOffset   = 0;
+            drawArgs.m_instanceOffset = batch.m_instanceStart;
+
+            RHI::DrawPacketBuilder builder;
+            builder.Begin(nullptr);
+            builder.SetDrawArguments(RHI::DrawArguments(drawArgs));
+
+            RHI::DrawPacketBuilder::DrawRequest request;
+            request.m_listTag       = m_drawListTag;
+            request.m_pipelineState = m_pipelineStates[static_cast<size_t>(batch.m_mode)]->GetRHIPipelineState();
+            builder.AddDrawItem(request);
+
+            m_drawPackets.push_back(builder.End());
+        }
+
+        if (m_drawPackets.empty())
+        {
+            return;
+        }
+
+        // Submit draw packets to every view that participates in the froxelLocalVolume draw list.
+        for (const auto& view : packet.m_views)
+        {
+            if (!view->HasDrawListTag(m_drawListTag))
+            {
+                continue;
+            }
+            for (const auto& pkt : m_drawPackets)
+            {
+                view->AddDrawPacket(pkt.get(), 0.0f);
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Volume registration
+    // -------------------------------------------------------------------------
+
+    FogVolumeFeatureProcessor::VolumeHandle FogVolumeFeatureProcessor::AcquireVolume()
+    {
+        const uint16_t rawIndex = m_volumeStates.GetFreeSlotIndex();
+        m_volumeStates.GetData(rawIndex) = VolumeState{};
+        return VolumeHandle(rawIndex);
+    }
+
+    bool FogVolumeFeatureProcessor::ReleaseVolume(VolumeHandle& handle)
+    {
+        if (!handle.IsValid())
+        {
+            return false;
+        }
+        m_volumeStates.RemoveIndex(handle.GetIndex());
+        handle.Reset();
+        return true;
+    }
+
+    void FogVolumeFeatureProcessor::SetVolumeTransform(VolumeHandle handle, const AZ::Transform& transform)
+    {
+        m_volumeStates.GetData(handle.GetIndex()).m_transform = transform;
+    }
+
+    void FogVolumeFeatureProcessor::SetVolumeExtents(VolumeHandle handle, const AZ::Vector3& halfExtents)
+    {
+        m_volumeStates.GetData(handle.GetIndex()).m_halfExtents = halfExtents;
+    }
+
+#define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)           \
+    void FogVolumeFeatureProcessor::SetVolume##Name(VolumeHandle handle, ValueType val) \
+    {                                                                            \
+        m_volumeStates.GetData(handle.GetIndex()).MemberName = val;              \
+    }
+
+#include <Atom/Feature/ParamMacros/MapParamCommon.inl>
+
+#undef AZ_GFX_TEXTURE_ASSET_PARAM
+#define AZ_GFX_TEXTURE_ASSET_PARAM(Name, MemberName, DefaultValue)
+
+#include <Atom/Feature/VolumetricFog/FogVolumeParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+
+    void FogVolumeFeatureProcessor::SetVolumeNoiseTexture(
+        VolumeHandle handle, [[maybe_unused]] Data::Asset<AZ::RPI::StreamingImageAsset> val)
+    {
+        auto& state = m_volumeStates.GetData(handle.GetIndex());
+        const auto& indirectionList = m_noiseImageAssetsId.GetIndirectionList();
+        if (state.m_noiseTextureIndex >= 0 && state.m_noiseTextureIndex < static_cast<int>(indirectionList.size()))
+        {
+            uint32_t resourceIndex = indirectionList[state.m_noiseTextureIndex];
+            const auto& assetId = m_noiseImageAssetsId.GetResourceList()[resourceIndex];
+            if (assetId == val.GetId())
+            {
+                return;
+            }
+
+            m_noiseImageAssetsId.RemoveResource(assetId);
+        }
+
+        int index = -1;
+        if (val.GetId().IsValid())
+        {
+            index = static_cast<int>(m_noiseImageAssetsId.AddResource(val.GetId()));
+            if (!val.IsReady() && !val.IsLoading())
+            {
+                val.QueueLoad();
+            }
+
+        }
+        state.m_noiseTextureIndex = index;
+
+    }
+
+    // -------------------------------------------------------------------------
+    // Pipeline change notification
+    // -------------------------------------------------------------------------
+
+    void FogVolumeFeatureProcessor::OnRenderPipelineChanged(
+        RPI::RenderPipeline* pipeline,
+        RPI::SceneNotification::RenderPipelineChangeType changeType)
+    {
+        if (changeType == RPI::SceneNotification::RenderPipelineChangeType::Added ||
+            changeType == RPI::SceneNotification::RenderPipelineChangeType::PassChanged)
+        {
+            auto passFilter = RPI::PassFilter::CreateWithTemplateName(
+                AZ::Name("FroxelLocalVolumeTemplate"), pipeline);
+            if (auto* foundPass = RPI::PassSystemInterface::Get()->FindFirstPass(passFilter); foundPass)
+            {
+                m_rasterPass = static_cast<RPI::RasterPass*>(foundPass);
+                m_noiseTextureArrayIndex =
+                    m_rasterPass->GetShaderResourceGroup()->FindShaderInputImageUnboundedArrayIndex(Name("m_noiseTextures"));
+
+            }
+            else
+            {
+                m_rasterPass = nullptr;
+            }
+
+            if (m_rasterPass && LoadShader())
+            {
+                BuildPipelines();
+            }
+        }
+        else if (changeType == RPI::SceneNotification::RenderPipelineChangeType::Removed)
+        {
+            m_rasterPass = nullptr;
+            m_shader = nullptr;
+            m_pipelineStates.fill(nullptr);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Shader reload
+    // -------------------------------------------------------------------------
+
+    void FogVolumeFeatureProcessor::OnAssetReloaded([[maybe_unused]] AZ::Data::Asset<AZ::Data::AssetData> asset)
+    {
+        Data::AssetBus::MultiHandler::BusDisconnect();
+        if (LoadShader())
+        {
+            BuildPipelines();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Initialisation helpers
+    // -------------------------------------------------------------------------
+
+    bool FogVolumeFeatureProcessor::LoadShader()
+    {
+        m_shader = RPI::LoadCriticalShader("Shaders/VolumetricFog/FroxelLocalVolume.azshader");
+        if (!m_shader)
+        {
+            AZ_Error("FogVolumeFeatureProcessor", false, "Failed to create Shader instance.");
+            return false;
+        }
+
+        Data::AssetBus::MultiHandler::BusConnect(m_shader->GetAssetId());
+        return true;
+    }
+
+    void FogVolumeFeatureProcessor::BuildProxyMeshBuffers()
+    {
+        BuildCubeProxy();
+        BuildSphereProxy();
+    }
+
+    void FogVolumeFeatureProcessor::BuildCubeProxy()
+    {
+        auto* bufferSystem = RPI::BufferSystemInterface::Get();
+        constexpr uint32_t boxIndex = static_cast<uint32_t>(FogVolumeShape::Box);
+        RPI::CommonBufferDescriptor desc;
+        desc.m_poolType   = RPI::CommonBufferPoolType::ReadOnly;
+        desc.m_bufferName = "FogVolumeCubeVerts";
+        desc.m_byteCount  = sizeof(CUBE_VERTICES);
+        desc.m_elementSize = sizeof(float) * 3;
+        desc.m_bufferData = CUBE_VERTICES;
+        desc.m_elementFormat = RHI::Format::R32G32B32_FLOAT;
+        m_vertexBuffers[boxIndex] = bufferSystem->CreateBufferFromCommonPool(desc);
+
+        desc.m_bufferName = "FogVolumeCubeIndices";
+        desc.m_byteCount  = sizeof(CUBE_INDICES);
+        desc.m_elementSize = sizeof(uint32_t);
+        desc.m_bufferData = CUBE_INDICES;
+        desc.m_elementFormat = RHI::Format::R32_UINT;
+        m_indexBuffers[boxIndex] = bufferSystem->CreateBufferFromCommonPool(desc);
+    }
+
+    void FogVolumeFeatureProcessor::BuildSphereProxy()
+    {
+        uint32_t numRings = 25;
+        uint32_t numSections = 25;
+
+        const float radius = 1.0f;
+
+        // calculate "inner" vertices
+        float sectionAngle(DegToRad(360.0f / static_cast<float>(numSections)));
+        float ringSlice(DegToRad(180.0f / static_cast<float>(numRings)));
+
+        uint32_t numberOfPoles = 2;
+        // calc required number of vertices/indices/triangles to build a sphere for the given parameters
+        uint32_t numVertices = (numRings - 1) * numSections + numberOfPoles;
+
+        using PosType = AZStd::array<float, 3>;
+        // setup buffers
+        AZStd::vector<PosType> positions;
+        positions.clear();
+        positions.reserve(numVertices);
+
+        // 1st pole vertex (top, along +Z — up axis in O3DE)
+        positions.push_back(PosType{ 0.0f, 0.0f, radius });
+
+        for (uint32_t ring = 1; ring < numRings - numberOfPoles + 2; ++ring)
+        {
+            float w(sinf(ring * ringSlice));
+            for (uint32_t section = 0; section < numSections; ++section)
+            {
+                float x = radius * cosf(section * sectionAngle) * w;
+                float y = radius * sinf(section * sectionAngle) * w;
+                float z = radius * cosf(ring * ringSlice);
+                PosType radialVector{ x, y, z };
+                positions.push_back(radialVector);
+            }
+        }
+
+        // 2nd vertex of pole (bottom, along -Z)
+        positions.push_back(PosType{ 0.0f, 0.0f, -radius });     
+
+        // NumTriangles = NumTrianglesAtPoles + NumQuads * 2
+        //              = (numSections * 2) + ((numRings - 2) * numSections * 2)
+        //              = (numSections * 2) * (numRings - 2 + 1)
+        const uint32_t numTriangles = (numRings - 1) * numSections * 2;
+        const uint32_t numTriangleIndices = numTriangles * 3;
+
+        // build "inner" faces
+        AZStd::vector<uint32_t> indices;
+        indices.clear();
+        indices.reserve(numTriangleIndices);
+
+        for (uint32_t ring = 0; ring < numRings - numberOfPoles; ++ring)
+        {
+            uint32_t firstVertOfThisRing = 1 + ring * numSections;
+            uint32_t firstVertOfNextRing = firstVertOfThisRing + numSections;
+
+            for (uint32_t section = 0; section < numSections; ++section)
+            {
+                uint32_t nextSection = (section + 1) % numSections;
+                indices.push_back(static_cast<uint16_t>(firstVertOfThisRing + section));
+                indices.push_back(static_cast<uint16_t>(firstVertOfThisRing + nextSection));
+                indices.push_back(static_cast<uint16_t>(firstVertOfNextRing + nextSection));
+
+                indices.push_back(static_cast<uint16_t>(firstVertOfNextRing + nextSection));
+                indices.push_back(static_cast<uint16_t>(firstVertOfNextRing + section));
+                indices.push_back(static_cast<uint16_t>(firstVertOfThisRing + section));
+            }
+        }
+
+        // build faces for end caps (to connect "inner" vertices with poles)
+        uint32_t firstPoleVert = 0;
+        uint32_t firstVertOfFirstRing = 1 + (0) * numSections;
+        for (uint32_t section = 0; section < numSections; ++section)
+        {
+            uint32_t nextSection = (section + 1) % numSections;
+            indices.push_back(static_cast<uint16_t>(firstVertOfFirstRing + nextSection));
+            indices.push_back(static_cast<uint16_t>(firstVertOfFirstRing + section));
+            indices.push_back(static_cast<uint16_t>(firstPoleVert));
+        }
+
+        uint32_t lastPoleVert = (numRings - 1) * numSections + 1;
+        uint32_t firstVertOfLastRing = 1 + (numRings - 2) * numSections;
+        for (uint32_t section = 0; section < numSections; ++section)
+        {
+            uint32_t nextSection = (section + 1) % numSections;
+            indices.push_back(static_cast<uint16_t>(firstVertOfLastRing + section));
+            indices.push_back(static_cast<uint16_t>(firstVertOfLastRing + nextSection));
+            indices.push_back(static_cast<uint16_t>(lastPoleVert));
+        }
+
+        auto* bufferSystem = RPI::BufferSystemInterface::Get();
+        constexpr uint32_t sphereIndex = static_cast<uint32_t>(FogVolumeShape::Sphere);
+        RPI::CommonBufferDescriptor desc;
+        desc.m_poolType = RPI::CommonBufferPoolType::ReadOnly;
+        desc.m_bufferName = "FogVolumeSphereVerts";
+        desc.m_elementSize = sizeof(PosType);
+        desc.m_byteCount = positions.size() * desc.m_elementSize;
+        desc.m_bufferData = positions.data();
+        desc.m_elementFormat = RHI::Format::R32G32B32_FLOAT;
+        m_vertexBuffers[sphereIndex] = bufferSystem->CreateBufferFromCommonPool(desc);
+
+        desc.m_bufferName = "FogVolumeSphereIndices";
+        desc.m_elementSize = sizeof(uint32_t);
+        desc.m_byteCount = indices.size() * desc.m_elementSize;
+        desc.m_bufferData = indices.data();
+        desc.m_elementFormat = RHI::Format::R32_UINT;
+        m_indexBuffers[sphereIndex] = bufferSystem->CreateBufferFromCommonPool(desc);
+    }
+
+    void FogVolumeFeatureProcessor::BuildPipelines()
+    {
+        if (!m_shader || !m_rasterPass)
+        {
+            return;
+        }
+
+        RHI::InputStreamLayout inputStreamLayout;
+        inputStreamLayout.SetTopology(RHI::PrimitiveTopology::TriangleList);
+        inputStreamLayout.Finalize();
+
+        for (uint32_t i = 0; i < FogVolumeBlendModeCount; ++i)
+        {
+            auto* pipeline = aznew RPI::PipelineStateForDraw;
+            pipeline->Init(m_shader, m_shader->GetDefaultShaderOptions().GetShaderVariantId());
+            pipeline->SetOutputFromPass(m_rasterPass);
+            // RT0 (FroxelMedium) and RT1 (FroxelEmissive) share the same blend mode so that
+            // an Overwrite volume replaces the global emissive, a Multiply volume scales it, etc.
+            RHI::TargetBlendState blendState = GetBlendState(static_cast<FogVolumeBlendMode>(i));
+            pipeline->RenderStatesOverlay().m_blendState.m_targets[0] = blendState;
+            pipeline->RenderStatesOverlay().m_blendState.m_targets[1] = blendState;
+
+            pipeline->InputStreamLayout() = inputStreamLayout;
+            pipeline->Finalize();
+            m_pipelineStates[i].reset(pipeline);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Per-frame data preparation
+    // -------------------------------------------------------------------------
+
+    void FogVolumeFeatureProcessor::ComputeSliceRanges(
+        const RPI::ViewPtr& view, float fogNear, float fogFar, uint32_t sliceCount)
+    {
+        const auto& stateVec = m_volumeStates.GetDataVector();
+        const uint32_t volumeCount = static_cast<uint32_t>(stateVec.size());
+        if (volumeCount == 0)
+        {
+            m_currentFrameVolumes.clear();
+            return;
+        }
+
+        // Split volumes into at most 8 batches so each job handles a contiguous index range.
+        const uint32_t numBatches = AZ::GetMax(1u, AZ::GetMin(volumeCount, 8u));
+        const uint32_t batchSize = (volumeCount + numBatches - 1) / numBatches;
+
+        m_currentFrameVolumes.resize(stateVec.size());
+        AZ::JobCompletion jobCompletion;
+
+        for (uint32_t batchStart = 0; batchStart < volumeCount; batchStart += batchSize)
+        {
+            const uint32_t batchEnd = AZ::GetMin(batchStart + batchSize, volumeCount);
+
+            const auto jobLambda = [this, batchStart, batchEnd, view, fogNear, fogFar, sliceCount, &stateVec]() -> void
+            {
+                for (uint32_t i = batchStart; i < batchEnd; ++i)
+                {
+                    auto& state = stateVec[i];
+                    FogVolumeFeatureProcessor::LocalVolumeData& volumeData = m_currentFrameVolumes[i];
+                    volumeData = FogVolumeFeatureProcessor::LocalVolumeData();
+                    if (state.m_shape != FogVolumeShape::Unknown)
+                    {
+                        AZ::Aabb localAabb = AZ::Aabb::CreateFromMinMax(-state.m_halfExtents, state.m_halfExtents);
+                        AZ::Obb worldObb = localAabb.GetTransformedObb(state.m_transform);
+
+                        const AZ::Frustum viewFrustum = AZ::Frustum::CreateFromMatrixColumnMajor(view->GetWorldToClipMatrix());
+                        if (AZ::ShapeIntersection::Overlaps(viewFrustum, worldObb))
+                        {
+                            volumeData = BuildVolumeGpuData(state);
+                            AZ::Vector3 absRight =
+                                AZ::Vector3(
+                                    std::abs(volumeData.m_right[0]),
+                                    std::abs(volumeData.m_right[1]),
+                                    std::abs(volumeData.m_right[2])) *
+                                volumeData.m_extentX;
+
+                            AZ::Vector3 absUp =
+                                AZ::Vector3(
+                                    std::abs(volumeData.m_up[0]),
+                                    std::abs(volumeData.m_up[1]),
+                                    std::abs(volumeData.m_up[2])) *
+                                volumeData.m_extentY;
+
+                            AZ::Vector3 absForward =
+                                AZ::Vector3(
+                                    std::abs(volumeData.m_forward[0]),
+                                    std::abs(volumeData.m_forward[1]),
+                                    std::abs(volumeData.m_forward[2])) *
+                                volumeData.m_extentZ;
+
+                            AZ::Vector3 halfExtents = absRight + absUp + absForward;
+                            AZ::Vector3 center = AZ::Vector3::CreateFromFloat3(volumeData.m_center.data());
+                            AZ::Aabb worldAabb = AZ::Aabb::CreateFromMinMax(center - halfExtents, center + halfExtents);
+
+                            const auto range = ComputeSliceRange(worldAabb, view->GetCameraTransform(), fogNear, fogFar, sliceCount);
+                            volumeData.m_sliceMin = range.min;
+                            volumeData.m_sliceMax = range.max;
+                        }
+                    }
+                }
+            };
+
+            AZ::Job* job = aznew AZ::JobFunction<decltype(jobLambda)>(jobLambda, true, nullptr); // auto-deletes
+            job->SetDependent(&jobCompletion);
+            job->Start();
+        }
+
+        jobCompletion.StartAndWaitForCompletion();
+    }
+
+    void FogVolumeFeatureProcessor::SortAndPartitionVolumes()
+    {
+        AZStd::sort(m_currentFrameVolumes.begin(), m_currentFrameVolumes.end(),
+            [](const LocalVolumeData& a, const LocalVolumeData& b)
+            {
+                if (a.m_blendMode != b.m_blendMode) return a.m_blendMode < b.m_blendMode;
+                if (a.m_shape     != b.m_shape)     return a.m_shape     < b.m_shape;
+                return a.m_priority < b.m_priority;
+            });
+
+        m_batches.clear();
+        if (m_currentFrameVolumes.empty())
+        {
+            return;
+        }
+
+        Batch current{};
+        current.m_mode  = static_cast<FogVolumeBlendMode>(m_currentFrameVolumes[0].m_blendMode);
+        current.m_shape = static_cast<FogVolumeShape>(m_currentFrameVolumes[0].m_shape);
+        current.m_volumeStart = 0;
+
+        for (uint32_t i = 1; i < static_cast<uint32_t>(m_currentFrameVolumes.size()); ++i)
+        {
+            const auto mode  = static_cast<FogVolumeBlendMode>(m_currentFrameVolumes[i].m_blendMode);
+            const auto shape = static_cast<FogVolumeShape>(m_currentFrameVolumes[i].m_shape);
+            if (mode != current.m_mode || shape != current.m_shape)
+            {
+                current.m_volumeCount = i - current.m_volumeStart;
+                m_batches.push_back(current);
+                current = {};
+                current.m_mode  = mode;
+                current.m_shape = shape;
+                current.m_volumeStart = i;
+            }
+        }
+
+        current.m_volumeCount = static_cast<uint32_t>(m_currentFrameVolumes.size()) - current.m_volumeStart;
+        m_batches.push_back(current);
+    }
+
+    void FogVolumeFeatureProcessor::BuildInstanceMappingBuffer()
+    {
+        m_instanceMapping.clear();
+        for (auto& batch : m_batches)
+        {
+            batch.m_instanceStart = static_cast<uint32_t>(m_instanceMapping.size());
+            for (uint32_t index = 0; index < batch.m_volumeCount; ++index)
+            {
+                const uint32_t globalIndex = batch.m_volumeStart + index;
+                const auto& volume = m_currentFrameVolumes[globalIndex];
+                if (volume.m_shape == static_cast<uint32_t>(FogVolumeShape::Unknown) ||
+                    volume.m_sliceMax < volume.m_sliceMin)
+                {
+                    continue;
+                }
+
+                for (uint32_t slice = volume.m_sliceMin; slice <= volume.m_sliceMax; ++slice)
+                {
+                    m_instanceMapping.emplace_back(globalIndex, slice);
+                }
+            }
+            batch.m_instanceCount = static_cast<uint32_t>(m_instanceMapping.size()) - batch.m_instanceStart;
+        }
+
+        if (m_instanceMappingCapacity < m_instanceMapping.size())
+        {
+            m_instanceMappingCapacity = RHI::AlignUp(static_cast<uint32_t>(m_instanceMapping.size()), 256u);
+            RPI::CommonBufferDescriptor desc;
+            desc.m_poolType    = RPI::CommonBufferPoolType::ReadOnly;
+            desc.m_bufferName  = "FogVolumeInstanceMapping";
+            desc.m_byteCount   = m_instanceMappingCapacity * sizeof(uint32_t) * 2;
+            desc.m_elementSize = sizeof(uint32_t) * 2;
+            desc.m_elementFormat = RHI::Format::R32G32_UINT;
+            m_instanceMappingBuffer = RPI::BufferSystemInterface::Get()->CreateBufferFromCommonPool(desc);
+        }
+        if (!m_instanceMapping.empty())
+        {
+            m_instanceMappingBuffer->UpdateData(
+                m_instanceMapping.data(),
+                m_instanceMapping.size() * sizeof(uint32_t) * 2,
+                0);
+        }
+    }
+
+    void FogVolumeFeatureProcessor::UploadVolumeBuffer()
+    {
+        if (m_volumeBufferCapacity < m_currentFrameVolumes.size())
+        {
+            m_volumeBufferCapacity = RHI::AlignUp(static_cast<uint32_t>(m_currentFrameVolumes.size()), 32u);
+            RPI::CommonBufferDescriptor desc;
+            desc.m_poolType    = RPI::CommonBufferPoolType::ReadOnly;
+            desc.m_bufferName  = "FogVolumeData";
+            desc.m_byteCount   = m_volumeBufferCapacity * sizeof(LocalVolumeData);
+            desc.m_elementSize = sizeof(LocalVolumeData);
+            m_volumeBuffer = RPI::BufferSystemInterface::Get()->CreateBufferFromCommonPool(desc);
+        }
+        if (!m_currentFrameVolumes.empty())
+        {
+            m_volumeBuffer->UpdateData(
+                m_currentFrameVolumes.data(),
+                m_currentFrameVolumes.size() * sizeof(LocalVolumeData),
+                0);
+        }
+    }
+
+    void FogVolumeFeatureProcessor::BuildNoiseTextureArray()
+    {
+        const auto& resourceList = m_noiseImageAssetsId.GetResourceList();
+        const auto& indirectionLis = m_noiseImageAssetsId.GetIndirectionList();
+        for (auto& volume : m_currentFrameVolumes)
+        {
+            if (volume.m_noiseTextureIndex >= 0 && volume.m_noiseTextureIndex < indirectionLis.size())
+            {
+                volume.m_noiseTextureIndex = indirectionLis[volume.m_noiseTextureIndex];
+            }
+            else
+            {
+                volume.m_noiseTextureIndex = -1;
+            }
+        }
+
+        m_noiseImageImages.resize(resourceList.size());
+        for (uint32_t i = 0; i < resourceList.size(); ++i)
+        {
+            m_noiseImageImages[i] = nullptr;
+            const AZ::Data::AssetId& assetId = resourceList[i];
+            if (assetId.IsValid())
+            {
+                auto textureAsset = AZ::Data::AssetManager::Instance().GetAsset<AZ::RPI::StreamingImageAsset>(
+                    assetId, AZ::Data::AssetLoadBehavior::PreLoad);
+                if (textureAsset.IsReady())
+                {
+                    m_noiseImageImages[i] = RPI::StreamingImage::FindOrCreate(textureAsset);
+                    continue;
+                }
+            }
+        }        
+    }
+
+    // -------------------------------------------------------------------------
+    // GPU data construction
+    // -------------------------------------------------------------------------
+
+    float FogVolumeFeatureProcessor::EdgeFadeToRcp(float edgeFraction)
+    {
+        return (edgeFraction > 1e-5f) ? 1.0f / edgeFraction : 1e6f;
+    }
+
+    FogVolumeFeatureProcessor::LocalVolumeData FogVolumeFeatureProcessor::BuildVolumeGpuData(const VolumeState& state)
+    {
+        LocalVolumeData data{};
+
+        state.m_transform.GetTranslation().StoreToFloat3(data.m_center.data());
+        state.m_transform.GetBasisX().GetNormalized().StoreToFloat3(data.m_right.data());
+        state.m_transform.GetBasisZ().GetNormalized().StoreToFloat3(data.m_up.data());      // Z is up in O3DE
+        state.m_transform.GetBasisY().GetNormalized().StoreToFloat3(data.m_forward.data()); // Y is forward in O3DE
+
+        data.m_extentX = state.m_halfExtents.GetX();
+        data.m_extentY = state.m_halfExtents.GetZ(); // paired with m_up = BasisZ
+        data.m_extentZ = state.m_halfExtents.GetY(); // paired with m_forward = BasisY
+
+        data.m_shape = static_cast<uint32_t>(state.m_shape);
+        data.m_blendMode = static_cast<uint32_t>(state.m_blendMode);
+
+        const float rcpX = EdgeFadeToRcp(state.m_edgeFade.GetX());
+        const float rcpY = EdgeFadeToRcp(state.m_edgeFade.GetY());
+        const float rcpZ = EdgeFadeToRcp(state.m_edgeFade.GetZ());
+        AZ::Vector3(rcpX, rcpY, rcpZ).StoreToFloat3(data.m_rcpFadePos.data());
+        data.m_rcpFadeNeg = data.m_rcpFadePos;
+
+        data.m_priority          = state.m_priority;
+        data.m_noiseTextureIndex = state.m_noiseTextureIndex;
+
+        data.m_sliceMin = 0;
+        data.m_sliceMax = 0;
+        data.m_pad0     = 0;
+
+ #define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)          \
+        data.m_volumeData.MemberName = state.MemberName;                 \
+
+#include <Atom/Feature/ParamMacros/MapAllCommon.inl>
+#undef AZ_GFX_VEC3_PARAM
+#define AZ_GFX_VEC3_PARAM(Name, MemberName, DefaultValue)                                                          \
+        data.m_volumeData.MemberName = { state.MemberName.m_x, state.MemberName.m_y, state.MemberName.m_z };       \
+
+#include <Atom/Feature/VolumetricFog/VolumetricFogVolumeSRGConstants.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+
+        return data;
+    }
+} // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FogVolumeFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FogVolumeFeatureProcessor.cpp
@@ -146,7 +146,7 @@ namespace AZ::Render
                 blend.m_blendAlphaDest  = RHI::BlendFactor::One;
                 break;
             default:
-                AZ_Assert(false, "Unknown FogVolumeBlendMode");
+                AZ_Assert(false, "Unknown FogVolumeBlendMode %d", mode);
                 break;
             }
             return blend;
@@ -205,7 +205,7 @@ namespace AZ::Render
         }
 
         RPI::Pass* pass = m_rasterPass;
-        while (!pass)
+        while (pass)
         {
             if (!pass->IsEnabled())
             {
@@ -603,6 +603,7 @@ namespace AZ::Render
     {
         if (!m_shader || !m_rasterPass)
         {
+            AZ_Error("FogVolumeFeatureProcessor", false, "Failed to build pipelines because shade or raster pass is invalid.");
             return;
         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FogVolumeFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FogVolumeFeatureProcessor.h
@@ -33,6 +33,8 @@
 
 namespace AZ::Render
 {
+    //! Manages all local fog volumes; each frame it sorts, batches by (shape, blendMode),
+    //! builds GPU structured buffers, and drives the FroxelLocalVolume raster pass.
     class FogVolumeFeatureProcessor final
         : public FogVolumeFeatureProcessorInterface
         , protected AZ::Data::AssetBus::MultiHandler
@@ -66,7 +68,7 @@ namespace AZ::Render
 #include <Atom/Feature/ParamMacros/EndParams.inl>
 
     private:
-        // CPU-side state per registered volume
+        //! CPU-side state for one registered fog volume; mirrors FogVolumeComponentConfig fields.
         struct VolumeState
         {
             AZ::Transform  m_transform   = AZ::Transform::CreateIdentity();
@@ -85,18 +87,19 @@ namespace AZ::Render
 #include <Atom/Feature/ParamMacros/EndParams.inl>
         };
 
-        // A contiguous run of volumes sharing (blendMode, shape) after sorting
+        //! A contiguous run of volumes that share blend mode and shape,
+        //! submitted as one multi-draw-indirect call.
         struct Batch
         {
             FogVolumeBlendMode m_mode;
             FogVolumeShape     m_shape;
-            uint32_t           m_volumeStart;
-            uint32_t           m_volumeCount;
-            uint32_t           m_instanceStart;
-            uint32_t           m_instanceCount;
+            uint32_t           m_volumeStart;  // index range in m_currentFrameVolumes.
+            uint32_t           m_volumeCount;  // index range in m_currentFrameVolumes.
+            uint32_t           m_instanceStart; // first draw instance and total instances (volumes × slices).
+            uint32_t           m_instanceCount; // first draw instance and total instances (volumes × slices).
         };
 
-        // Must match LocalVolumeData in FroxelLocalVolumeCommon.azsli — verified by static_assert in .cpp.
+        // Must match LocalVolumeData in FroxelLocalVolumeCommon.azsli
         struct LocalVolumeData
         {
             AZStd::array<float, 3> m_center;
@@ -107,11 +110,11 @@ namespace AZ::Render
             float m_extentY;
             AZStd::array<float, 3> m_forward;
             float m_extentZ;
-            AZStd::array<float, 3> m_rcpFadePos;
+            AZStd::array<float, 3> m_rcpFadePos; // reciprocal of the per-axis fade extents, precomputed to avoid division in the shader.
             int32_t m_noiseTextureIndex;
-            AZStd::array<float, 3> m_rcpFadeNeg;
-            uint32_t m_sliceMin = 1;
-            uint32_t m_sliceMax = 0;
+            AZStd::array<float, 3> m_rcpFadeNeg; // reciprocal of the per-axis fade extents, precomputed to avoid division in the shader.
+            uint32_t m_sliceMin = 1; // froxel Z slice range this volume overlaps in the current frame; used to cull draw instances.
+            uint32_t m_sliceMax = 0; // froxel Z slice range this volume overlaps in the current frame; used to cull draw instances.
             uint32_t m_priority;
             uint32_t m_blendMode;
             uint32_t m_pad0;
@@ -132,13 +135,20 @@ namespace AZ::Render
         void BuildSphereProxy();
         void BuildPipelines();
 
+        //! For each registered volume, computes the first/last froxel Z slice it occupies in the current view to tighten draw ranges.
         void ComputeSliceRanges(const RPI::ViewPtr& view, float fogNear, float fogFar, uint32_t sliceCount);
+        //! Sorts volumes by (blendMode, shape) and builds the Batch list.
         void SortAndPartitionVolumes();
+        //! Writes a GPU buffer that maps each draw instance to the volume + slice range it covers.
         void BuildInstanceMappingBuffer();
+        //! Packs LocalVolumeData structs into the GPU structured buffer.
         void UploadVolumeBuffer();
+        //! Assembles the unbounded texture array of per-volume noise textures.
         void BuildNoiseTextureArray();
 
+        //! Converts a VolumeState (CPU) into a LocalVolumeData (GPU-layout) struct.
         LocalVolumeData BuildVolumeGpuData(const VolumeState& state);
+        //! Converts a [0,1] edge fade fraction to a reciprocal for fast HLSL lookup.
         static float EdgeFadeToRcp(float edgeFraction);
 
         IndexedDataVector<VolumeState>   m_volumeStates;
@@ -146,14 +156,14 @@ namespace AZ::Render
         AZStd::vector<Batch>             m_batches;
         AZStd::vector<AZStd::pair<uint32_t, uint32_t>> m_instanceMapping;
 
-        Data::Instance<RPI::Buffer> m_volumeBuffer;
-        uint32_t                    m_volumeBufferCapacity = 0;
+        Data::Instance<RPI::Buffer> m_volumeBuffer; // GPU structured buffer holding all LocalVolumeData this frame; capacity doubles on overflow.
+        uint32_t                    m_volumeBufferCapacity = 0; // GPU structured buffer holding all LocalVolumeData this frame; capacity doubles on overflow.
 
-        Data::Instance<RPI::Buffer> m_instanceMappingBuffer;
+        Data::Instance<RPI::Buffer> m_instanceMappingBuffer; // maps draw instance index to (volumeIndex, sliceIndex) for the VS.
         uint32_t                    m_instanceMappingCapacity = 0;
 
-        AZStd::array<Data::Instance<RPI::Buffer>, FogVolumeShapeCount - 1> m_vertexBuffers;
-        AZStd::array<Data::Instance<RPI::Buffer>, FogVolumeShapeCount - 1> m_indexBuffers;
+        AZStd::array<Data::Instance<RPI::Buffer>, FogVolumeShapeCount - 1> m_vertexBuffers; // one VB/IB pair per shape (Box, Sphere); indexed by FogVolumeShape.
+        AZStd::array<Data::Instance<RPI::Buffer>, FogVolumeShapeCount - 1> m_indexBuffers;  // one VB/IB pair per shape (Box, Sphere); indexed by FogVolumeShape.
 
         RPI::RasterPass*             m_rasterPass = nullptr;
         Data::Instance<RPI::Shader>  m_shader;
@@ -170,8 +180,8 @@ namespace AZ::Render
 
         RHI::DrawListTag m_drawListTag;
 
-        RayTracingResourceList<AZ::Data::AssetId> m_noiseImageAssetsId;
-        AZStd::vector<Data::Instance<RPI::StreamingImage>> m_noiseImageImages;
+        RayTracingResourceList<AZ::Data::AssetId> m_noiseImageAssetsId; // parallel arrays tracking noise texture asset IDs and loaded StreamingImage instances.
+        AZStd::vector<Data::Instance<RPI::StreamingImage>> m_noiseImageImages; // Noise texture asset IDs and loaded StreamingImage instances.
     };
 } // namespace AZ::Render
 

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FogVolumeFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FogVolumeFeatureProcessor.h
@@ -95,8 +95,8 @@ namespace AZ::Render
             FogVolumeShape     m_shape;
             uint32_t           m_volumeStart;  // index range in m_currentFrameVolumes.
             uint32_t           m_volumeCount;  // index range in m_currentFrameVolumes.
-            uint32_t           m_instanceStart; // first draw instance and total instances (volumes × slices).
-            uint32_t           m_instanceCount; // first draw instance and total instances (volumes × slices).
+            uint32_t           m_instanceStart; // first draw instance and total instances (volumes x slices).
+            uint32_t           m_instanceCount; // first draw instance and total instances (volumes x slices).
         };
 
         // Must match LocalVolumeData in FroxelLocalVolumeCommon.azsli

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FogVolumeFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FogVolumeFeatureProcessor.h
@@ -180,15 +180,9 @@ namespace AZ::Render
 
         RHI::DrawListTag m_drawListTag;
 
-        RayTracingResourceList<AZ::Data::AssetId> m_noiseImageAssetsId; // parallel arrays tracking noise texture asset IDs and loaded StreamingImage instances.
-        AZStd::vector<Data::Instance<RPI::StreamingImage>> m_noiseImageImages; // Noise texture asset IDs and loaded StreamingImage instances.
+        // Arrays tracking noise texture asset.
+        RayTracingResourceList<Data::Asset<AZ::RPI::StreamingImageAsset>> m_noiseImageAssets;
+        AZStd::vector<Data::Instance<RPI::StreamingImage>> m_noiseImageImages; // Noise texture loaded StreamingImage instances.
     };
 } // namespace AZ::Render
 
-namespace AZ::Data
-{
-    inline bool operator!(const AssetId& assetId)
-    {
-        return !assetId.IsValid();
-    }
-}

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FogVolumeFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FogVolumeFeatureProcessor.h
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Atom/Feature/Utils/IndexedDataVector.h>
+#include <Atom/Feature/VolumetricFog/FogVolumeFeatureProcessorInterface.h>
+#include <Atom/Feature/VolumetricFog/VolumetricFogConstants.h>
+#include <RayTracing/RayTracingResourceList.h>
+
+#include <Atom/RHI/DrawPacket.h>
+#include <Atom/RHI/DrawPacketBuilder.h>
+#include <Atom/RHI.Reflect/ShaderResourceGroupLayoutDescriptor.h>
+
+#include <Atom/RPI.Public/Buffer/Buffer.h>
+#include <Atom/RPI.Public/Pass/RasterPass.h>
+#include <Atom/RPI.Public/PipelineState.h>
+#include <Atom/RPI.Public/Shader/Shader.h>
+#include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
+#include <Atom/RPI.Public/Image/StreamingImage.h>
+
+#include <AzCore/Asset/AssetCommon.h>
+#include <AzCore/Math/Color.h>
+#include <AzCore/Math/Transform.h>
+#include <AzCore/Math/Vector3.h>
+#include <AzCore/std/containers/array.h>
+#include <AzCore/std/containers/vector.h>
+
+namespace AZ::Render
+{
+    class FogVolumeFeatureProcessor final
+        : public FogVolumeFeatureProcessorInterface
+        , protected AZ::Data::AssetBus::MultiHandler
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(FogVolumeFeatureProcessor, AZ::SystemAllocator)
+        AZ_RTTI(AZ::Render::FogVolumeFeatureProcessor, "{3E5D9A7B-1C4F-4B8E-A9D2-7F0C3B5E8A1D}", FogVolumeFeatureProcessorInterface)
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        FogVolumeFeatureProcessor() = default;
+        ~FogVolumeFeatureProcessor() = default;
+
+        // FeatureProcessor
+        void Activate() override;
+        void Deactivate() override;
+        void Simulate(const SimulatePacket& packet) override;
+        void Render(const RenderPacket& packet) override;
+
+        // FogVolumeFeatureProcessorInterface
+        VolumeHandle AcquireVolume() override;
+        bool ReleaseVolume(VolumeHandle& handle) override;
+        void SetVolumeTransform(VolumeHandle handle, const AZ::Transform& transform) override;
+        void SetVolumeExtents(VolumeHandle handle, const AZ::Vector3& halfExtents) override;
+
+#define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)  \
+        void SetVolume##Name(VolumeHandle handle, ValueType val) override;
+
+#include <Atom/Feature/ParamMacros/MapParamCommon.inl>
+#include <Atom/Feature/VolumetricFog/FogVolumeParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+
+    private:
+        // CPU-side state per registered volume
+        struct VolumeState
+        {
+            AZ::Transform  m_transform   = AZ::Transform::CreateIdentity();
+            AZ::Vector3    m_halfExtents = AZ::Vector3(1.0f);
+
+#define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)  \
+            ValueType MemberName = DefaultValue;
+
+#include <Atom/Feature/ParamMacros/MapParamCommon.inl>
+
+#undef AZ_GFX_TEXTURE_ASSET_PARAM
+#define AZ_GFX_TEXTURE_ASSET_PARAM(Name, MemberName, DefaultValue)  \
+            int MemberName##Index = -1;                             \
+
+#include <Atom/Feature/VolumetricFog/FogVolumeParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+        };
+
+        // A contiguous run of volumes sharing (blendMode, shape) after sorting
+        struct Batch
+        {
+            FogVolumeBlendMode m_mode;
+            FogVolumeShape     m_shape;
+            uint32_t           m_volumeStart;
+            uint32_t           m_volumeCount;
+            uint32_t           m_instanceStart;
+            uint32_t           m_instanceCount;
+        };
+
+        // Must match LocalVolumeData in FroxelLocalVolumeCommon.azsli — verified by static_assert in .cpp.
+        struct LocalVolumeData
+        {
+            AZStd::array<float, 3> m_center;
+            uint32_t m_shape;
+            AZStd::array<float, 3> m_right;
+            float m_extentX;
+            AZStd::array<float, 3> m_up;
+            float m_extentY;
+            AZStd::array<float, 3> m_forward;
+            float m_extentZ;
+            AZStd::array<float, 3> m_rcpFadePos;
+            int32_t m_noiseTextureIndex;
+            AZStd::array<float, 3> m_rcpFadeNeg;
+            uint32_t m_sliceMin = 1;
+            uint32_t m_sliceMax = 0;
+            uint32_t m_priority;
+            uint32_t m_blendMode;
+            uint32_t m_pad0;
+            VolumetricFogVolumeConstants m_volumeData;
+        };
+
+        // RPI::SceneNotification
+        void OnRenderPipelineChanged(
+            RPI::RenderPipeline* pipeline,
+            RPI::SceneNotification::RenderPipelineChangeType changeType) override;
+
+        // Data::AssetBus::MultiHandler
+        void OnAssetReloaded(AZ::Data::Asset<AZ::Data::AssetData> asset) override;
+
+        bool LoadShader();
+        void BuildProxyMeshBuffers();
+        void BuildCubeProxy();
+        void BuildSphereProxy();
+        void BuildPipelines();
+
+        void ComputeSliceRanges(const RPI::ViewPtr& view, float fogNear, float fogFar, uint32_t sliceCount);
+        void SortAndPartitionVolumes();
+        void BuildInstanceMappingBuffer();
+        void UploadVolumeBuffer();
+        void BuildNoiseTextureArray();
+
+        LocalVolumeData BuildVolumeGpuData(const VolumeState& state);
+        static float EdgeFadeToRcp(float edgeFraction);
+
+        IndexedDataVector<VolumeState>   m_volumeStates;
+        AZStd::vector<LocalVolumeData>   m_currentFrameVolumes;
+        AZStd::vector<Batch>             m_batches;
+        AZStd::vector<AZStd::pair<uint32_t, uint32_t>> m_instanceMapping;
+
+        Data::Instance<RPI::Buffer> m_volumeBuffer;
+        uint32_t                    m_volumeBufferCapacity = 0;
+
+        Data::Instance<RPI::Buffer> m_instanceMappingBuffer;
+        uint32_t                    m_instanceMappingCapacity = 0;
+
+        AZStd::array<Data::Instance<RPI::Buffer>, FogVolumeShapeCount - 1> m_vertexBuffers;
+        AZStd::array<Data::Instance<RPI::Buffer>, FogVolumeShapeCount - 1> m_indexBuffers;
+
+        RPI::RasterPass*             m_rasterPass = nullptr;
+        Data::Instance<RPI::Shader>  m_shader;
+
+        RHI::ShaderInputNameIndex m_verticesBufferIndex = RHI::ShaderInputNameIndex("m_proxyVertices");
+        RHI::ShaderInputNameIndex m_indicesBufferIndex = RHI::ShaderInputNameIndex("m_proxyIndices");
+        RHI::ShaderInputNameIndex m_volumesBufferIndex = RHI::ShaderInputNameIndex("m_volumes");
+        RHI::ShaderInputNameIndex m_instanceMappingBufferIndex = RHI::ShaderInputNameIndex("m_instanceToVolumeSlice");
+        RHI::ShaderInputImageUnboundedArrayIndex m_noiseTextureArrayIndex;
+
+        AZStd::array<RPI::Ptr<RPI::PipelineStateForDraw>, FogVolumeBlendModeCount> m_pipelineStates;
+
+        AZStd::vector<AZ::RHI::ConstPtr<RHI::DrawPacket>> m_drawPackets;
+
+        RHI::DrawListTag m_drawListTag;
+
+        RayTracingResourceList<AZ::Data::AssetId> m_noiseImageAssetsId;
+        AZStd::vector<Data::Instance<RPI::StreamingImage>> m_noiseImageImages;
+    };
+} // namespace AZ::Render
+
+namespace AZ::Data
+{
+    inline bool operator!(const AssetId& assetId)
+    {
+        return !assetId.IsValid();
+    }
+}

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FroxelIntegratePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FroxelIntegratePass.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <VolumetricFog/FroxelIntegratePass.h>
+#include <VolumetricFog/VolumetricFogUtils.h>
+#include <VolumetricFog/VolumetricFogFeatureProcessor.h>
+
+namespace AZ::Render
+{
+    RPI::Ptr<FroxelIntegratePass> FroxelIntegratePass::Create(const RPI::PassDescriptor& descriptor)
+    {
+        RPI::Ptr<FroxelIntegratePass> pass = aznew FroxelIntegratePass(descriptor);
+        return pass;
+    }
+
+    FroxelIntegratePass::FroxelIntegratePass(const RPI::PassDescriptor& descriptor)
+        : RPI::ComputePass(descriptor)
+    {
+    }
+
+    void FroxelIntegratePass::BuildInternal()
+    {
+        m_scatteringAttachments[0] = FindAttachment(Name("Scattering1"));
+        m_scatteringAttachments[1] = FindAttachment(Name("Scattering2"));
+
+        bool attachmentsValid = true;
+        for (auto i : { 0, 1 })
+        {
+            if (m_scatteringAttachments[i])
+            {
+                attachmentsValid = UpdateAttachmentImage(i);
+            }
+            else
+            {
+                attachmentsValid = false;
+            }
+            if (!attachmentsValid)
+            {
+                break;
+            }
+        }
+
+        if (!attachmentsValid)
+        {
+            SetEnabled(false);
+            AZ_Error(
+                "FroxelIntegratePass", false,
+                "FroxelIntegratePass disabled because the ImageAttachments Scattering1 and Scattering2 are invalid.");
+            return;
+        }
+
+        m_historyScatteredBinding = FindAttachmentBinding(Name("FroxelHistory"));
+        AZ_Error("FroxelIntegratePass", m_historyScatteredBinding, "FroxelIntegratePass requires a slot for FroxelHistory.");
+        m_scatteredBinding = FindAttachmentBinding(Name("FroxelOutput"));
+        AZ_Error("FroxelIntegratePass", m_scatteredBinding, "FroxelIntegratePass requires a slot for FroxelOutput.");
+
+        if (m_historyScatteredBinding->GetAttachment() == nullptr)
+        {
+            m_scatteredBinding->SetAttachment(m_scatteringAttachments[0]);
+            m_historyScatteredBinding->SetAttachment(m_scatteringAttachments[1]);
+        }
+
+        Base::BuildInternal();
+    }
+
+    void FroxelIntegratePass::ResetInternal()
+    {
+        m_scatteringAttachments[0].reset();
+        m_scatteringAttachments[1].reset();
+        m_historyScatteredBinding = nullptr;
+        m_scatteredBinding = nullptr;
+        Base::ResetInternal();
+    }
+
+    void FroxelIntegratePass::FrameBeginInternal(FramePrepareParams params)
+    {
+        Base::FrameBeginInternal(params);
+        UpdateThreadsCount();
+    }
+
+    void FroxelIntegratePass::FrameEndInternal()
+    {
+        m_historyScatteredBinding->SetAttachment(m_scatteringAttachments[m_scatteringOuptutIndex]);
+        m_scatteringOuptutIndex ^= 1;
+        UpdateAttachmentImage(m_scatteringOuptutIndex);
+        m_scatteredBinding->SetAttachment(m_scatteringAttachments[m_scatteringOuptutIndex]);
+        Base::FrameEndInternal();
+    }
+
+    bool FroxelIntegratePass::UpdateAttachmentImage(uint32_t attachmentIndex)
+    {
+        RPI::Ptr<RPI::PassAttachment>& attachment = m_scatteringAttachments[attachmentIndex];
+        return UpdateImportedAttachmentImage(attachment);
+    }
+
+    void FroxelIntegratePass::UpdateThreadsCount()
+    {
+        RPI::PassAttachment* outputAttachment = nullptr;
+
+        if (GetOutputCount() > 0)
+        {
+            outputAttachment = GetOutputBinding(0).GetAttachment().get();
+        }
+        else if (GetInputOutputCount() > 0)
+        {
+            outputAttachment = GetInputOutputBinding(0).GetAttachment().get();
+        }
+
+        AZ_Assert(
+            outputAttachment != nullptr,
+            "[FroxelIntegratePass '%s']: A fullscreen compute pass must have a valid output or input/output.",
+            GetPathName().GetCStr());
+
+        AZ_Assert(
+            outputAttachment->GetAttachmentType() == RHI::AttachmentType::Image,
+            "[FroxelIntegratePass '%s']: The output of a fullscreen compute pass must be an image.",
+            GetPathName().GetCStr());
+
+        RHI::Size targetImageSize = outputAttachment->m_descriptor.m_image.m_size;
+        SetTargetThreadCounts(targetImageSize.m_width, targetImageSize.m_height, 1);
+    }
+}   // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FroxelIntegratePass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FroxelIntegratePass.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Memory/SystemAllocator.h>
+
+#include <Atom/RPI.Public/Pass/ComputePass.h>
+#include <Atom/RPI.Reflect/Pass/ComputePassData.h>
+#include <Atom/Feature/VolumetricFog/VolumetricFogSettings.h>
+
+namespace AZ::Render
+{
+    //! Compute pass that performs temporal reprojection then ray-marching integration
+    //! of the volumetric fog froxel volume in a single z-slice loop.
+    class FroxelIntegratePass final
+        : public RPI::ComputePass
+    {
+        AZ_RPI_PASS(FroxelIntegratePass);
+
+        using Base = RPI::ComputePass;
+    public:
+        AZ_RTTI(AZ::Render::FroxelIntegratePass, "{E3E55EC0-BA58-4B33-BDA6-7746151E3408}", Base);
+        AZ_CLASS_ALLOCATOR(FroxelIntegratePass, SystemAllocator);
+        virtual ~FroxelIntegratePass() = default;
+
+        static RPI::Ptr<FroxelIntegratePass> Create(const RPI::PassDescriptor& descriptor);
+
+    private:
+        FroxelIntegratePass(const RPI::PassDescriptor& descriptor);
+
+        // Pass behavior overrides
+        void BuildInternal() override;
+        void ResetInternal() override;
+        void FrameBeginInternal(FramePrepareParams params) override;
+        void FrameEndInternal() override;
+
+        bool UpdateAttachmentImage(uint32_t attachmentIndex);
+        void UpdateThreadsCount();
+
+        // Ping-pong attachments for temporal history
+        AZStd::array<Data::Instance<RPI::PassAttachment>, 2> m_scatteringAttachments;
+        RPI::PassAttachmentBinding* m_historyScatteredBinding = nullptr;
+        RPI::PassAttachmentBinding* m_scatteredBinding = nullptr;
+        uint8_t m_scatteringOuptutIndex = 0;
+    };
+}   // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FroxelIntegratePass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FroxelIntegratePass.h
@@ -34,18 +34,23 @@ namespace AZ::Render
         FroxelIntegratePass(const RPI::PassDescriptor& descriptor);
 
         // Pass behavior overrides
+        //! Creates the two ping-pong scatter history attachments and wires them to the pass bindings.
         void BuildInternal() override;
+        //! Tears down ping-pong attachments so they are recreated on next resize.
         void ResetInternal() override;
+        //! Swaps the ping-pong index and rebinds history/output attachments for this frame.
         void FrameBeginInternal(FramePrepareParams params) override;
+        //! Advances the froxelFrameIndex in the scene SRG.
         void FrameEndInternal() override;
 
+        //! Allocates or resizes the Texture3D at the given ping-pong slot to match the current froxel grid.
         bool UpdateAttachmentImage(uint32_t attachmentIndex);
+        //! Sets dispatch thread count to match froxel XY.
         void UpdateThreadsCount();
 
-        // Ping-pong attachments for temporal history
-        AZStd::array<Data::Instance<RPI::PassAttachment>, 2> m_scatteringAttachments;
-        RPI::PassAttachmentBinding* m_historyScatteredBinding = nullptr;
-        RPI::PassAttachmentBinding* m_scatteredBinding = nullptr;
-        uint8_t m_scatteringOuptutIndex = 0;
+        AZStd::array<Data::Instance<RPI::PassAttachment>, 2> m_scatteringAttachments; // ping-pong pair of Texture3D attachments holding previous-frame scatter for temporal reprojection.
+        RPI::PassAttachmentBinding* m_historyScatteredBinding = nullptr; // cached binding pointers for fast per-frame rebind.
+        RPI::PassAttachmentBinding* m_scatteredBinding = nullptr; // cached binding pointers for fast per-frame rebind.
+        uint8_t m_scatteringOuptutIndex = 0; // 0 or 1, toggles each frame to alternate write target.
     };
 }   // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FroxelPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FroxelPass.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <VolumetricFog/FroxelPass.h>
+#include <VolumetricFog/VolumetricFogUtils.h>
+#include <VolumetricFog/VolumetricFogFeatureProcessor.h>
+#include <Atom/RPI.Public/RenderPipeline.h>
+#include <Atom/RPI.Public/Scene.h>
+#include <Atom/RPI.Public/View.h>
+#include <Atom/RPI.Reflect/Shader/ShaderOptionGroup.h>
+#include <Atom/RHI.Reflect/ShaderResourceGroupLayout.h>
+#include <AzCore/Math/Plane.h>
+
+
+namespace AZ::Render
+{
+    RPI::Ptr<FroxelPass> FroxelPass::Create(const RPI::PassDescriptor& descriptor)
+    {
+        RPI::Ptr<FroxelPass> pass = aznew FroxelPass(descriptor);
+        return pass;
+    }
+
+
+    FroxelPass::FroxelPass(const RPI::PassDescriptor& descriptor)
+        : RPI::ComputePass(descriptor)
+    {
+    }
+
+    void FroxelPass::SetShaderOption(const Name& optionName, const Name& valueName)
+    {
+        auto layout = m_shaderOptions.GetShaderOptionLayout();
+        if (!layout)
+        {
+            return;
+        }
+
+        auto value = layout->FindValue(optionName, valueName);
+        if (value != m_shaderOptions.GetValue(optionName))
+        {
+            m_shaderOptions.SetValue(optionName, valueName);
+            LoadShader();
+        }
+    }
+
+    void FroxelPass::BuildInternal()
+    {
+        UpdateFroxelVolumeSize();
+        Base::BuildInternal();
+    }
+
+    void FroxelPass::UpdateFroxelVolumeSize()
+    {
+        if (auto scene = GetScene())
+        {
+            if (auto fp = scene->GetFeatureProcessor<VolumetricFogFeatureProcessor>())
+            {
+                RPI::Ptr<RPI::PassAttachment> attachment = m_ownedAttachments.front();
+                AZ_Assert(attachment, "[FroxelPass %s] Cannot find froxel volume image attachment.", GetPathName().GetCStr());
+                AZ_Assert(
+                    attachment->m_descriptor.m_type == RHI::AttachmentType::Image,
+                    "[FroxelPass %s] requires an image attachment",
+                    GetPathName().GetCStr());
+
+                RHI::Size tileSize = VolumetricFog::ToFroxelSize(fp->GetFogQuality());
+                auto& multipliers = attachment->m_sizeMultipliers;
+                multipliers.m_widthMultiplier = 1.0f / tileSize.m_width;
+                multipliers.m_heightMultiplier = 1.0f / tileSize.m_height;
+                multipliers.m_depthMultiplier = static_cast<float>(tileSize.m_depth);
+            }
+        }
+    }
+}   // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FroxelPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FroxelPass.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Memory/SystemAllocator.h>
+
+#include <Atom/RPI.Public/Pass/ComputePass.h>
+#include <Atom/Feature/VolumetricFog/VolumetricFogSettings.h>
+
+namespace AZ::Render
+{
+    class FroxelPass final
+        : public RPI::ComputePass
+    {
+        AZ_RPI_PASS(FroxelPass);
+
+        using Base = RPI::ComputePass;
+    public:
+        AZ_RTTI(AZ::Render::FroxelPass, "{8245E04B-AC97-4FC9-A5E4-90B6F41AC394}", Base);
+        AZ_CLASS_ALLOCATOR(FroxelPass, SystemAllocator);
+        virtual ~FroxelPass() = default;
+
+        static RPI::Ptr<FroxelPass> Create(const RPI::PassDescriptor& descriptor);
+
+        void SetShaderOption(const Name& optionName, const Name& valueName);
+
+    private:
+        FroxelPass(const RPI::PassDescriptor& descriptor);
+
+        // Pass behavior overrides...
+        void BuildInternal() override;
+
+        void UpdateFroxelVolumeSize();
+    };
+}   // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FroxelPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/FroxelPass.h
@@ -14,6 +14,8 @@
 
 namespace AZ::Render
 {
+    //! Thin ComputePass subclass that exposes shader option control for quality/noise
+    //! variants and resizes the dispatch count to match the froxel grid.
     class FroxelPass final
         : public RPI::ComputePass
     {
@@ -27,6 +29,8 @@ namespace AZ::Render
 
         static RPI::Ptr<FroxelPass> Create(const RPI::PassDescriptor& descriptor);
 
+        //! Writes a named option value into the persistent m_shaderOptions group (from the modified ComputePass base);
+        //! Call before the pass is compiled.
         void SetShaderOption(const Name& optionName, const Name& valueName);
 
     private:
@@ -35,6 +39,7 @@ namespace AZ::Render
         // Pass behavior overrides...
         void BuildInternal() override;
 
+        //! Resolves froxel grid dimensions
         void UpdateFroxelVolumeSize();
     };
 }   // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/VolumetricFogFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/VolumetricFogFeatureProcessor.cpp
@@ -1,0 +1,485 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <VolumetricFog/VolumetricFogFeatureProcessor.h>
+#include <VolumetricFog/FroxelPass.h>
+#include <VolumetricFog/VolumetricFogUtils.h>
+
+#include <AzCore/Name/NameDictionary.h>
+#include <AzCore/Math/Random.h>
+
+#include <Atom/RPI.Public/RenderPipeline.h>
+#include <Atom/RPI.Public/RPISystemInterface.h>
+#include <Atom/RPI.Public/Pass/PassSystem.h>
+#include <Atom/RPI.Public/Pass/PassFilter.h>
+#include <Atom/RPI.Public/Scene.h>
+#include <Atom/RPI.Public/View.h>
+#include <Atom/RPI.Public/RPIUtils.h>
+#include <Atom/RHI/DrawPacketBuilder.h>
+#include <Atom/RHI/RHISystemInterface.h>
+
+namespace AZ::Render
+{
+    void VolumetricFogFeatureProcessor::Reflect(ReflectContext* context)
+    {
+        if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))
+        {
+            serializeContext
+                ->Class<VolumetricFogFeatureProcessor, FeatureProcessor>()
+                ->Version(0);
+        }
+    }
+
+    //-------------------------------------------
+    // Getters / setters macro
+#define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)                                                                     \
+    ValueType VolumetricFogFeatureProcessor::Get##Name() const                                                                                       \
+    {                                                                                                                                      \
+        return m_settings.MemberName;                                                                                                                 \
+    }                                                                                                                                      \
+    void VolumetricFogFeatureProcessor::Set##Name(ValueType val)                                                                                     \
+    {                                                                                                                                      \
+        m_settings.MemberName = val;                                                                                                                  \
+        OnSettingsChanged();                                                                                                               \
+    }
+
+#include <Atom/Feature/ParamMacros/MapParamCommon.inl>
+#include <Atom/Feature/VolumetricFog/VolumetricFogParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+    //-------------------------------------------
+    
+    void VolumetricFogFeatureProcessor::Activate()
+    {
+        m_settings.m_enabled = false;
+        m_sceneSrg = GetParentScene()->GetShaderResourceGroup();
+        m_shaderConstantsIndex = m_sceneSrg->FindShaderInputConstantIndex(Name("m_volumetricFogData"));
+        m_shaderConstantsVolumeIndex = m_sceneSrg->FindShaderInputConstantIndex(Name("m_volumetricFogVolumeData"));
+
+#include <Atom/Feature/ParamMacros/MapParamEmpty.inl>
+
+#undef AZ_GFX_TEXTURE_ASSET_PARAM
+#define AZ_GFX_TEXTURE_ASSET_PARAM(_Name, MemberName, DefaultValue)                                 \
+            MemberName##SrgIndex = m_sceneSrg->FindShaderInputImageIndex(Name(#MemberName));    \
+ 
+#include <Atom/Feature/VolumetricFog/VolumetricFogParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+
+        LoadShaders();
+
+        auto* rhiSystem = RHI::RHISystemInterface::Get();
+        for (uint32_t i = 0; i < m_drawListTagNames.size(); ++i)
+        {
+            m_drawListTags[i] = rhiSystem->GetDrawListTagRegistry()->AcquireTag(m_drawListTagNames[i]);
+        }
+        EnableSceneNotification();
+    }
+    
+    void VolumetricFogFeatureProcessor::Deactivate()
+    {
+        DisableSceneNotification();
+        m_shaderConstantsIndex.Reset();
+        m_shaderConstantsVolumeIndex.Reset();
+        #include <Atom/Feature/ParamMacros/MapParamEmpty.inl>
+
+#undef AZ_GFX_TEXTURE_ASSET_PARAM
+#define AZ_GFX_TEXTURE_ASSET_PARAM(_Name, MemberName, DefaultValue) \
+            MemberName##SrgIndex.Reset();                           \
+            MemberName##Image.reset();                              \
+ 
+#include <Atom/Feature/VolumetricFog/VolumetricFogParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+        ResetShaderResources();
+        m_sceneSrg = {};
+        m_settings = {};
+    }   
+
+    void VolumetricFogFeatureProcessor::AddRenderPasses([[maybe_unused]] RPI::RenderPipeline* renderPipeline)
+    {
+    }
+
+    void VolumetricFogFeatureProcessor::OnRenderPipelineChanged([[maybe_unused]] RPI::RenderPipeline* pipeline,
+        RPI::SceneNotification::RenderPipelineChangeType changeType)
+    {
+        if (changeType == RPI::SceneNotification::RenderPipelineChangeType::Added
+            || changeType == RPI::SceneNotification::RenderPipelineChangeType::PassChanged)
+        {
+            BuildPipelines();
+            UpdatePasses(pipeline);
+        }
+
+        if (changeType == RPI::SceneNotification::RenderPipelineChangeType::Removed)
+        {
+            m_meshPipelineStates.fill(nullptr);
+            UpdatePasses(nullptr);
+        }
+    }
+
+    void VolumetricFogFeatureProcessor::OnAssetReloaded(AZ::Data::Asset<AZ::Data::AssetData> asset)
+    {
+        Data::AssetBus::MultiHandler::BusDisconnect();
+        if (LoadShaders())
+        {
+            m_buildDrawPackets = true;
+        }
+    }
+    
+    void VolumetricFogFeatureProcessor::Render([[maybe_unused]] const FeatureProcessor::RenderPacket& packet)
+    {
+        AZ_PROFILE_SCOPE(RPI, "VolumetricFogFeatureProcessor: Render");
+        if (!m_settings.m_enabled)
+        {
+            return;
+        }
+
+        auto toDepth = [this](uint32_t index)
+        {
+            return index == 0 ? m_settings.m_fogNear : m_settings.m_fogFar;
+        };
+
+        for (auto& view : packet.m_views)
+        {
+            for (uint32_t i = 0; i < m_drawListTags.size(); ++i)
+            {
+                if (!view->HasDrawListTag(m_drawListTags[i]))
+                {
+                    continue;
+                }
+
+                view->AddDrawPacket(m_drawPackets[i].get(), toDepth(i));
+            }
+        }
+    }
+
+    void VolumetricFogFeatureProcessor::Simulate([[maybe_unused]] const FeatureProcessor::SimulatePacket& packet)
+    {
+        SetPassesEnabled();
+        if (m_settings.m_enabled)
+        {
+            AZ_PROFILE_SCOPE(RPI, "VolumetricFogFeatureProcessor: Simulate");
+
+            if (m_buildDrawPackets)
+            {
+                BuildPipelines();
+            }
+
+            m_sceneSrgGlobalConstants.m_frameIndex++;
+            if (m_needUpdate)
+            {
+                UpdateSceneSrgConstants();
+                BuildDrawItems();
+                m_needUpdate = false;
+            }
+
+            m_sceneSrg->SetConstant(m_shaderConstantsIndex, m_sceneSrgGlobalConstants);
+            m_sceneSrg->SetConstant(m_shaderConstantsVolumeIndex, m_sceneSrgVolumeConstants);
+
+#include <Atom/Feature/ParamMacros/MapParamEmpty.inl>
+
+            // The following macro overrides the regular macro defined above, loads an image and bind it
+#undef AZ_GFX_TEXTURE_ASSET_PARAM
+#define AZ_GFX_TEXTURE_ASSET_PARAM(Name, MemberName, DefaultValue)                                  \
+            if (!MemberName##Image)                                                                 \
+            {                                                                                       \
+                if (m_settings.MemberName.IsReady())                                               \
+                {                                                                                   \
+                    MemberName##Image = RPI::StreamingImage::FindOrCreate(m_settings.MemberName);   \
+                }                                                                                   \
+            }                                                                                       \
+            if (MemberName##SrgIndex.IsValid())                                                     \
+            {                                                                                       \
+                if (!m_sceneSrg->SetImage(MemberName##SrgIndex, MemberName##Image))                 \
+                {                                                                                   \
+                    AZ_Error(                                                       \
+                        "VolumetricFogFeatureProcessor::Simulate",                  \
+                        false,                                                      \
+                        "Failed to bind SRG image for %s = %s",                     \
+                        #MemberName,                                                \
+                        m_settings.MemberName.GetHint().c_str());                   \
+                }                                                                   \
+            }                                                                       \
+
+#include <Atom/Feature/VolumetricFog/VolumetricFogParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+
+            if (m_injectPass)
+            {
+                m_injectPass->SetShaderOption(Name("o_enableNoiseTexture"), m_noiseTextureImage ? Name("true") : Name("false"));
+            }
+        }
+        else
+        {
+            // Fog disabled — clear the enabled flag so transparent shaders skip fog sampling
+            m_sceneSrgGlobalConstants.m_enabled = 0u;
+            m_sceneSrg->SetConstant(m_shaderConstantsIndex, m_sceneSrgGlobalConstants);
+        }
+    }
+
+    const VolumetricFogSettings& VolumetricFogFeatureProcessor::GetSettings() const
+    {
+        return m_settings;
+    }
+
+    void VolumetricFogFeatureProcessor::OnSettingsChanged()
+    {
+        m_needUpdate = true; // even if disabled, mark it for when it'll become enabled
+        if (m_froxelParentPass)
+        {
+            if (m_settings.m_enabled != m_froxelParentPass->IsEnabled() ||
+                VolumetricFog::ToFroxelSize(m_settings.m_quality).m_width != m_sceneSrgGlobalConstants.m_tileSize)
+            {
+                m_froxelParentPass->QueueForBuildAndInitialization();
+            }
+        }
+    }
+
+    void VolumetricFogFeatureProcessor::UpdatePasses(AZ::RPI::RenderPipeline* renderPipeline)
+    {
+        m_injectPass = nullptr;
+        m_froxelParentPass = nullptr;
+        m_froxelCompositePass = nullptr;
+
+        if (renderPipeline == nullptr)
+        {
+            m_renderPipeline = nullptr;
+            return;
+        }
+
+        {
+            const auto templateName = Name("FroxelInjectTemplate");
+            auto passFilter = AZ::RPI::PassFilter::CreateWithTemplateName(templateName, renderPipeline);
+            if (auto foundPass = AZ::RPI::PassSystemInterface::Get()->FindFirstPass(passFilter); foundPass)
+            {
+                m_injectPass = static_cast<FroxelPass*>(foundPass);
+            }
+        }
+
+        {
+            const auto templateName = Name("FroxelParentTemplate");
+            auto passFilter = AZ::RPI::PassFilter::CreateWithTemplateName(templateName, renderPipeline);
+            if (auto foundPass = AZ::RPI::PassSystemInterface::Get()->FindFirstPass(passFilter); foundPass)
+            {
+                m_froxelParentPass = static_cast<RPI::ParentPass*>(foundPass);
+            }
+        }
+
+        {
+            const auto templateName = Name("FroxelCompositeTemplate");
+            auto passFilter = AZ::RPI::PassFilter::CreateWithTemplateName(templateName, renderPipeline);
+            if (auto foundPass = AZ::RPI::PassSystemInterface::Get()->FindFirstPass(passFilter); foundPass)
+            {
+                m_froxelCompositePass = foundPass;
+            }
+        }
+        
+
+        // remember which render pipeline we found our passes on
+        m_renderPipeline = (m_injectPass && m_froxelParentPass && m_froxelCompositePass) ? renderPipeline : nullptr;
+    }
+
+    void VolumetricFogFeatureProcessor::UpdateSceneSrgConstants()
+    {
+        RHI::Size tileSize = VolumetricFog::ToFroxelSize(m_settings.m_quality);
+        m_sceneSrgGlobalConstants.m_enabled = static_cast<uint32_t>(m_settings.m_enabled);
+        m_sceneSrgGlobalConstants.m_tileSize = tileSize.m_width;
+        if (m_froxelParentPass)
+        {
+            if (auto attachmentBinding = m_froxelParentPass->FindAttachmentBinding(Name("PipelineOutput")))
+            {
+                if (auto attachment = attachmentBinding->GetAttachment())
+                {
+                    RHI::Size outputSize = attachment->m_descriptor.m_image.m_size;
+                    m_sceneSrgGlobalConstants.m_froxelCount =
+                        RHI::Size(
+                            uint32_t(ceil(float(outputSize.m_width) * 1.0f / tileSize.m_width)),
+                            uint32_t(ceil(float(outputSize.m_height) * 1.0f / tileSize.m_height)),
+                            tileSize.m_depth);
+                }
+            }
+        }
+        m_sceneSrgGlobalConstants.m_lightingChannelMask = m_settings.m_lightingChannelConfig.GetLightingChannelMask();
+        // The coprimes 2, 3 and 5 are commonly used for halton sequences because they have an even distribution even for
+        // few samples. With larger primes you need to offset by some amount between each prime to have the same
+        // effect. We could allow this to be configurable in the future.
+        SetupSubPixelOffsets(2, 3, 5, m_settings.m_sequenceLength);
+
+#define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)          \
+        m_sceneSrgGlobalConstants.MemberName = m_settings.MemberName;                 \
+
+#include <Atom/Feature/ParamMacros/MapAllCommon.inl>
+#undef AZ_GFX_VEC3_PARAM
+#define AZ_GFX_VEC3_PARAM(Name, MemberName, DefaultValue)                                                                           \
+        m_sceneSrgGlobalConstants.MemberName = { m_settings.MemberName.m_x, m_settings.MemberName.m_y, m_settings.MemberName.m_z };       \
+
+#include <Atom/Feature/VolumetricFog/VolumetricFogSRGConstants.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+
+#define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)          \
+        m_sceneSrgVolumeConstants.MemberName = m_settings.MemberName;                 \
+
+#include <Atom/Feature/ParamMacros/MapAllCommon.inl>
+#undef AZ_GFX_VEC3_PARAM
+#define AZ_GFX_VEC3_PARAM(Name, MemberName, DefaultValue)                                                                           \
+        m_sceneSrgVolumeConstants.MemberName = { m_settings.MemberName.m_x, m_settings.MemberName.m_y, m_settings.MemberName.m_z };       \
+
+#include <Atom/Feature/VolumetricFog/VolumetricFogVolumeSRGConstants.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+
+        // Load all texture resources:
+        // first set all macros to be empty, but override the texture for setting images.
+#include <Atom/Feature/ParamMacros/MapParamEmpty.inl>
+
+#undef AZ_GFX_TEXTURE_ASSET_PARAM
+#define AZ_GFX_TEXTURE_ASSET_PARAM(_Name, MemberName, DefaultValue)                         \
+        MemberName##Image = {};                                                             \
+        if (!m_settings.MemberName.IsReady() && m_settings.MemberName.GetId().IsValid())    \
+        {                                                                                   \
+            /*This is a workaround because on certain cases the subId of the StreamingImageAsset doesn't load and it's 0*/  \
+            Data::AssetId id(m_settings.MemberName.GetId().m_guid, RPI::StreamingImageAsset::GetImageAssetSubId());         \
+            m_settings.MemberName = AZ::Data::AssetManager::Instance().GetAsset<RPI::StreamingImageAsset>(                  \
+                id, AZ::Data::AssetLoadBehavior::PreLoad);                                                                  \
+        }                                                                                                                   \
+
+#include <Atom/Feature/VolumetricFog/VolumetricFogParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+        
+        m_sceneSrgGlobalConstants.m_blendPercentage /= 100.0f;
+    }
+
+    void VolumetricFogFeatureProcessor::BuildDrawItems()
+    {
+        m_drawPackets[0] = BuildDrawItem(m_settings.m_fogNear, m_drawListTags[0], m_meshPipelineStates[0].get());
+        m_drawPackets[1] = BuildDrawItem(m_settings.m_fogFar, m_drawListTags[1], m_meshPipelineStates[1].get());
+    }
+
+    AZ::RHI::DrawPacket* VolumetricFogFeatureProcessor::BuildDrawItem(
+        float depth, RHI::DrawListTag tag, const AZ::RPI::PipelineStateForDraw* pipelineState)
+    {
+        if (!pipelineState)
+        {
+            return nullptr;
+        }
+
+        AZ::RHI::DrawPacketBuilder drawPacketBuilder;
+
+        drawPacketBuilder.Begin(nullptr);
+
+        // This draw item purposefully does not reference any geometry buffers.
+        // Instead it's expected that the extended class uses a vertex shader
+        // that generates a full-screen triangle completely from vertex ids.
+        RHI::DrawLinear draw = RHI::DrawLinear();
+        draw.m_vertexCount = 3;
+        drawPacketBuilder.SetDrawArguments(RHI::DrawArguments(draw));
+
+        AZ::RHI::DrawPacketBuilder::DrawRequest drawRequest;
+        drawRequest.m_listTag = tag;
+        drawRequest.m_pipelineState = pipelineState->GetRHIPipelineState();
+        drawPacketBuilder.AddDrawItem(drawRequest);
+        drawPacketBuilder.SetRootConstants(AZStd::span<const uint8_t>(reinterpret_cast<uint8_t*>(&depth), sizeof(depth)));
+        return drawPacketBuilder.End();
+    }
+
+    AZ::RPI::PipelineStateForDraw* VolumetricFogFeatureProcessor::BuildPipeline(
+        RHI::DrawListTag tag, const Data::Instance<RPI::Shader>& shader)
+    {
+        if (!shader)
+        {
+            return nullptr;
+        }
+
+        auto pipeline = aznew AZ::RPI::PipelineStateForDraw;
+        pipeline->Init(shader);
+
+        // No streams required
+        RHI::InputStreamLayout inputStreamLayout;
+        inputStreamLayout.SetTopology(RHI::PrimitiveTopology::TriangleList);
+        inputStreamLayout.Finalize();
+
+        pipeline->InputStreamLayout() = inputStreamLayout;
+        pipeline->SetOutputFromScene(GetParentScene(), tag);
+        pipeline->Finalize();
+        return pipeline;
+    }
+
+    void VolumetricFogFeatureProcessor::BuildPipelines()
+    {
+        for (uint32_t i = 0; i < m_meshPipelineStates.size(); ++i)
+        {          
+            m_meshPipelineStates[i] = BuildPipeline(m_drawListTags[i], m_shaders[i]);
+        }
+        BuildDrawItems();
+        m_buildDrawPackets = false;
+    }
+
+    bool VolumetricFogFeatureProcessor::LoadShaders()
+    {
+        ResetShaderResources();
+
+        constexpr const char* ShaderFilePaths[] = {
+            "shaders/volumetricfog/volumetricfogmintransparent.azshader",
+            "shaders/volumetricfog/volumetricfogmaxtransparent.azshader",
+        };
+        for (uint32_t i = 0; i < m_shaders.size(); ++i)
+        {
+            m_shaders[i] = AZ::RPI::LoadCriticalShader(ShaderFilePaths[i]);
+
+            if (!m_shaders[i])
+            {
+                AZ_Error("VolumetricFogFeatureProcessor", false, "LoadShader(): Failed to load required Transparent Min/Max shader.");
+                return false;
+            }
+
+            AZ::Data::AssetBus::MultiHandler::BusConnect(m_shaders[i]->GetAssetId());
+        }       
+
+        return true;
+    }
+
+    void VolumetricFogFeatureProcessor::ResetShaderResources()
+    {
+        m_drawPackets.fill(nullptr);
+        m_meshPipelineStates.fill(nullptr);
+        m_shaders.fill(nullptr);
+        Data::AssetBus::MultiHandler::BusDisconnect();
+    }
+
+    void VolumetricFogFeatureProcessor::SetupSubPixelOffsets(uint32_t haltonX, uint32_t haltonY, uint32_t haltonZ, uint32_t length)
+    {
+        HaltonSequence<3> sequence = HaltonSequence<3>({ haltonX, haltonY, haltonZ });
+        AZ_Assert(
+            length <= VolumetricFogMaxSequenceLength,
+            "[VolumetricFogFeatureProcessor] Sequence %d is larger that max allowed %d",
+            static_cast<int>(length),
+            static_cast<int>(VolumetricFogMaxSequenceLength));
+        auto beginIt = AZStd::begin(m_sceneSrgGlobalConstants.m_haltonSequence);
+        auto endIt = beginIt + length;
+        sequence.FillHaltonSequence(beginIt, endIt);
+
+        AZStd::for_each(
+            beginIt,
+            endIt,
+            [](Offset& offset)
+            {
+                offset.m_xOffset -= 0.5f;
+                offset.m_yOffset -= 0.5f;
+                offset.m_zOffset -= 0.5f;
+            });
+    }
+
+    void VolumetricFogFeatureProcessor::SetPassesEnabled()
+    {
+        if (m_froxelParentPass)
+        {
+            m_froxelParentPass->SetEnabled(m_settings.m_enabled);
+        }
+
+        if (m_froxelCompositePass)
+        {
+            m_froxelCompositePass->SetEnabled(m_settings.m_enabled);
+        }
+    }
+}

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/VolumetricFogFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/VolumetricFogFeatureProcessor.cpp
@@ -132,6 +132,32 @@ namespace AZ::Render
             return;
         }
 
+        // Update the froxel size every frame in case the pipeline output size changed.
+        UpdateFroxelSize();
+        m_sceneSrg->SetConstant(m_shaderConstantsIndex, m_sceneSrgGlobalConstants);
+        m_sceneSrg->SetConstant(m_shaderConstantsVolumeIndex, m_sceneSrgVolumeConstants);
+
+        #include <Atom/Feature/ParamMacros/MapParamEmpty.inl>
+
+        // The following macro overrides the regular macro defined above, loads an image and bind it
+#undef AZ_GFX_TEXTURE_ASSET_PARAM
+#define AZ_GFX_TEXTURE_ASSET_PARAM(Name, MemberName, DefaultValue)                                                                             \
+        if (MemberName##SrgIndex.IsValid())                                                                                                    \
+        {                                                                                                                                      \
+            if (!m_sceneSrg->SetImage(MemberName##SrgIndex, MemberName##Image))                                                                \
+            {                                                                                                                                  \
+                AZ_Error(                                                                                                                      \
+                    "VolumetricFogFeatureProcessor::Simulate",                                                                                 \
+                    false,                                                                                                                     \
+                    "Failed to bind SRG image for %s = %s",                                                                                    \
+                    #MemberName,                                                                                                               \
+                    m_settings.MemberName.GetHint().c_str());                                                                                  \
+            }                                                                                                                                  \
+        }
+
+#include <Atom/Feature/VolumetricFog/VolumetricFogParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+
         auto toDepth = [this](uint32_t index)
         {
             return index == 0 ? m_settings.m_fogNear : m_settings.m_fogFar;
@@ -153,11 +179,10 @@ namespace AZ::Render
 
     void VolumetricFogFeatureProcessor::Simulate([[maybe_unused]] const FeatureProcessor::SimulatePacket& packet)
     {
+        AZ_PROFILE_SCOPE(RPI, "VolumetricFogFeatureProcessor: Simulate");
         SetPassesEnabled();
         if (m_settings.m_enabled)
         {
-            AZ_PROFILE_SCOPE(RPI, "VolumetricFogFeatureProcessor: Simulate");
-
             if (m_buildDrawPackets)
             {
                 BuildPipelines();
@@ -171,33 +196,18 @@ namespace AZ::Render
                 m_needUpdate = false;
             }
 
-            m_sceneSrg->SetConstant(m_shaderConstantsIndex, m_sceneSrgGlobalConstants);
-            m_sceneSrg->SetConstant(m_shaderConstantsVolumeIndex, m_sceneSrgVolumeConstants);
-
 #include <Atom/Feature/ParamMacros/MapParamEmpty.inl>
 
             // The following macro overrides the regular macro defined above, loads an image and bind it
 #undef AZ_GFX_TEXTURE_ASSET_PARAM
-#define AZ_GFX_TEXTURE_ASSET_PARAM(Name, MemberName, DefaultValue)                                  \
-            if (!MemberName##Image)                                                                 \
-            {                                                                                       \
-                if (m_settings.MemberName.IsReady())                                               \
-                {                                                                                   \
-                    MemberName##Image = RPI::StreamingImage::FindOrCreate(m_settings.MemberName);   \
-                }                                                                                   \
-            }                                                                                       \
-            if (MemberName##SrgIndex.IsValid())                                                     \
-            {                                                                                       \
-                if (!m_sceneSrg->SetImage(MemberName##SrgIndex, MemberName##Image))                 \
-                {                                                                                   \
-                    AZ_Error(                                                       \
-                        "VolumetricFogFeatureProcessor::Simulate",                  \
-                        false,                                                      \
-                        "Failed to bind SRG image for %s = %s",                     \
-                        #MemberName,                                                \
-                        m_settings.MemberName.GetHint().c_str());                   \
-                }                                                                   \
-            }                                                                       \
+#define AZ_GFX_TEXTURE_ASSET_PARAM(Name, MemberName, DefaultValue)                                                                         \
+        if (!MemberName##Image)                                                                                                                \
+        {                                                                                                                                      \
+            if (m_settings.MemberName.IsReady())                                                                                               \
+            {                                                                                                                                  \
+                MemberName##Image = RPI::StreamingImage::FindOrCreate(m_settings.MemberName);                                                  \
+            }                                                                                                                                  \
+        }                                                                                                                                      \
 
 #include <Atom/Feature/VolumetricFog/VolumetricFogParams.inl>
 #include <Atom/Feature/ParamMacros/EndParams.inl>
@@ -282,22 +292,8 @@ namespace AZ::Render
         RHI::Size tileSize = VolumetricFog::ToFroxelSize(m_settings.m_quality);
         m_sceneSrgGlobalConstants.m_enabled = static_cast<uint32_t>(m_settings.m_enabled);
         m_sceneSrgGlobalConstants.m_tileSize = tileSize.m_width;
-        if (m_froxelParentPass)
-        {
-            if (auto attachmentBinding = m_froxelParentPass->FindAttachmentBinding(Name("PipelineOutput")))
-            {
-                if (auto attachment = attachmentBinding->GetAttachment())
-                {
-                    RHI::Size outputSize = attachment->m_descriptor.m_image.m_size;
-                    m_sceneSrgGlobalConstants.m_froxelCount =
-                        RHI::Size(
-                            uint32_t(ceil(float(outputSize.m_width) * 1.0f / tileSize.m_width)),
-                            uint32_t(ceil(float(outputSize.m_height) * 1.0f / tileSize.m_height)),
-                            tileSize.m_depth);
-                }
-            }
-        }
         m_sceneSrgGlobalConstants.m_lightingChannelMask = m_settings.m_lightingChannelConfig.GetLightingChannelMask();
+
         // The coprimes 2, 3 and 5 are commonly used for halton sequences because they have an even distribution even for
         // few samples. With larger primes you need to offset by some amount between each prime to have the same
         // effect. We could allow this to be configurable in the future.
@@ -344,6 +340,23 @@ namespace AZ::Render
 #include <Atom/Feature/ParamMacros/EndParams.inl>
         
         m_sceneSrgGlobalConstants.m_blendPercentage /= 100.0f;
+    }
+
+    void VolumetricFogFeatureProcessor::UpdateFroxelSize()
+    {
+        if (auto attachmentBinding = m_froxelParentPass->FindAttachmentBinding(Name("PipelineOutput")))
+        {
+            if (auto attachment = attachmentBinding->GetAttachment())
+            {
+                auto outputSize = attachment->m_descriptor.m_image.m_size;
+                RHI::Size tileSize = VolumetricFog::ToFroxelSize(m_settings.m_quality);
+                m_sceneSrgGlobalConstants.m_froxelCount = RHI::Size(
+                    uint32_t(ceil(float(outputSize.m_width) * 1.0f / tileSize.m_width)),
+                    uint32_t(ceil(float(outputSize.m_height) * 1.0f / tileSize.m_height)),
+                    tileSize.m_depth);
+
+            }
+        }
     }
 
     void VolumetricFogFeatureProcessor::BuildDrawItems()

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/VolumetricFogFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/VolumetricFogFeatureProcessor.cpp
@@ -98,10 +98,6 @@ namespace AZ::Render
         m_settings = {};
     }   
 
-    void VolumetricFogFeatureProcessor::AddRenderPasses([[maybe_unused]] RPI::RenderPipeline* renderPipeline)
-    {
-    }
-
     void VolumetricFogFeatureProcessor::OnRenderPipelineChanged([[maybe_unused]] RPI::RenderPipeline* pipeline,
         RPI::SceneNotification::RenderPipelineChangeType changeType)
     {

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/VolumetricFogFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/VolumetricFogFeatureProcessor.cpp
@@ -219,7 +219,7 @@ namespace AZ::Render
         }
         else
         {
-            // Fog disabled — clear the enabled flag so transparent shaders skip fog sampling
+            // Fog disabled. Clear the enabled flag so transparent shaders skip fog sampling
             m_sceneSrgGlobalConstants.m_enabled = 0u;
             m_sceneSrg->SetConstant(m_shaderConstantsIndex, m_sceneSrgGlobalConstants);
         }

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/VolumetricFogFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/VolumetricFogFeatureProcessor.cpp
@@ -127,7 +127,7 @@ namespace AZ::Render
     void VolumetricFogFeatureProcessor::Render([[maybe_unused]] const FeatureProcessor::RenderPacket& packet)
     {
         AZ_PROFILE_SCOPE(RPI, "VolumetricFogFeatureProcessor: Render");
-        if (!m_settings.m_enabled)
+        if (!m_settings.m_enabled || !m_renderPipeline)
         {
             return;
         }
@@ -344,6 +344,11 @@ namespace AZ::Render
 
     void VolumetricFogFeatureProcessor::UpdateFroxelSize()
     {
+        if (!m_froxelParentPass)
+        {
+            return;
+        }
+
         if (auto attachmentBinding = m_froxelParentPass->FindAttachmentBinding(Name("PipelineOutput")))
         {
             if (auto attachment = attachmentBinding->GetAttachment())

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/VolumetricFogFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/VolumetricFogFeatureProcessor.cpp
@@ -115,7 +115,7 @@ namespace AZ::Render
         }
     }
 
-    void VolumetricFogFeatureProcessor::OnAssetReloaded(AZ::Data::Asset<AZ::Data::AssetData> asset)
+    void VolumetricFogFeatureProcessor::OnAssetReloaded([[maybe_unused]] AZ::Data::Asset<AZ::Data::AssetData> asset)
     {
         Data::AssetBus::MultiHandler::BusDisconnect();
         if (LoadShaders())

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/VolumetricFogFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/VolumetricFogFeatureProcessor.h
@@ -52,7 +52,7 @@ namespace AZ::Render
         void Render(const RenderPacket& packet) override;
         void Simulate(const FeatureProcessor::SimulatePacket& packet) override;
 
-        //! VolumetricFogFeatureProcessorInterface — global fog settings
+        //! VolumetricFogFeatureProcessorInterface. Global fog settings
         const VolumetricFogSettings& GetSettings() const override;
 
 #include <Atom/Feature/ParamMacros/StartParamFunctionsOverride.inl>

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/VolumetricFogFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/VolumetricFogFeatureProcessor.h
@@ -31,6 +31,9 @@ namespace AZ::Render
 {
     class FroxelPass;
 
+    //! Feature processor for global volumetric fog; owns the froxel grid, halton jitter sequence,
+    //! scene SRG constants, and the FroxelParent pass hierarchy. It handles enabling/disabling the passes
+    //! involved in the Volumetric Fog process. Manages the volumetric fog constant data that the passes access.
     class VolumetricFogFeatureProcessor final
         : public VolumetricFogFeatureProcessorInterface
         , protected AZ::Data::AssetBus::MultiHandler
@@ -45,14 +48,13 @@ namespace AZ::Render
         VolumetricFogFeatureProcessor() = default;
         virtual ~VolumetricFogFeatureProcessor() = default;
 
-        //! FeatureProcessor 
+        //! FeatureProcessor
         void Activate() override;
         void Deactivate() override;
-        void AddRenderPasses(RPI::RenderPipeline* renderPipeline) override;
         void Render(const RenderPacket& packet) override;
         void Simulate(const FeatureProcessor::SimulatePacket& packet) override;
 
-        //! VolumetricFogFeatureProcessorInterface — global fog
+        //! VolumetricFogFeatureProcessorInterface — global fog settings
         const VolumetricFogSettings& GetSettings() const override;
 
 #include <Atom/Feature/ParamMacros/StartParamFunctionsOverride.inl>
@@ -60,6 +62,7 @@ namespace AZ::Render
 #include <Atom/Feature/ParamMacros/EndParams.inl>
 
     private:
+        //! 16-byte GPU-aligned Halton jitter sample.
         struct Offset
         {
             Offset() = default;
@@ -73,7 +76,7 @@ namespace AZ::Render
             float m_xOffset = 0.0f;
             float m_yOffset = 0.0f;
             float m_zOffset = 0.0f;
-            float m_padding0;
+            float m_padding0; // explicit pad to 16 bytes for constant buffer alignment.
         };
 
         RHI::ShaderInputConstantIndex m_shaderConstantsIndex;
@@ -103,14 +106,14 @@ namespace AZ::Render
 #include <Atom/Feature/ParamMacros/EndParams.inl>
         //---------------------------------------------------------
 
-        // Volumetric Fog scene global constants
+        //! CPU mirror of the global fog constants pushed to the scene SRG each frame.
         struct VolumetricFogConstants
         {
-            Offset m_haltonSequence[VolumetricFogMaxSequenceLength];
-            RHI::Size m_froxelCount;
-            uint32_t m_tileSize = 0;
-            uint32_t m_frameIndex = 0;
-            uint32_t m_lightingChannelMask = 0;
+            Offset m_haltonSequence[VolumetricFogMaxSequenceLength]; // pre-computed Halton jitter offsets, one per temporal frame.
+            RHI::Size m_froxelCount; // froxel grid dimensions (xy = screen tiles, z = depth slices).
+            uint32_t m_tileSize = 0; // pixels per froxel tile (e.g. 8 for High quality).
+            uint32_t m_frameIndex = 0; // monotonically increasing frame counter, wraps at sequenceLength.
+            uint32_t m_lightingChannelMask = 0; // bitmask selecting which lighting layers contribute to in-scattering.
 #define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue) ValueType MemberName;
 
 #include <Atom/Feature/ParamMacros/MapAllCommon.inl>
@@ -121,7 +124,7 @@ namespace AZ::Render
 #include <Atom/Feature/VolumetricFog/VolumetricFogSRGConstants.inl>
 #include <Atom/Feature/ParamMacros/EndParams.inl>
 
-            uint32_t m_enabled = 0;
+            uint32_t m_enabled = 0; // 0/1 toggle sent to the shader to short-circuit the composite pass.
             float m_padding0 = 0.0f;
         };
 
@@ -136,28 +139,33 @@ namespace AZ::Render
         void OnSettingsChanged();
         void UpdatePasses(AZ::RPI::RenderPipeline* renderPipeline);
         void UpdateSceneSrgConstants();
+        //! Creates draw packets for the transparent depth min/max pre-pass that positions one screen-space quad per froxel slice.
         void BuildDrawItems();
+        //! Creates draw items for the transparent depth min/max pre-pass that positions one screen-space quad per froxel slice.
         AZ::RHI::DrawPacket* BuildDrawItem(float depth, RHI::DrawListTag tag, const AZ::RPI::PipelineStateForDraw* pipelineState);
+        //! Compiles pipeline states for the two draw list tags (depthTransparentMin / depthTransparentMax).
         AZ::RPI::PipelineStateForDraw* BuildPipeline(RHI::DrawListTag tag, const Data::Instance<RPI::Shader>& shader);
+        //! Compiles pipeline states for the two draw list tags (depthTransparentMin / depthTransparentMax).
         void BuildPipelines();
         bool LoadShaders();
         void ResetShaderResources();
+        //! Generates the Halton low-discrepancy jitter sequence for temporal anti-aliasing.
         void SetupSubPixelOffsets(uint32_t haltonX, uint32_t haltonY, uint32_t haltonZ, uint32_t length);
+        //! Enables or disables child passes based on the current Enable setting.
         void SetPassesEnabled();
 
         VolumetricFogSettings m_settings;
 
-        // Indicates that the srg indices were set
-        bool m_needUpdate = true;
-        bool m_buildDrawPackets = false;
+        bool m_needUpdate = true; // set to true when SRG index cache must be rebuilt.
+        bool m_buildDrawPackets = false; // set when froxel size changes and draw packets must be rebuilt.
         RPI::ParentPass* m_froxelParentPass = nullptr;
         FroxelPass* m_injectPass = nullptr;
         RPI::Pass* m_froxelCompositePass = nullptr;
         AZ::RPI::RenderPipeline* m_renderPipeline = nullptr;
         Data::Instance<RPI::ShaderResourceGroup> m_sceneSrg;
-        AZStd::array<AZ::RHI::DrawListTag, 2> m_drawListTags;
+        AZStd::array<AZ::RHI::DrawListTag, 2> m_drawListTags; // one tag per transparent depth pass (min/max).
         AZStd::array<AZ::Name, 2> m_drawListTagNames = { AZ::Name("depthTransparentMin"), AZ::Name("depthTransparentMax") };
-        AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::DrawPacket>,2> m_drawPackets;
+        AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::DrawPacket>,2> m_drawPackets; // pre-built draw packets submitted each Render() call.
         AZStd::array<AZ::RPI::Ptr<AZ::RPI::PipelineStateForDraw>, 2> m_meshPipelineStates;
         AZStd::array<AZ::Data::Instance<AZ::RPI::Shader>, 2> m_shaders;
     };

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/VolumetricFogFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/VolumetricFogFeatureProcessor.h
@@ -18,12 +18,10 @@
 #include <AzCore/std/containers/vector.h>
 
 #include <Atom/RHI.Reflect/ShaderResourceGroupLayoutDescriptor.h>
-
 #include <Atom/RPI.Public/Shader/Shader.h>
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 #include <Atom/RPI.Public/Image/StreamingImage.h>
 #include <Atom/RPI.Public/PipelineState.h>
-
 
 #include <Atom/Feature/VolumetricFog/VolumetricFogFeatureProcessorInterface.h>
 
@@ -139,6 +137,7 @@ namespace AZ::Render
         void OnSettingsChanged();
         void UpdatePasses(AZ::RPI::RenderPipeline* renderPipeline);
         void UpdateSceneSrgConstants();
+        void UpdateFroxelSize();
         //! Creates draw packets for the transparent depth min/max pre-pass that positions one screen-space quad per froxel slice.
         void BuildDrawItems();
         //! Creates draw items for the transparent depth min/max pre-pass that positions one screen-space quad per froxel slice.

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/VolumetricFogFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/VolumetricFogFeatureProcessor.h
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Math/Color.h>
+#include <AzCore/Math/Transform.h>
+#include <AzCore/Math/Vector2.h>
+#include <AzCore/Math/Vector3.h>
+
+#include <AzCore/Asset/AssetCommon.h>
+#include <AzCore/RTTI/ReflectContext.h>
+#include <AzCore/std/containers/vector.h>
+
+#include <Atom/RHI.Reflect/ShaderResourceGroupLayoutDescriptor.h>
+
+#include <Atom/RPI.Public/Shader/Shader.h>
+#include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
+#include <Atom/RPI.Public/Image/StreamingImage.h>
+#include <Atom/RPI.Public/PipelineState.h>
+
+
+#include <Atom/Feature/VolumetricFog/VolumetricFogFeatureProcessorInterface.h>
+
+namespace AZ::Render
+{
+    class FroxelPass;
+
+    class VolumetricFogFeatureProcessor final
+        : public VolumetricFogFeatureProcessorInterface
+        , protected AZ::Data::AssetBus::MultiHandler
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(VolumetricFogFeatureProcessor, AZ::SystemAllocator)
+
+        AZ_RTTI(AZ::Render::VolumetricFogFeatureProcessor, "{0A638612-B357-4C41-B1E5-0DD86B8310C6}", AZ::Render::VolumetricFogFeatureProcessorInterface);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        VolumetricFogFeatureProcessor() = default;
+        virtual ~VolumetricFogFeatureProcessor() = default;
+
+        //! FeatureProcessor 
+        void Activate() override;
+        void Deactivate() override;
+        void AddRenderPasses(RPI::RenderPipeline* renderPipeline) override;
+        void Render(const RenderPacket& packet) override;
+        void Simulate(const FeatureProcessor::SimulatePacket& packet) override;
+
+        //! VolumetricFogFeatureProcessorInterface — global fog
+        const VolumetricFogSettings& GetSettings() const override;
+
+#include <Atom/Feature/ParamMacros/StartParamFunctionsOverride.inl>
+#include <Atom/Feature/VolumetricFog/VolumetricFogParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+
+    private:
+        struct Offset
+        {
+            Offset() = default;
+
+            // Constructor for implicit conversion from array output by HaltonSequence.
+            Offset(AZStd::array<float, 3> offsets)
+                : m_xOffset(offsets[0])
+                , m_yOffset(offsets[1])
+                , m_zOffset(offsets[2]){};
+
+            float m_xOffset = 0.0f;
+            float m_yOffset = 0.0f;
+            float m_zOffset = 0.0f;
+            float m_padding0;
+        };
+
+        RHI::ShaderInputConstantIndex m_shaderConstantsIndex;
+        RHI::ShaderInputConstantIndex m_shaderConstantsVolumeIndex;
+
+        //---------------------------------------------------------
+        // Generate all Image members instances
+        // Set all macros to be empty, but override the texture for defining image members
+#include <Atom/Feature/ParamMacros/MapParamEmpty.inl>
+
+        // Macro to replace only the image macro for defining only image resources
+#undef AZ_GFX_TEXTURE_ASSET_PARAM
+#define AZ_GFX_TEXTURE_ASSET_PARAM(Name, MemberName, DefaultValue)              \
+            RHI::ShaderInputImageIndex MemberName##SrgIndex;                    \
+
+#include <Atom/Feature/VolumetricFog/VolumetricFogParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+
+#include <Atom/Feature/ParamMacros/MapParamEmpty.inl>
+
+        // Macro to replace only the image macro for defining only image resources
+#undef AZ_GFX_TEXTURE_ASSET_PARAM
+#define AZ_GFX_TEXTURE_ASSET_PARAM(Name, MemberName, DefaultValue)            \
+            Data::Instance<AZ::RPI::StreamingImage> MemberName##Image;        \
+
+#include <Atom/Feature/VolumetricFog/VolumetricFogParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+        //---------------------------------------------------------
+
+        // Volumetric Fog scene global constants
+        struct VolumetricFogConstants
+        {
+            Offset m_haltonSequence[VolumetricFogMaxSequenceLength];
+            RHI::Size m_froxelCount;
+            uint32_t m_tileSize = 0;
+            uint32_t m_frameIndex = 0;
+            uint32_t m_lightingChannelMask = 0;
+#define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue) ValueType MemberName;
+
+#include <Atom/Feature/ParamMacros/MapAllCommon.inl>
+
+#undef AZ_GFX_VEC3_PARAM
+#define AZ_GFX_VEC3_PARAM(Name, MemberName, DefaultValue) AZStd::array<float, 3> MemberName;
+
+#include <Atom/Feature/VolumetricFog/VolumetricFogSRGConstants.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+
+            uint32_t m_enabled = 0;
+            float m_padding0 = 0.0f;
+        };
+
+        VolumetricFogConstants m_sceneSrgGlobalConstants;
+        VolumetricFogVolumeConstants m_sceneSrgVolumeConstants;
+
+        //! RPI::SceneNotificationBus::Handler
+        void OnRenderPipelineChanged(AZ::RPI::RenderPipeline* pipeline, RPI::SceneNotification::RenderPipelineChangeType changeType) override;
+        // AZ::Data::AssetBus override
+        void OnAssetReloaded(AZ::Data::Asset<AZ::Data::AssetData> asset) override;
+
+        void OnSettingsChanged();
+        void UpdatePasses(AZ::RPI::RenderPipeline* renderPipeline);
+        void UpdateSceneSrgConstants();
+        void BuildDrawItems();
+        AZ::RHI::DrawPacket* BuildDrawItem(float depth, RHI::DrawListTag tag, const AZ::RPI::PipelineStateForDraw* pipelineState);
+        AZ::RPI::PipelineStateForDraw* BuildPipeline(RHI::DrawListTag tag, const Data::Instance<RPI::Shader>& shader);
+        void BuildPipelines();
+        bool LoadShaders();
+        void ResetShaderResources();
+        void SetupSubPixelOffsets(uint32_t haltonX, uint32_t haltonY, uint32_t haltonZ, uint32_t length);
+        void SetPassesEnabled();
+
+        VolumetricFogSettings m_settings;
+
+        // Indicates that the srg indices were set
+        bool m_needUpdate = true;
+        bool m_buildDrawPackets = false;
+        RPI::ParentPass* m_froxelParentPass = nullptr;
+        FroxelPass* m_injectPass = nullptr;
+        RPI::Pass* m_froxelCompositePass = nullptr;
+        AZ::RPI::RenderPipeline* m_renderPipeline = nullptr;
+        Data::Instance<RPI::ShaderResourceGroup> m_sceneSrg;
+        AZStd::array<AZ::RHI::DrawListTag, 2> m_drawListTags;
+        AZStd::array<AZ::Name, 2> m_drawListTagNames = { AZ::Name("depthTransparentMin"), AZ::Name("depthTransparentMax") };
+        AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::DrawPacket>,2> m_drawPackets;
+        AZStd::array<AZ::RPI::Ptr<AZ::RPI::PipelineStateForDraw>, 2> m_meshPipelineStates;
+        AZStd::array<AZ::Data::Instance<AZ::RPI::Shader>, 2> m_shaders;
+    };
+}

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/VolumetricFogUtils.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/VolumetricFogUtils.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <VolumetricFog/VolumetricFogUtils.h>
+
+namespace AZ::Render::VolumetricFog
+{
+    RHI::Size ToFroxelSize(VolumetricFogQuality quality)
+    {
+        switch (quality)
+        {
+        case VolumetricFogQuality::Low:
+            return RHI::Size(16, 16, 64);
+        case VolumetricFogQuality::Mid:
+            return RHI::Size(8, 8, 128);
+        case VolumetricFogQuality::High:
+            return RHI::Size(4, 4, 128);
+        default:
+            AZ_Assert(false, "Invalid VolumetricFogQuality value %d", static_cast<int>(quality));
+            return RHI::Size();
+        }
+    }    
+} // namespace AZ::Render::VolumetricFog

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/VolumetricFogUtils.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/VolumetricFogUtils.cpp
@@ -12,6 +12,8 @@ namespace AZ::Render::VolumetricFog
 {
     RHI::Size ToFroxelSize(VolumetricFogQuality quality)
     {
+        // The width and height are the pixel size of a froxel
+        // The depth is the number of froxels in the z direction
         switch (quality)
         {
         case VolumetricFogQuality::Low:

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/VolumetricFogUtils.h
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/VolumetricFogUtils.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI.Reflect/Size.h>
+#include <AzCore/Name/Name.h>
+#include <Atom/Feature/VolumetricFog/VolumetricFogConstants.h>
+
+namespace AZ::Render::VolumetricFog
+{
+    RHI::Size ToFroxelSize(VolumetricFogQuality quality);
+}   // namespace AZ::Render::VolumetricFog

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/VolumetricFogUtils.h
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/VolumetricFogUtils.h
@@ -13,5 +13,6 @@
 
 namespace AZ::Render::VolumetricFog
 {
+    //! Maps a VolumetricFogQuality enum to the corresponding froxel grid Size (xy tile dims × z slices). Low = 16×16×64, Mid = 8×8×128, High = 4×4×128.
     RHI::Size ToFroxelSize(VolumetricFogQuality quality);
 }   // namespace AZ::Render::VolumetricFog

--- a/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/VolumetricFogUtils.h
+++ b/Gems/Atom/Feature/Common/Code/Source/VolumetricFog/VolumetricFogUtils.h
@@ -13,6 +13,6 @@
 
 namespace AZ::Render::VolumetricFog
 {
-    //! Maps a VolumetricFogQuality enum to the corresponding froxel grid Size (xy tile dims × z slices). Low = 16×16×64, Mid = 8×8×128, High = 4×4×128.
+    //! Maps a VolumetricFogQuality enum to the corresponding froxel grid Size (xy tile dims x z slices). Low = 16x16x64, Mid = 8x8x128, High = 4x4x128.
     RHI::Size ToFroxelSize(VolumetricFogQuality quality);
 }   // namespace AZ::Render::VolumetricFog

--- a/Gems/Atom/Feature/Common/Code/atom_feature_common_files.cmake
+++ b/Gems/Atom/Feature/Common/Code/atom_feature_common_files.cmake
@@ -363,6 +363,18 @@ set(FILES
     Source/SplashScreen/SplashScreenPass.h
     Source/TransformService/TransformServiceFeatureProcessor.cpp
     Source/Utils/GpuBufferHandler.cpp
+#if defined(CARBONATED)
+    Source/VolumetricFog/VolumetricFogFeatureProcessor.cpp
+    Source/VolumetricFog/VolumetricFogFeatureProcessor.h
+    Source/VolumetricFog/FogVolumeFeatureProcessor.cpp
+    Source/VolumetricFog/FogVolumeFeatureProcessor.h
+    Source/VolumetricFog/FroxelPass.cpp
+    Source/VolumetricFog/FroxelPass.h
+    Source/VolumetricFog/FroxelIntegratePass.cpp
+    Source/VolumetricFog/FroxelIntegratePass.h
+    Source/VolumetricFog/VolumetricFogUtils.cpp
+    Source/VolumetricFog/VolumetricFogUtils.h    
+#endif
 )
 
 set(SKIP_UNITY_BUILD_INCLUSION_FILES

--- a/Gems/Atom/Feature/Common/Code/atom_feature_common_files.cmake
+++ b/Gems/Atom/Feature/Common/Code/atom_feature_common_files.cmake
@@ -183,10 +183,10 @@ set(FILES
     Source/OcclusionCullingPlane/OcclusionCullingPlane.cpp
     Source/Silhouette/SilhouetteFeatureProcessor.cpp
     Source/Silhouette/SilhouetteFeatureProcessor.h
-#if defined(CARBONATED)
+# Begin CARBONATED
     Source/Silhouette/SilhouetteJFAStepParentPass.cpp
     Source/Silhouette/SilhouetteJFAStepParentPass.h
-#endif
+# End CARBONATED
     Source/PostProcess/PostProcessBase.cpp
     Source/PostProcess/PostProcessBase.h
     Source/PostProcess/PostProcessFeatureProcessor.cpp
@@ -363,7 +363,7 @@ set(FILES
     Source/SplashScreen/SplashScreenPass.h
     Source/TransformService/TransformServiceFeatureProcessor.cpp
     Source/Utils/GpuBufferHandler.cpp
-#if defined(CARBONATED)
+# Begin CARBONATED
     Source/VolumetricFog/VolumetricFogFeatureProcessor.cpp
     Source/VolumetricFog/VolumetricFogFeatureProcessor.h
     Source/VolumetricFog/FogVolumeFeatureProcessor.cpp
@@ -374,7 +374,7 @@ set(FILES
     Source/VolumetricFog/FroxelIntegratePass.h
     Source/VolumetricFog/VolumetricFogUtils.cpp
     Source/VolumetricFog/VolumetricFogUtils.h    
-#endif
+# End CARBONATED
 )
 
 set(SKIP_UNITY_BUILD_INCLUSION_FILES

--- a/Gems/Atom/Feature/Common/Code/atom_feature_common_public_files.cmake
+++ b/Gems/Atom/Feature/Common/Code/atom_feature_common_public_files.cmake
@@ -99,6 +99,14 @@ set(FILES
     Include/Atom/Feature/TransformService/TransformServiceFeatureProcessorInterface.h
     Include/Atom/Feature/SkyBox/SkyBoxFeatureProcessorInterface.h
     Include/Atom/Feature/SkyAtmosphere/SkyAtmosphereFeatureProcessorInterface.h
+#if defined(CARBONATED)
+    Include/Atom/Feature/VolumetricFog/VolumetricFogFeatureProcessorInterface.h
+    Include/Atom/Feature/VolumetricFog/FogVolumeFeatureProcessorInterface.h
+    Include/Atom/Feature/VolumetricFog/VolumetricFogParams.inl
+    Include/Atom/Feature/VolumetricFog/FogVolumeParams.inl
+    Include/Atom/Feature/VolumetricFog/VolumetricFogConstants.h
+    Include/Atom/Feature/VolumetricFog/VolumetricFogSettings.h
+#endif
     Source/CoreLights/PhotometricValue.cpp
     Source/MorphTargets/MorphTargetInputBuffers.cpp
     Source/SkinnedMesh/SkinnedMeshInputBuffers.cpp

--- a/Gems/Atom/Feature/Common/Code/atom_feature_common_public_files.cmake
+++ b/Gems/Atom/Feature/Common/Code/atom_feature_common_public_files.cmake
@@ -99,14 +99,14 @@ set(FILES
     Include/Atom/Feature/TransformService/TransformServiceFeatureProcessorInterface.h
     Include/Atom/Feature/SkyBox/SkyBoxFeatureProcessorInterface.h
     Include/Atom/Feature/SkyAtmosphere/SkyAtmosphereFeatureProcessorInterface.h
-#if defined(CARBONATED)
+# Begin CARBONATED
     Include/Atom/Feature/VolumetricFog/VolumetricFogFeatureProcessorInterface.h
     Include/Atom/Feature/VolumetricFog/FogVolumeFeatureProcessorInterface.h
     Include/Atom/Feature/VolumetricFog/VolumetricFogParams.inl
     Include/Atom/Feature/VolumetricFog/FogVolumeParams.inl
     Include/Atom/Feature/VolumetricFog/VolumetricFogConstants.h
     Include/Atom/Feature/VolumetricFog/VolumetricFogSettings.h
-#endif
+# End CARBONATED
     Source/CoreLights/PhotometricValue.cpp
     Source/MorphTargets/MorphTargetInputBuffers.cpp
     Source/SkinnedMesh/SkinnedMeshInputBuffers.cpp

--- a/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroupData.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroupData.cpp
@@ -145,7 +145,16 @@ namespace AZ::RHI
             bool isValidAll = true;
             for (size_t i = 0; i < imageViews.size(); ++i)
             {
+#if defined(CARBONATED)
+                bool isValid = true;
+                if (imageViews[i])
+                {
+                    isValid = ValidateImageViewAccess<ShaderInputImageUnboundedArrayIndex, ShaderInputImageUnboundedArrayDescriptor>(
+                        inputIndex, imageViews[i], static_cast<uint32_t>(i));
+                }
+#else
                 const bool isValid = ValidateImageViewAccess<ShaderInputImageUnboundedArrayIndex, ShaderInputImageUnboundedArrayDescriptor>(inputIndex, imageViews[i], static_cast<uint32_t>(i));
+#endif
                 if (isValid)
                 {
                     m_imageViewsUnboundedArray.push_back(imageViews[i]);

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Framebuffer.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Framebuffer.cpp
@@ -151,6 +151,11 @@ namespace AZ
             uint32_t maxLayers = 1;
             for (size_t index = 0; index < imageViews.size(); ++index)
             {
+#if defined(CARBONATED)
+                const auto& vkRange = m_attachments[index]->GetVkImageSubresourceRange();
+                imageViews[index] = m_attachments[index]->GetNativeImageView();
+                maxLayers = AZStd::max(maxLayers, vkRange.layerCount);
+#else
                 imageViews[index] = m_attachments[index]->GetNativeImageView();
                 if (m_attachments[index]->GetDescriptor().m_isArray)
                 {
@@ -160,6 +165,7 @@ namespace AZ
                             m_attachments[index]->GetImageSubresourceRange().m_arraySliceMax -
                             m_attachments[index]->GetImageSubresourceRange().m_arraySliceMin + 1));
                 }
+#endif
             }
 
             VkFramebufferCreateInfo createInfo{};

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/ImageView.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/ImageView.cpp
@@ -93,14 +93,21 @@ namespace AZ
             }
 
             const VkImageViewType imageViewType = GetImageViewType(image);
+#if defined(CARBONATED)
+            m_vkCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+            m_vkCreateInfo.pNext = nullptr;
+            m_vkCreateInfo.flags = createFlags;
+            m_vkCreateInfo.image = image.GetNativeImage();
+            m_vkCreateInfo.viewType = imageViewType;
+            m_vkCreateInfo.format = ConvertFormat(m_format);
+            m_vkCreateInfo.components = ConvertComponentMapping(componentMapping);
+            m_vkCreateInfo.subresourceRange = BuildImageSubresourceRange(imageViewType, aspectFlags);
+
+            const VkResult result =
+                device.GetContext().CreateImageView(device.GetNativeDevice(), &m_vkCreateInfo, VkSystemAllocator::Get(), &m_vkImageView);
+#else
             BuildImageSubresourceRange(imageViewType, aspectFlags);
-            const RHI::ImageSubresourceRange& range = GetImageSubresourceRange();
-            VkImageSubresourceRange vkRange{};
-            vkRange.baseMipLevel = range.m_mipSliceMin;
-            vkRange.levelCount = range.m_mipSliceMax - range.m_mipSliceMin + 1;
-            vkRange.baseArrayLayer = range.m_arraySliceMin;
-            vkRange.layerCount = range.m_arraySliceMax - range.m_arraySliceMin + 1;
-            vkRange.aspectMask = aspectFlags;
+
             VkImageViewCreateInfo createInfo{};
             createInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
             createInfo.pNext = nullptr;
@@ -109,10 +116,11 @@ namespace AZ
             createInfo.viewType = imageViewType;
             createInfo.format = ConvertFormat(m_format);
             createInfo.components = ConvertComponentMapping(componentMapping);
-            createInfo.subresourceRange = vkRange;
+            createInfo.subresourceRange = m_vkImageSubResourceRange;
 
             const VkResult result =
                 device.GetContext().CreateImageView(device.GetNativeDevice(), &createInfo, VkSystemAllocator::Get(), &m_vkImageView);
+#endif
             AssertSuccess(result);
             RETURN_RESULT_IF_UNSUCCESSFUL(ConvertResult(result));
 
@@ -125,7 +133,15 @@ namespace AZ
                                     viewDescriptor.m_aspectFlags != RHI::ImageAspectFlags::Depth &&
                                     viewDescriptor.m_aspectFlags != RHI::ImageAspectFlags::Stencil;
 
+#if defined(CARBONATED)
+            bool isArray = m_vkCreateInfo.subresourceRange.layerCount > 1;
+#endif
+
+#if defined(CARBONATED)
+            if (device.GetBindlessDescriptorPool().IsInitialized() && !isArray && !isDSRendertarget)
+#else
             if (device.GetBindlessDescriptorPool().IsInitialized() && !viewDescriptor.m_isArray && !isDSRendertarget)
+#endif
             {
                 if (!viewDescriptor.m_isCubemap)
                 {
@@ -276,13 +292,16 @@ namespace AZ
                 // One of the main usage of depth slices of a 3D Image would be to set the slice to a Framebuffer,
                 // and here we give an image view of 2D or 2D array.
                 AZ_Assert(arrayLayers == 1 && samples == 1, "Both of arrayLayers and samples must be 1 for Image3D.");
+#if defined(CARBONATED)
                 if (physicalDevice.IsFeatureSupported(DeviceFeature::Compatible2dArrayTexture))
                 {
                     if (imgViewDesc.m_depthSliceMin == imgViewDesc.m_depthSliceMax)
                     {
                         return VK_IMAGE_VIEW_TYPE_2D;
                     }
-                    else if (imgViewDesc.m_depthSliceMin == 0 && imgViewDesc.m_depthSliceMax + 1 >= depth)
+
+                    if (!RHI::CheckBitsAll(imgViewDesc.m_overrideBindFlags, RHI::ImageBindFlags::Color) &&
+                        (imgViewDesc.m_depthSliceMin == 0 && imgViewDesc.m_depthSliceMax + 1 >= depth))
                     {
                         // If ImageView's depth slice range covers the one of the base 3D Image,
                         // it returns the view of the entire depth slices.
@@ -295,8 +314,35 @@ namespace AZ
                 }
                 else
                 {
+                    AZ_Assert(
+                        !RHI::CheckBitsAll(imgViewDesc.m_overrideBindFlags, RHI::ImageBindFlags::Color),
+                        "Can't use 3D image as RenderTarget because the Compatible2dArrayTexture is not available");
                     return VK_IMAGE_VIEW_TYPE_3D;
                 }
+#else
+                if (physicalDevice.IsFeatureSupported(DeviceFeature::Compatible2dArrayTexture))
+                {
+                    if (!RHI::CheckBitsAll(imgViewDesc.m_overrideBindFlags, RHI::ImageBindFlags::Color) &&
+                        (imgViewDesc.m_depthSliceMin == 0 && imgViewDesc.m_depthSliceMax + 1 >= depth))
+                    {
+                        // If ImageView's depth slice range covers the one of the base 3D Image,
+                        // it returns the view of the entire depth slices.
+                        return VK_IMAGE_VIEW_TYPE_3D;
+                    }
+                    else if (imgViewDesc.m_depthSliceMin == imgViewDesc.m_depthSliceMax)
+                    {
+                        return VK_IMAGE_VIEW_TYPE_2D;
+                    }
+                    else
+                    {
+                        return VK_IMAGE_VIEW_TYPE_2D_ARRAY;
+                    }
+                }
+                else
+                {
+                    return VK_IMAGE_VIEW_TYPE_3D;
+                }
+#endif
             }
             default:
             {
@@ -306,7 +352,11 @@ namespace AZ
             }
         }
 
+#if defined(CARBONATED)
+        VkImageSubresourceRange ImageView::BuildImageSubresourceRange(VkImageViewType imageViewType, VkImageAspectFlags aspectFlags)
+#else
         void ImageView::BuildImageSubresourceRange(VkImageViewType imageViewType, VkImageAspectFlags aspectFlags)
+#endif
         {
             const Image& image = static_cast<const Image&>(GetImage());
             const RHI::ImageDescriptor& imageDesc = image.GetDescriptor();
@@ -346,16 +396,26 @@ namespace AZ
                 }
             }
 
-            m_vkImageSubResourceRange.aspectMask = aspectFlags;
-            m_vkImageSubResourceRange.baseArrayLayer = range.m_arraySliceMin;
-            m_vkImageSubResourceRange.layerCount = range.m_arraySliceMax - range.m_arraySliceMin + 1;
-            m_vkImageSubResourceRange.baseMipLevel = range.m_mipSliceMin;
-            m_vkImageSubResourceRange.levelCount = range.m_mipSliceMax - range.m_mipSliceMin + 1;            
+            VkImageSubresourceRange vkRange = {};
+            vkRange.aspectMask = aspectFlags;
+            vkRange.baseArrayLayer = range.m_arraySliceMin;
+            vkRange.layerCount = range.m_arraySliceMax - range.m_arraySliceMin + 1;
+            vkRange.baseMipLevel = range.m_mipSliceMin;
+            vkRange.levelCount = range.m_mipSliceMax - range.m_mipSliceMin + 1;
+#if defined(CARBONATED)
+            return vkRange;
+#else
+            m_vkImageSubResourceRange = vkRange;
+#endif
         }
 
         const VkImageSubresourceRange& ImageView::GetVkImageSubresourceRange() const
         {
+#if defined(CARBONATED)
+            return m_vkCreateInfo.subresourceRange;
+#else
             return m_vkImageSubResourceRange;
+#endif
         }
     }
 }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/ImageView.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/ImageView.cpp
@@ -107,16 +107,20 @@ namespace AZ
                 device.GetContext().CreateImageView(device.GetNativeDevice(), &m_vkCreateInfo, VkSystemAllocator::Get(), &m_vkImageView);
 #else
             BuildImageSubresourceRange(imageViewType, aspectFlags);
-
+            const RHI::ImageSubresourceRange& range = GetImageSubresourceRange();
+            VkImageSubresourceRange vkRange{};
+            vkRange.baseMipLevel = range.m_mipSliceMin;
+            vkRange.levelCount = range.m_mipSliceMax - range.m_mipSliceMin + 1;
+            vkRange.baseArrayLayer = range.m_arraySliceMin;
+            vkRange.layerCount = range.m_arraySliceMax - range.m_arraySliceMin + 1;
+            vkRange.aspectMask = aspectFlags;
             VkImageViewCreateInfo createInfo{};
             createInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
             createInfo.pNext = nullptr;
-            createInfo.flags = createFlags;
-            createInfo.image = image.GetNativeImage();
             createInfo.viewType = imageViewType;
             createInfo.format = ConvertFormat(m_format);
             createInfo.components = ConvertComponentMapping(componentMapping);
-            createInfo.subresourceRange = m_vkImageSubResourceRange;
+            createInfo.subresourceRange = vkRange;
 
             const VkResult result =
                 device.GetContext().CreateImageView(device.GetNativeDevice(), &createInfo, VkSystemAllocator::Get(), &m_vkImageView);
@@ -134,7 +138,7 @@ namespace AZ
                                     viewDescriptor.m_aspectFlags != RHI::ImageAspectFlags::Stencil;
 
 #if defined(CARBONATED)
-            bool isArray = m_vkCreateInfo.subresourceRange.layerCount > 1;
+            const bool isArray = m_vkCreateInfo.subresourceRange.layerCount > 1;
 #endif
 
 #if defined(CARBONATED)
@@ -322,16 +326,15 @@ namespace AZ
 #else
                 if (physicalDevice.IsFeatureSupported(DeviceFeature::Compatible2dArrayTexture))
                 {
-                    if (!RHI::CheckBitsAll(imgViewDesc.m_overrideBindFlags, RHI::ImageBindFlags::Color) &&
-                        (imgViewDesc.m_depthSliceMin == 0 && imgViewDesc.m_depthSliceMax + 1 >= depth))
+                    if (imgViewDesc.m_depthSliceMin == imgViewDesc.m_depthSliceMax)
+                    {
+                        return VK_IMAGE_VIEW_TYPE_2D;
+                    }
+                    else if (imgViewDesc.m_depthSliceMin == 0 && imgViewDesc.m_depthSliceMax + 1 >= depth)
                     {
                         // If ImageView's depth slice range covers the one of the base 3D Image,
                         // it returns the view of the entire depth slices.
                         return VK_IMAGE_VIEW_TYPE_3D;
-                    }
-                    else if (imgViewDesc.m_depthSliceMin == imgViewDesc.m_depthSliceMax)
-                    {
-                        return VK_IMAGE_VIEW_TYPE_2D;
                     }
                     else
                     {
@@ -395,17 +398,21 @@ namespace AZ
                     break;
                 }
             }
-
+#if defined(CARBONATED)
             VkImageSubresourceRange vkRange = {};
             vkRange.aspectMask = aspectFlags;
             vkRange.baseArrayLayer = range.m_arraySliceMin;
             vkRange.layerCount = range.m_arraySliceMax - range.m_arraySliceMin + 1;
             vkRange.baseMipLevel = range.m_mipSliceMin;
             vkRange.levelCount = range.m_mipSliceMax - range.m_mipSliceMin + 1;
-#if defined(CARBONATED)
             return vkRange;
 #else
-            m_vkImageSubResourceRange = vkRange;
+
+            m_vkImageSubResourceRange.aspectMask = aspectFlags;
+            m_vkImageSubResourceRange.baseArrayLayer = range.m_arraySliceMin;
+            m_vkImageSubResourceRange.layerCount = range.m_arraySliceMax - range.m_arraySliceMin + 1;
+            m_vkImageSubResourceRange.baseMipLevel = range.m_mipSliceMin;
+            m_vkImageSubResourceRange.levelCount = range.m_mipSliceMax - range.m_mipSliceMin + 1;
 #endif
         }
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/ImageView.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/ImageView.cpp
@@ -117,6 +117,8 @@ namespace AZ
             VkImageViewCreateInfo createInfo{};
             createInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
             createInfo.pNext = nullptr;
+            createInfo.flags = createFlags;
+            createInfo.image = image.GetNativeImage();
             createInfo.viewType = imageViewType;
             createInfo.format = ConvertFormat(m_format);
             createInfo.components = ConvertComponentMapping(componentMapping);

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/ImageView.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/ImageView.h
@@ -55,14 +55,22 @@ namespace AZ
             //////////////////////////////////////////////////////////////////////////
 
             VkImageViewType GetImageViewType(const Image& image) const;
+#if defined(CARBONATED)
+            VkImageSubresourceRange BuildImageSubresourceRange(VkImageViewType imageViewType, VkImageAspectFlags aspectFlags);
+#else
             void BuildImageSubresourceRange(VkImageViewType imageViewType, VkImageAspectFlags aspectFlags);
+#endif
             void ReleaseView();
             void ReleaseBindlessIndices();
 
             VkImageView m_vkImageView = VK_NULL_HANDLE;
             RHI::Format m_format = RHI::Format::Unknown;
             RHI::ImageSubresourceRange m_imageSubresourceRange;
+#if defined(CARBONATED)
+            VkImageViewCreateInfo m_vkCreateInfo = {};
+#else
             VkImageSubresourceRange m_vkImageSubResourceRange;
+#endif
 
             uint32_t m_readIndex = InvalidBindlessIndex;
             uint32_t m_readWriteIndex = InvalidBindlessIndex;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
@@ -334,6 +334,9 @@ namespace AZ
                 VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME,
                 VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME,
                 VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME,
+#if defined(CARBONATED)
+                VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME,
+#endif
             } };
 
             [[maybe_unused]] uint32_t optionalExtensionCount = aznumeric_cast<uint32_t>(optionalExtensions.size());

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.h
@@ -66,6 +66,9 @@ namespace AZ
             FragmentDensityMap,
             Renderpass2,
             TimelineSempahore,
+#if defined(CARBONATED)
+            ShaderViewportIndexLayer,
+#endif
             Count
         };
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/ComputePass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/ComputePass.h
@@ -95,6 +95,10 @@ namespace AZ
             // to call SetTargetThreadCounts(), update shader constants, etc.
             virtual void OnShaderReloadedInternal();
             ComputeShaderReloadedCallback m_shaderReloadedCallback = nullptr;
+
+#if defined(CARBONATED)
+            RPI::ShaderOptionGroup m_shaderOptions;
+#endif
         };
     }   // namespace RPI
 }   // namespace AZ

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/StreamingImageAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Image/StreamingImageAsset.h
@@ -157,3 +157,20 @@ namespace AZ
         };
     }
 }
+
+#if defined(CARBONATED)
+namespace AZStd
+{
+    // hash specialization
+    template<>
+    struct hash<AZ::Data::Asset<AZ::RPI::StreamingImageAsset>>
+    {
+        using argument_type = AZ::Uuid;
+        using result_type = size_t;
+        size_t operator()(const AZ::Data::Asset<AZ::RPI::StreamingImageAsset>& asset) const
+        {
+            return asset.GetId().m_guid.GetHash();
+        }
+    };
+} // namespace AZStd
+#endif

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ComputePass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ComputePass.cpp
@@ -139,6 +139,20 @@ namespace AZ
 
             // Setup pipeline state...
             RHI::PipelineStateDescriptorForDispatch pipelineStateDescriptor;
+#if defined(CARBONATED)
+            if (!m_shaderOptions.GetShaderOptionLayout() ||
+                m_shaderOptions.GetShaderOptionLayout()->GetHash() != m_shader->GetDefaultShaderOptions().GetShaderOptionLayout()->GetHash())
+            {
+                m_shaderOptions = m_shader->GetDefaultShaderOptions();
+            }
+            m_shader->GetDefaultVariant().ConfigurePipelineState(pipelineStateDescriptor, m_shaderOptions);
+
+            m_dispatchItem.m_pipelineState = m_shader->AcquirePipelineState(pipelineStateDescriptor);
+            if (m_drawSrg && m_shader->GetDefaultVariant().UseKeyFallback())
+            {
+                m_drawSrg->SetShaderVariantKeyFallbackValue(m_shaderOptions.GetShaderVariantKeyFallbackValue());
+            }
+#else
             ShaderOptionGroup options = m_shader->GetDefaultShaderOptions();
             m_shader->GetDefaultVariant().ConfigurePipelineState(pipelineStateDescriptor, options);
 
@@ -147,6 +161,7 @@ namespace AZ
             {
                 m_drawSrg->SetShaderVariantKeyFallbackValue(options.GetShaderVariantKeyFallbackValue());
             }
+#endif
 
             OnShaderReloadedInternal();
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderOptionGroup.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderOptionGroup.cpp
@@ -60,6 +60,13 @@ namespace AZ
 
         ShaderOptionIndex ShaderOptionGroup::FindShaderOptionIndex(const Name& optionName) const
         {
+#if defined(CARBONATED)
+            if (!m_layout)
+            {
+                return ShaderOptionIndex::Null;
+            }
+#endif
+
             return m_layout->FindShaderOptionIndex(optionName);
         }
 
@@ -83,6 +90,14 @@ namespace AZ
                 AZ_Error(DebugCategory, false, "Invalid ShaderOptionIndex");
                 return false;
             }
+
+#if defined(CARBONATED)
+            if (!m_layout)
+            {
+                AZ_Error(DebugCategory, false, "Invalid ShaderOptionLayout");
+                return false;
+            }
+#endif
 
             return true;
         }
@@ -206,6 +221,13 @@ namespace AZ
 
         void ShaderOptionGroup::SetAllToDefaultValues()
         {
+#if defined(CARBONATED)
+            if (!m_layout)
+            {
+                return;
+            }
+#endif
+
             for (auto& option : m_layout->GetShaderOptions())
             {
                 option.Set(*this, option.GetDefaultValue());                    
@@ -214,6 +236,13 @@ namespace AZ
 
         void ShaderOptionGroup::SetUnspecifiedToDefaultValues()
         {
+#if defined(CARBONATED)
+            if (!m_layout)
+            {
+                return;
+            }
+#endif
+
             for (auto& option : m_layout->GetShaderOptions())
             {
                 if (!(m_id.m_mask & option.GetBitMask()).any())
@@ -225,6 +254,13 @@ namespace AZ
 
         bool ShaderOptionGroup::IsFullySpecified() const
         {
+#if defined(CARBONATED)
+            if (!m_layout)
+            {
+                return false;
+            }
+#endif
+
             for (auto& option : m_layout->GetShaderOptions())
             {
                 if (!(m_id.m_mask & option.GetBitMask()).any())
@@ -245,6 +281,13 @@ namespace AZ
         {
             // By default the fallback value is the search key
             auto fallbackValueKey = m_id.m_key;
+
+#if defined(CARBONATED)
+            if (!m_layout)
+            {
+                return fallbackValueKey;
+            }
+#endif
 
             // However, we have to make sure that all options are set, opting for default values where missing
             for (auto& option : m_layout->GetShaderOptions())
@@ -296,6 +339,13 @@ namespace AZ
         AZStd::string ShaderOptionGroup::ToString() const
         {
             AZStd::string s;
+#if defined(CARBONATED)
+            if (!m_layout)
+            {
+                return s;
+            }
+#endif
+
             for (int i = 0; i < GetShaderOptionLayout()->GetShaderOptionCount(); ++i)
             {
                 ShaderOptionIndex index{i};
@@ -323,6 +373,14 @@ namespace AZ
 
         const AZStd::vector<AZ::RPI::ShaderOptionDescriptor>& ShaderOptionGroup::GetShaderOptionDescriptors() const
         {
+#if defined(CARBONATED)
+            if (!m_layout)
+            {
+                static const AZStd::vector<AZ::RPI::ShaderOptionDescriptor> invalidDescriptors;
+                return invalidDescriptors;
+            }
+#endif
+
             return m_layout->GetShaderOptions();
         }
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/VolumetricFog/FogVolumeBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/VolumetricFog/FogVolumeBus.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Atom/Feature/VolumetricFog/VolumetricFogConstants.h>
+#include <AzCore/Component/ComponentBus.h>
+#include <AzCore/Math/Color.h>
+#include <AzCore/Math/Vector3.h>
+
+namespace AZ::Render
+{
+    class FogVolumeRequests : public AZ::ComponentBus
+    {
+    public:
+        // Auto-gen virtual getter/setter declarations
+#define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)  \
+        virtual ValueType Get##Name() const = 0;                        \
+        virtual void Set##Name(ValueType val) = 0;                      \
+
+#include <Atom/Feature/ParamMacros/MapParamCommon.inl>
+#include <Atom/Feature/VolumetricFog/FogVolumeParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+    };
+
+    using FogVolumeRequestsBus = AZ::EBus<FogVolumeRequests>;
+
+} // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/VolumetricFog/FogVolumeBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/VolumetricFog/FogVolumeBus.h
@@ -15,6 +15,7 @@
 
 namespace AZ::Render
 {
+    //! EBus request interface for the FogVolume component (local volume overrides).
     class FogVolumeRequests : public AZ::ComponentBus
     {
     public:

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/VolumetricFog/FogVolumeComponentConfig.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/VolumetricFog/FogVolumeComponentConfig.h
@@ -16,6 +16,8 @@
 
 namespace AZ::Render
 {
+    //! Serializable config for the FogVolume component
+    //! All fields are auto-generated from FogVolumeParams.inl macros.
     class FogVolumeComponentConfig final
         : public AZ::ComponentConfig
     {

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/VolumetricFog/FogVolumeComponentConfig.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/VolumetricFog/FogVolumeComponentConfig.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Atom/Feature/VolumetricFog/VolumetricFogConstants.h>
+#include <AzCore/Component/Component.h>
+#include <AzCore/Math/Color.h>
+#include <AzCore/Math/Vector3.h>
+#include <Atom/RPI.Reflect/Image/StreamingImageAsset.h>
+
+namespace AZ::Render
+{
+    class FogVolumeComponentConfig final
+        : public AZ::ComponentConfig
+    {
+        friend class EditorFogVolumeComponent;
+
+    public:
+        AZ_CLASS_ALLOCATOR(FogVolumeComponentConfig, AZ::SystemAllocator)
+        AZ_RTTI(FogVolumeComponentConfig, "{3A7D9F2E-B1C4-4E8A-95D2-6F0B3C7A1E4D}", AZ::ComponentConfig);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        // Auto-generate getters/setters
+#define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)  \
+        ValueType Get##Name() const { return MemberName; }              \
+        void Set##Name(ValueType val) { MemberName = val; }             \
+
+#include <Atom/Feature/ParamMacros/MapParamCommon.inl>
+#include <Atom/Feature/VolumetricFog/FogVolumeParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+
+    private:
+        // Auto-generate members
+#define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)  \
+        ValueType MemberName = DefaultValue;                            \
+
+#include <Atom/Feature/ParamMacros/MapParamCommon.inl>
+#include <Atom/Feature/VolumetricFog/FogVolumeParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+    };
+
+} // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/VolumetricFog/VolumetricFogBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/VolumetricFog/VolumetricFogBus.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+#include <AzCore/Component/ComponentBus.h>
+#include <AtomLyIntegration/CommonFeatures/VolumetricFog/VolumetricFogComponentConfig.h>
+
+namespace AZ::Render
+{
+    //! The EBus for requests to modify volumetric fog components.
+    class VolumetricFogRequests
+        : public ComponentBus
+    {
+    public:
+        AZ_RTTI(AZ::Render::VolumetricFogRequests, "{3F4474E5-D618-4BBA-B4DC-E0E46B699D2C}");
+
+        /// Overrides the default AZ::EBusTraits handler policy to allow one listener only.
+        static const EBusHandlerPolicy HandlerPolicy = EBusHandlerPolicy::Single;
+        virtual ~VolumetricFogRequests() {}
+
+        // Auto-gen virtual getter and setter functions - matching the interface methods    
+#define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)                                  \
+        virtual ValueType Get##Name() const = 0;                                                        \
+        virtual void Set##Name(ValueType val) = 0;                                                      \
+
+#include <Atom/Feature/ParamMacros/MapParamCommon.inl>
+#include <Atom/Feature/VolumetricFog/VolumetricFogParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+    };
+
+    typedef AZ::EBus<VolumetricFogRequests> VolumetricFogRequestsBus;
+}

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/VolumetricFog/VolumetricFogBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/VolumetricFog/VolumetricFogBus.h
@@ -12,7 +12,8 @@
 
 namespace AZ::Render
 {
-    //! The EBus for requests to modify volumetric fog components.
+    //! EBus request interface for the VolumetricFog component
+    //! Use this to read/write global fog settings from Lua or other components.
     class VolumetricFogRequests
         : public ComponentBus
     {

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/VolumetricFog/VolumetricFogComponentConfig.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/VolumetricFog/VolumetricFogComponentConfig.h
@@ -20,6 +20,8 @@ namespace AZ::Render
 {
     class VolumetricFogFeatureProcessorInterface;
 
+    //! Serializable config for the VolumetricFog component
+    //! All fields are auto-generated from VolumetricFogParams.inl macros.
     class VolumetricFogComponentConfig final
         : public AZ::ComponentConfig
     {
@@ -31,7 +33,9 @@ namespace AZ::Render
 
         static void Reflect(AZ::ReflectContext* context);
 
+        //! Pulls current values from a live feature processor into this config.
         void CopySettingsFrom(VolumetricFogFeatureProcessorInterface* settings);
+        //! Pushes config values into a live feature processor.
         void CopySettingsTo(VolumetricFogFeatureProcessorInterface* settings);
 
         // Generate Get / Set methods

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/VolumetricFog/VolumetricFogComponentConfig.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/VolumetricFog/VolumetricFogComponentConfig.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <AzCore/Asset/AssetCommon.h>
+#include <AzCore/Math/Color.h>
+#include <AzCore/Math/Vector3.h>
+#include <Atom/Feature/VolumetricFog/VolumetricFogConstants.h>
+#include <Atom/Feature/LightingChannel/LightingChannelConfiguration.h>
+#include <Atom/RPI.Reflect/Image/StreamingImageAsset.h>
+
+namespace AZ::Render
+{
+    class VolumetricFogFeatureProcessorInterface;
+
+    class VolumetricFogComponentConfig final
+        : public AZ::ComponentConfig
+    {
+        friend class EditorVolumetricFogComponent;
+
+    public:
+        AZ_CLASS_ALLOCATOR(VolumetricFogComponentConfig, SystemAllocator)
+        AZ_RTTI(AZ::Render::VolumetricFogComponentConfig, "{FAEC22F1-91EB-4304-9779-5C6239B236E5}", AZ::ComponentConfig);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        void CopySettingsFrom(VolumetricFogFeatureProcessorInterface* settings);
+        void CopySettingsTo(VolumetricFogFeatureProcessorInterface* settings);
+
+        // Generate Get / Set methods
+#define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)                                  \
+        virtual ValueType Get##Name() const { return MemberName; }                                      \
+        virtual void Set##Name(ValueType val) { MemberName = val; }                                     \
+
+#include <Atom/Feature/ParamMacros/MapParamCommon.inl>
+#include <Atom/Feature/VolumetricFog/VolumetricFogParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+
+        private:
+
+            // SRG constants
+#define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)                                  \
+        ValueType MemberName = DefaultValue;                                                            \
+
+#include <Atom/Feature/ParamMacros/MapParamCommon.inl>
+#include <Atom/Feature/VolumetricFog/VolumetricFogParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+    };
+} // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Module.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Module.cpp
@@ -46,6 +46,10 @@
 #include <Scripting/EntityReferenceComponent.h>
 #include <SurfaceData/SurfaceDataMeshComponent.h>
 #include <Animation/AttachmentComponent.h>
+#if defined(CARBONATED)
+#include <VolumetricFog/VolumetricFogComponent.h>
+#include <VolumetricFog/FogVolumeComponent.h>
+#endif
 
 #ifdef ATOMLYINTEGRATION_FEATURE_COMMON_EDITOR
 #include <EditorCommonFeaturesSystemComponent.h>
@@ -89,6 +93,8 @@
 #include <Animation/EditorAttachmentComponent.h>
 #if defined(CARBONATED)
 #include <Silhouette/EditorSilhouetteSystemComponent.h>
+#include <VolumetricFog/EditorVolumetricFogComponent.h>
+#include <VolumetricFog/EditorFogVolumeComponent.h>
 #endif
 #endif
 
@@ -143,6 +149,10 @@ namespace AZ
                         WhiteBalanceComponent::CreateDescriptor(),
                         VignetteComponent::CreateDescriptor(),
                         CubeMapCaptureComponent::CreateDescriptor(),
+#if defined(CARBONATED)
+                        VolumetricFogComponent::CreateDescriptor(),
+                        FogVolumeComponent::CreateDescriptor(),
+#endif
 
 #ifdef ATOMLYINTEGRATION_FEATURE_COMMON_EDITOR
                         EditorAreaLightComponent::CreateDescriptor(),
@@ -186,6 +196,8 @@ namespace AZ
                         EditorCubeMapCaptureComponent::CreateDescriptor(),
 #if defined(CARBONATED)
                         EditorSilhouetteSystemComponent::CreateDescriptor(),
+                        EditorVolumetricFogComponent::CreateDescriptor(),
+                        EditorFogVolumeComponent::CreateDescriptor(),
 #endif
 #endif
                     });

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/EditorFogVolumeComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/EditorFogVolumeComponent.cpp
@@ -74,10 +74,10 @@ namespace AZ::Render
                         &FogVolumeComponentConfig::m_blendMode,
                         "Blend Mode",
                         "How this volume's contribution is composited with existing froxel data.\n"
-                        "  Additive  — adds on top of existing fog\n"
-                        "  Multiply  — multiplies into existing fog (darkens/thins)\n"
-                        "  Overwrite — replaces fog inside the volume entirely\n"
-                        "  Min / Max — take per-froxel minimum or maximum")
+                        "  Additive: adds on top of existing fog\n"
+                        "  Multiply: multiplies into existing fog (darkens/thins)\n"
+                        "  Overwrite: replaces fog inside the volume entirely\n"
+                        "  Min / Max: take per-froxel minimum or maximum")
                         ->Attribute(AZ::Edit::Attributes::EnumValues, AZ::Edit::GetEnumConstantsFromTraits<Render::FogVolumeBlendMode>())
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::ValuesOnly)
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/EditorFogVolumeComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/EditorFogVolumeComponent.cpp
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <VolumetricFog/EditorFogVolumeComponent.h>
+#include <AtomLyIntegration/CommonFeatures/VolumetricFog/FogVolumeComponentConfig.h>
+
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzToolsFramework/API/EntityCompositionRequestBus.h>
+#include <LmbrCentral/Shape/EditorShapeComponentBus.h>
+#include <LmbrCentral/Shape/SphereShapeComponentBus.h>
+#include <LmbrCentral/Shape/BoxShapeComponentBus.h>
+
+namespace AZ::Render
+{
+    EditorFogVolumeComponent::EditorFogVolumeComponent(const FogVolumeComponentConfig& config)
+        : BaseClass(config)
+    {
+    }
+
+    void EditorFogVolumeComponent::Reflect(AZ::ReflectContext* context)
+    {
+        BaseClass::Reflect(context);
+
+        if (auto* sc = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            sc->Class<EditorFogVolumeComponent, BaseClass>()
+                ->Version(1);
+
+            if (AZ::EditContext* ec = sc->GetEditContext())
+            {
+                ec->Class<EditorFogVolumeComponent>(
+                    "Fog Volume",
+                    "A local volume that modifies the volumetric fog medium within its bounds. "
+                    "Requires a Box or Sphere shape component on the same entity.")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::Category, "Graphics/Environment")
+                        ->Attribute(AZ::Edit::Attributes::Icon, "Icons/Components/Component_Placeholder.svg")
+                        ->Attribute(AZ::Edit::Attributes::ViewportIcon, "Icons/Components/Viewport/Component_Placeholder.svg")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu,
+                            AZStd::vector<AZ::Crc32>({ AZ_CRC_CE("Game") }))
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ;
+
+                ec->Class<FogVolumeComponentController>("FogVolumeComponentController", "")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->DataElement(AZ::Edit::UIHandlers::Default,
+                        &FogVolumeComponentController::m_config,
+                        "Configuration", "")
+                        ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
+                    ;
+
+                ec->Class<FogVolumeComponentConfig>("FogVolumeComponentConfig", "")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+
+                    ->DataElement(Edit::UIHandlers::ComboBox, &FogVolumeComponentConfig::m_shape, "Shape", "Shape of the volume.")
+                        ->EnumAttribute(FogVolumeShape::Unknown, "Choose a Shape type")
+                        ->EnumAttribute(FogVolumeShape::Box, "Box")
+                        ->EnumAttribute(FogVolumeShape::Sphere, "Sphere")
+
+                    // ---- Blend mode ---------------------------------------------
+                    ->ClassElement(AZ::Edit::ClassElements::Group, "Blend")
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+
+                    ->DataElement(AZ::Edit::UIHandlers::ComboBox,
+                        &FogVolumeComponentConfig::m_blendMode,
+                        "Blend Mode",
+                        "How this volume's contribution is composited with existing froxel data.\n"
+                        "  Additive  — adds on top of existing fog\n"
+                        "  Multiply  — multiplies into existing fog (darkens/thins)\n"
+                        "  Overwrite — replaces fog inside the volume entirely\n"
+                        "  Min / Max — take per-froxel minimum or maximum")
+                        ->Attribute(AZ::Edit::Attributes::EnumValues, AZ::Edit::GetEnumConstantsFromTraits<Render::FogVolumeBlendMode>())
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::ValuesOnly)
+
+                    ->DataElement(AZ::Edit::UIHandlers::SpinBox,
+                        &FogVolumeComponentConfig::m_priority,
+                        "Priority",
+                        "Volumes with higher priority are applied last. Matters most for Overwrite blend mode.")
+                        ->Attribute(AZ::Edit::Attributes::Min, 0)
+                        ->Attribute(AZ::Edit::Attributes::Max, 255)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::ValuesOnly)
+
+                    // ---- Edge fade ----------------------------------------------
+                    ->ClassElement(AZ::Edit::ClassElements::Group, "Edge Fade")
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+
+                    ->DataElement(AZ::Edit::UIHandlers::Vector3,
+                        &FogVolumeComponentConfig::m_edgeFade,
+                        "Edge Fade",
+                        "Per-axis fade fraction [0,1]. 0 = hard edge, 1 = fades to zero at center.\n"
+                        "For sphere volumes only the X component is used.")
+                        ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+                        ->Attribute(AZ::Edit::Attributes::Max, 1.0f)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::ValuesOnly)
+
+#undef CONFIG_COMPONENT_NAME
+#define CONFIG_COMPONENT_NAME FogVolumeComponentConfig
+#include <VolumetricFog//EditorVolumetricFogVolumeComponent.inl>
+
+                    ;
+            }
+        }
+
+        if (auto* bc = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            bc->Class<EditorFogVolumeComponent>()
+                ->RequestBus("FogVolumeRequestsBus");
+        }
+    }
+
+    void EditorFogVolumeComponent::Activate()
+    {
+        // Override the shape component so that this component controls the color.
+        LmbrCentral::EditorShapeComponentRequestsBus::Event(
+            GetEntityId(), &LmbrCentral::EditorShapeComponentRequests::SetShapeColorIsEditable, false);
+        LmbrCentral::EditorShapeComponentRequestsBus::Event(
+            GetEntityId(), &LmbrCentral::EditorShapeComponentRequests::SetShapeColor, AZ::Color(m_controller.GetFogAlbedo()));
+
+        BaseClass::Activate();
+    }
+
+    void EditorFogVolumeComponent::Deactivate()
+    {
+        LmbrCentral::EditorShapeComponentRequestsBus::Event(
+            GetEntityId(), &LmbrCentral::EditorShapeComponentRequests::SetShapeColorIsEditable, true);
+
+        BaseClass::Deactivate();
+    }
+
+    AZ::u32 EditorFogVolumeComponent::OnConfigurationChanged()
+    {
+        bool needsFullRefresh = HandleShapeTypeChange();
+        m_controller.OnConfigChanged();
+        LmbrCentral::EditorShapeComponentRequestsBus::Event(
+            GetEntityId(), &LmbrCentral::EditorShapeComponentRequests::SetShapeColor, AZ::Color(m_controller.GetFogAlbedo()));
+        LmbrCentral::EditorShapeComponentRequestsBus::Event(
+            GetEntityId(), &LmbrCentral::EditorShapeComponentRequests::SetShapeWireframeColor,  AZ::Color(m_controller.GetFogAlbedo()));
+
+        if (needsFullRefresh)
+        {
+            return Edit::PropertyRefreshLevels::EntireTree;
+        }
+        return AZ::Edit::PropertyRefreshLevels::AttributesAndValues;
+    }
+
+     bool EditorFogVolumeComponent::HandleShapeTypeChange()
+    {
+         if (m_shape == FogVolumeShape::Unknown)
+         {
+            // Shape is unknown, see if it can be determined from a shape component.
+            Crc32 shapeType = Crc32(0);
+            LmbrCentral::ShapeComponentRequestsBus::EventResult(
+                shapeType, GetEntityId(), &LmbrCentral::ShapeComponentRequestsBus::Events::GetShapeType);
+
+            constexpr Crc32 SphereShapeTypeId = AZ_CRC_CE("Sphere");
+            constexpr Crc32 BoxShapeTypeId = AZ_CRC_CE("Box");
+
+            switch (shapeType)
+            {
+            case SphereShapeTypeId:
+                m_shape = FogVolumeShape::Sphere;
+                break;
+            case BoxShapeTypeId:
+                m_shape = FogVolumeShape::Box;
+                break;
+            default:
+                break; // Shape type can't be deduced.
+            }
+        }
+
+        if (m_shape == m_controller.GetShape())
+        {
+            // No change, nothing to do
+            return false;
+        }
+
+        // Update the cached light type.
+        m_shape = m_controller.GetShape();
+
+        // components may be removed or added here, so deactivate now and reactivate the entity when everything is done shifting around.
+        GetEntity()->Deactivate();
+
+        // Check if there is already a shape components and remove it.
+        for (Component* component : GetEntity()->GetComponents())
+        {
+            ComponentDescriptor::DependencyArrayType provided;
+            ComponentDescriptor* componentDescriptor = nullptr;
+            ComponentDescriptorBus::EventResult(
+                componentDescriptor, component->RTTI_GetType(), &ComponentDescriptorBus::Events::GetDescriptor);
+            AZ_Assert(
+                componentDescriptor,
+                "Component class %s descriptor is not created! It must be before you can use it!",
+                component->RTTI_GetTypeName());
+            componentDescriptor->GetProvidedServices(provided, component);
+            auto providedItr = AZStd::find(provided.begin(), provided.end(), AZ_CRC_CE("ShapeService"));
+            if (providedItr != provided.end())
+            {
+                AZStd::vector<Component*> componentsToRemove = { component };
+                AzToolsFramework::EntityCompositionRequests::RemoveComponentsOutcome outcome =
+                    AZ::Failure(AZStd::string("Failed to remove old shape component."));
+                AzToolsFramework::EntityCompositionRequestBus::BroadcastResult(
+                    outcome, &AzToolsFramework::EntityCompositionRequests::RemoveComponents, componentsToRemove);
+                break;
+            }
+        }
+
+        // Add a new shape component for light types that require it.
+
+        auto addComponentOfType = [&](AZ::Uuid type)
+        {
+            AzToolsFramework::EntityCompositionRequests::AddComponentsOutcome outcome =
+                AZ::Failure(AZStd::string("Failed to add shape component for light type"));
+
+            const AZStd::vector<AZ::EntityId> entityList = { GetEntityId() };
+
+            AzToolsFramework::EntityCompositionRequestBus::BroadcastResult(
+                outcome, &AzToolsFramework::EntityCompositionRequests::AddComponentsToEntities, entityList, ComponentTypeList({ type }));
+        };
+
+        switch (m_shape)
+        {
+        case FogVolumeShape::Sphere:
+            addComponentOfType(LmbrCentral::EditorSphereShapeComponentTypeId);
+            break;
+        case FogVolumeShape::Box:
+            addComponentOfType(LmbrCentral::EditorBoxShapeComponentTypeId);
+            break;
+        default:
+            break;
+        }
+
+        GetEntity()->Activate();
+
+        // Set more reasonable default values for certain shapes.
+        switch (m_shape)
+        {
+        case FogVolumeShape::Sphere:
+            LmbrCentral::SphereShapeComponentRequestsBus::Event(
+                GetEntityId(), &LmbrCentral::SphereShapeComponentRequests::SetRadius, 1.0f);
+            break;
+        case FogVolumeShape::Box:
+            LmbrCentral::BoxShapeComponentRequestsBus::Event(
+                GetEntityId(), &LmbrCentral::BoxShapeComponentRequests::SetBoxDimensions, AZ::Vector3(1.0f, 1.0f, 1.0f));
+            break;
+        }
+
+        return true;
+    }
+
+} // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/EditorFogVolumeComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/EditorFogVolumeComponent.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Atom/Feature/Utils/EditorRenderComponentAdapter.h>
+#include <VolumetricFog/FogVolumeComponent.h>
+
+namespace AZ::Render
+{
+    class EditorFogVolumeComponent final
+        : public EditorRenderComponentAdapter<FogVolumeComponentController, FogVolumeComponent, FogVolumeComponentConfig>
+    {
+    public:
+        using BaseClass = EditorRenderComponentAdapter<FogVolumeComponentController, FogVolumeComponent, FogVolumeComponentConfig>;
+        AZ_EDITOR_COMPONENT(EditorFogVolumeComponent, "{A2D7F1E5-C4B3-4F9A-87D2-3B0E6C5A9F1D}", BaseClass);
+
+        EditorFogVolumeComponent() = default;
+        explicit EditorFogVolumeComponent(const FogVolumeComponentConfig& config);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        void Activate() override;
+        void Deactivate() override;
+
+    private:
+        AZ::u32 OnConfigurationChanged() override;
+        bool HandleShapeTypeChange();
+
+        FogVolumeShape m_shape = FogVolumeShape::Unknown;
+    };
+
+} // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/EditorFogVolumeComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/EditorFogVolumeComponent.h
@@ -13,6 +13,8 @@
 
 namespace AZ::Render
 {
+    //! Editor component for a local fog volume override; requires a Box or Sphere shape
+    //! component on the same entity.
     class EditorFogVolumeComponent final
         : public EditorRenderComponentAdapter<FogVolumeComponentController, FogVolumeComponent, FogVolumeComponentConfig>
     {
@@ -30,9 +32,10 @@ namespace AZ::Render
 
     private:
         AZ::u32 OnConfigurationChanged() override;
+        //! Detects when the Shape property has changed in the config and swaps the attached shape component (Box <-> Sphere) accordingly.
         bool HandleShapeTypeChange();
 
-        FogVolumeShape m_shape = FogVolumeShape::Unknown;
+        FogVolumeShape m_shape = FogVolumeShape::Unknown; // cached shape from last frame to detect changes in HandleShapeTypeChange
     };
 
 } // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/EditorVolumetricFogComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/EditorVolumetricFogComponent.cpp
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <VolumetricFog/EditorVolumetricFogComponent.h>
+#include <AtomLyIntegration/CommonFeatures/VolumetricFog/VolumetricFogComponentConfig.h>
+
+namespace AZ::Render
+{
+    void EditorVolumetricFogComponent::Reflect(AZ::ReflectContext* context)
+    {
+        BaseClass::Reflect(context);
+
+        if (AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<EditorVolumetricFogComponent, BaseClass>()
+                ->Version(1);
+
+            if (AZ::EditContext* editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<EditorVolumetricFogComponent>(
+                    "Volumetric Fog", "Volumetric fog component that renders 3D fog")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::Category, "Graphics/Environment")
+                        ->Attribute(AZ::Edit::Attributes::Icon, "Icons/Components/Component_Placeholder.svg")
+                        ->Attribute(AZ::Edit::Attributes::ViewportIcon, "Icons/Components/Viewport/Component_Placeholder.svg")
+                    ->Attribute(
+                        Edit::Attributes::AppearsInAddComponentMenu,
+                        AZStd::vector<AZ::Crc32>({ AZ_CRC("Level", 0x9aeacc13), AZ_CRC("Game", 0x232b318c) }))
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ;
+
+                editContext->Class<VolumetricFogComponentController>(
+                    "VolumetricFogComponentController", "")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &VolumetricFogComponentController::m_configuration, "Configuration", "")
+                        ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
+                    ;
+
+                editContext->Class<VolumetricFogComponentConfig>(
+                    "VolumetricFogComponentConfig", "")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+
+                    ->DataElement(Edit::UIHandlers::CheckBox,
+                            &VolumetricFogComponentConfig::m_enabled,
+                            "Enable Volumetric Fog",
+                            "Enable Volumetric Fog.")
+                            ->Attribute(Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
+
+                    ->DataElement(
+                        Edit::UIHandlers::ComboBox,
+                        &VolumetricFogComponentConfig::m_quality,
+                        "Quality",
+                        "The number of froxels to use (16x16, 8x8 or 4x4).")
+                        ->Attribute(AZ::Edit::Attributes::EnumValues, AZ::Edit::GetEnumConstantsFromTraits<Render::VolumetricFogQuality>())
+
+                    ->ClassElement(Edit::ClassElements::Group, "Distance")
+                        ->Attribute(Edit::Attributes::AutoExpand, true)
+
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Slider,
+                        &VolumetricFogComponentConfig::m_fogNear,
+                        "Start Distance", "The distance from the viewer when the fog starts")
+                        ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+                        ->Attribute(AZ::Edit::Attributes::Max, 5000.0f)
+                        ->Attribute(AZ::Edit::Attributes::SoftMin, 0.0f)
+                        ->Attribute(AZ::Edit::Attributes::SoftMax, 10.0f)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
+
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Slider,
+                        &VolumetricFogComponentConfig::m_fogFar,
+                        "End Distance", "At what distance from the viewer does the fog take over and mask the background scene out.")
+                    ->Attribute(AZ::Edit::Attributes::Min, &VolumetricFogComponentConfig::m_fogNear)
+                        ->Attribute(AZ::Edit::Attributes::Max, 5000.0f)
+                        ->Attribute(AZ::Edit::Attributes::SoftMin, 0.0f)
+                        ->Attribute(AZ::Edit::Attributes::SoftMax, 500.0f)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
+
+#undef CONFIG_COMPONENT_NAME
+#define CONFIG_COMPONENT_NAME VolumetricFogComponentConfig
+#include <VolumetricFog//EditorVolumetricFogVolumeComponent.inl>
+                    
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default, &VolumetricFogComponentConfig::m_lightingChannelConfig, "Lighting Channels", "")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
+
+                    ->ClassElement(Edit::ClassElements::Group, "Temporal Reprojection")
+                        ->Attribute(Edit::Attributes::AutoExpand, false)
+
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Slider,
+                        &VolumetricFogComponentConfig::m_sequenceLength,
+                        "Sequence Length",
+                        "Number of frames to create different jitter positions")
+                        ->Attribute(AZ::Edit::Attributes::Min, 0)
+                        ->Attribute(AZ::Edit::Attributes::Max, VolumetricFogMaxSequenceLength)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
+
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Slider,
+                        &VolumetricFogComponentConfig::m_blendPercentage,
+                        "Blend Percentage",
+                        "How much of the last frame to blend")
+                        ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+                        ->Attribute(AZ::Edit::Attributes::Max, 100.0f)
+                        ->Attribute(AZ::Edit::Attributes::SoftMin, 0.0f)
+                        ->Attribute(AZ::Edit::Attributes::SoftMax, 10.0f)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
+                    ;
+            }
+        }
+
+        if (auto* behaviorContext = azrtti_cast<BehaviorContext*>(context))
+        {
+            behaviorContext->Class<EditorVolumetricFogComponent>()
+                ->RequestBus("VolumetricFogRequestsBus");
+        }
+    }
+
+    EditorVolumetricFogComponent::EditorVolumetricFogComponent(const VolumetricFogComponentConfig& config)
+        : BaseClass(config)
+    {
+    }
+
+    AZ::u32 EditorVolumetricFogComponent::OnConfigurationChanged()
+    {
+        m_controller.OnConfigChanged();
+        return Edit::PropertyRefreshLevels::AttributesAndValues;
+    }
+
+    void EditorVolumetricFogComponent::OnEntityVisibilityChanged(bool visibility)
+    {
+        if(auto featureProcessor = m_controller.m_featureProcessorInterface)
+        {
+            AZ_UNUSED(visibility);
+        }
+    }
+}

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/EditorVolumetricFogComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/EditorVolumetricFogComponent.cpp
@@ -68,7 +68,7 @@ namespace AZ::Render
                         &VolumetricFogComponentConfig::m_fogNear,
                         "Start Distance", "The distance from the viewer when the fog starts")
                         ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
-                        ->Attribute(AZ::Edit::Attributes::Max, 5000.0f)
+                        ->Attribute(AZ::Edit::Attributes::Max, 1500.0f)
                         ->Attribute(AZ::Edit::Attributes::SoftMin, 0.0f)
                         ->Attribute(AZ::Edit::Attributes::SoftMax, 10.0f)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/EditorVolumetricFogComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/EditorVolumetricFogComponent.h
@@ -13,6 +13,8 @@
 
 namespace AZ::Render
 {
+    //! Editor component for scene-wide (global) volumetric fog
+    //! Wraps the runtime component via EditorRenderComponentAdapter.
     class EditorVolumetricFogComponent final
         : public EditorRenderComponentAdapter<VolumetricFogComponentController, VolumetricFogComponent, VolumetricFogComponentConfig>
     {
@@ -27,9 +29,9 @@ namespace AZ::Render
         EditorVolumetricFogComponent(const VolumetricFogComponentConfig& config);
 
     private:
-        //! EditorRenderComponentAdapter
-        //! we override OnEntityVisibilityChanged to avoid deactivating and activating unnecessarily
+        //! Pushes config to the feature processor without component deactivation; returns ValuesOnly refresh level.
         AZ::u32 OnConfigurationChanged() override;
+        //! Toggles the Enable flag instead of deactivating/activating to avoid expensive pass teardown.
         void OnEntityVisibilityChanged(bool visibility) override;
     };
 } // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/EditorVolumetricFogComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/EditorVolumetricFogComponent.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Atom/Feature/Utils/EditorRenderComponentAdapter.h>
+#include <VolumetricFog/VolumetricFogComponent.h>
+
+namespace AZ::Render
+{
+    class EditorVolumetricFogComponent final
+        : public EditorRenderComponentAdapter<VolumetricFogComponentController, VolumetricFogComponent, VolumetricFogComponentConfig>
+    {
+    public:
+
+        using BaseClass = EditorRenderComponentAdapter<VolumetricFogComponentController, VolumetricFogComponent, VolumetricFogComponentConfig>;
+        AZ_EDITOR_COMPONENT(AZ::Render::EditorVolumetricFogComponent, "{25D8BC2C-A77E-46F5-B35D-FC6C61E97839}", BaseClass);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        EditorVolumetricFogComponent() = default;
+        EditorVolumetricFogComponent(const VolumetricFogComponentConfig& config);
+
+    private:
+        //! EditorRenderComponentAdapter
+        //! we override OnEntityVisibilityChanged to avoid deactivating and activating unnecessarily
+        AZ::u32 OnConfigurationChanged() override;
+        void OnEntityVisibilityChanged(bool visibility) override;
+    };
+} // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/EditorVolumetricFogVolumeComponent.inl
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/EditorVolumetricFogVolumeComponent.inl
@@ -22,7 +22,7 @@
     AZ::Edit::UIHandlers::Slider,
     &CONFIG_COMPONENT_NAME::m_fogDensity,
     "Density",
-    "Total extinction coefficient (σ_t). Controls how quickly light is attenuated through the fog. "
+    "Total extinction coefficient (sigma_t). Controls how quickly light is attenuated through the fog. "
     "Higher values produce thicker, more opaque fog.")
     ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
     ->Attribute(AZ::Edit::Attributes::Max, 1.0f)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/EditorVolumetricFogVolumeComponent.inl
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/EditorVolumetricFogVolumeComponent.inl
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+->ClassElement(Edit::ClassElements::Group, "Density Control")
+    ->Attribute(Edit::Attributes::AutoExpand, true)
+
+->DataElement(
+    AZ::Edit::UIHandlers::Color,
+    &CONFIG_COMPONENT_NAME::m_fogAlbedo,
+    "Albedo",
+    "Single-scattering albedo: the fraction of light that scatters per channel. "
+    "White = fully scattering (typical mist/haze). "
+    "Dark = mostly absorbing (soot/smoke). "
+    "Together with Fog Density, this fully controls how the fog looks.")
+->Attribute(AZ::Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
+
+->DataElement(
+    AZ::Edit::UIHandlers::Slider,
+    &CONFIG_COMPONENT_NAME::m_fogDensity,
+    "Density",
+    "Total extinction coefficient (σ_t). Controls how quickly light is attenuated through the fog. "
+    "Higher values produce thicker, more opaque fog.")
+    ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+    ->Attribute(AZ::Edit::Attributes::Max, 1.0f)
+    ->Attribute(AZ::Edit::Attributes::SoftMin, 0.0f)
+    ->Attribute(AZ::Edit::Attributes::SoftMax, 1.0f)
+    ->Attribute(AZ::Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
+
+->DataElement(
+    AZ::Edit::UIHandlers::Slider,
+    &CONFIG_COMPONENT_NAME::m_fogBaseHeight,
+    "Base height",
+    "The height at which the fog layer starts")
+    ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+    ->Attribute(AZ::Edit::Attributes::Max, 500.0f)
+    ->Attribute(AZ::Edit::Attributes::SoftMin, 0.0f)
+    ->Attribute(AZ::Edit::Attributes::SoftMax, 50.0f)
+    ->Attribute(AZ::Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
+
+->DataElement(
+    AZ::Edit::UIHandlers::Slider,
+    &CONFIG_COMPONENT_NAME::m_fogHeightFalloff,
+    "Falloff",
+    "How quickly fog thins above the base height")
+    ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+    ->Attribute(AZ::Edit::Attributes::Max, 1.0f)
+    ->Attribute(AZ::Edit::Attributes::SoftMin, 0.0f)
+    ->Attribute(AZ::Edit::Attributes::SoftMax, 1.0f)
+    ->Attribute(AZ::Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
+
+    // Fog turbulence properties
+->ClassElement(Edit::ClassElements::Group, "Turbulence")
+    ->Attribute(Edit::Attributes::AutoExpand, true)
+->DataElement(AZ::Edit::UIHandlers::Default, &CONFIG_COMPONENT_NAME::m_noiseTexture,
+    "Noise Texture", "The noise texture used for creating the fog turbulence")
+    ->Attribute(AZ::Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
+
+->DataElement(
+    AZ::Edit::UIHandlers::Slider,
+    &CONFIG_COMPONENT_NAME::m_noiseScale,
+    "Noise Scale",
+    "UV tiling scale (smaller = larger blobs)")
+    ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+    ->Attribute(AZ::Edit::Attributes::Max, 1.0f)
+    ->Attribute(AZ::Edit::Attributes::SoftMin, 0.0f)
+    ->Attribute(AZ::Edit::Attributes::SoftMax, 1.0f)
+    ->Attribute(AZ::Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
+
+->DataElement(
+    AZ::Edit::UIHandlers::Vector3,
+    &CONFIG_COMPONENT_NAME::m_noiseWindVelocity,
+    "Noise Wind Velocity",
+    "Wind velocity (direction and magnitude)")
+    ->Attribute(AZ::Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
+
+->ClassElement(Edit::ClassElements::Group, "Lighting")
+    ->Attribute(Edit::Attributes::AutoExpand, true)
+
+->DataElement(
+    AZ::Edit::UIHandlers::Slider,
+    &CONFIG_COMPONENT_NAME::m_phaseG,
+    "Anisotropy",
+    "Phase function asymmetry parameter g for Henyey-Greenstein")
+    ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+    ->Attribute(AZ::Edit::Attributes::Max, 1.0f)
+    ->Attribute(AZ::Edit::Attributes::SoftMin, 0.0f)
+    ->Attribute(AZ::Edit::Attributes::SoftMax, 1.0f)
+    ->Attribute(AZ::Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
+
+->DataElement(
+    AZ::Edit::UIHandlers::Slider,
+    &CONFIG_COMPONENT_NAME::m_ambientIntensity,
+    "Ambient Intensity",
+    "Scale applied to the IBL diffuse ambient contribution sampled from the scene's environment cubemap")
+    ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+    ->Attribute(AZ::Edit::Attributes::Max, 1.0f)
+    ->Attribute(AZ::Edit::Attributes::SoftMin, 0.0f)
+    ->Attribute(AZ::Edit::Attributes::SoftMax, 1.0f)
+    ->Attribute(AZ::Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
+
+->DataElement(
+    AZ::Edit::UIHandlers::Color,
+    &CONFIG_COMPONENT_NAME::m_emissiveColor,
+    "Emissive Color",
+    "Self-illumination color. The fog emits this color proportionally to its density.")
+    ->Attribute(AZ::Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
+
+->DataElement(
+    AZ::Edit::UIHandlers::Slider,
+    &CONFIG_COMPONENT_NAME::m_emissiveIntensity,
+    "Emissive Intensity",
+    "Scale applied to the emissive color. Values above 1 produce HDR emission.")
+    ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+    ->Attribute(AZ::Edit::Attributes::Max, 100.0f)
+    ->Attribute(AZ::Edit::Attributes::SoftMin, 0.0f)
+    ->Attribute(AZ::Edit::Attributes::SoftMax, 10.0f)
+    ->Attribute(AZ::Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/FogVolumeComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/FogVolumeComponent.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <VolumetricFog/FogVolumeComponent.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+namespace AZ::Render
+{
+    FogVolumeComponent::FogVolumeComponent(const FogVolumeComponentConfig& config)
+        : BaseClass(config)
+    {
+    }
+
+    void FogVolumeComponent::Reflect(AZ::ReflectContext* context)
+    {
+        BaseClass::Reflect(context);
+
+        if (auto* sc = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            sc->Class<FogVolumeComponent, BaseClass>()
+                ->Version(1);
+        }
+    }
+
+} // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/FogVolumeComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/FogVolumeComponent.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzFramework/Components/ComponentAdapter.h>
+#include <VolumetricFog/FogVolumeComponentController.h>
+#include <AtomLyIntegration/CommonFeatures/VolumetricFog/FogVolumeComponentConfig.h>
+
+namespace AZ::Render
+{
+    class FogVolumeComponent final
+        : public AzFramework::Components::ComponentAdapter<FogVolumeComponentController, FogVolumeComponentConfig>
+    {
+    public:
+        using BaseClass = AzFramework::Components::ComponentAdapter<FogVolumeComponentController, FogVolumeComponentConfig>;
+        AZ_COMPONENT(FogVolumeComponent, "{1D4A9F7B-E3C2-4B8D-A5F1-6C0E9D2B7A3F}", BaseClass);
+
+        FogVolumeComponent() = default;
+        explicit FogVolumeComponent(const FogVolumeComponentConfig& config);
+
+        static void Reflect(AZ::ReflectContext* context);
+    };
+
+} // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/FogVolumeComponentConfig.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/FogVolumeComponentConfig.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AtomLyIntegration/CommonFeatures/VolumetricFog/FogVolumeComponentConfig.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+namespace AZ::Render
+{
+    void FogVolumeComponentConfig::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto* sc = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            sc->Class<FogVolumeComponentConfig, AZ::ComponentConfig>()
+                ->Version(1)
+#define SERIALIZE_CLASS FogVolumeComponentConfig
+#define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)  \
+                ->Field(#Name, &SERIALIZE_CLASS::MemberName)            \
+
+#include <Atom/Feature/ParamMacros/MapParamCommon.inl>
+#include <Atom/Feature/VolumetricFog/FogVolumeParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+#undef SERIALIZE_CLASS
+                ;
+        }
+    }
+
+} // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/FogVolumeComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/FogVolumeComponentController.cpp
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <VolumetricFog/FogVolumeComponentController.h>
+
+#include <Atom/RPI.Public/Scene.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+#include <LmbrCentral/Shape/BoxShapeComponentBus.h>
+#include <LmbrCentral/Shape/SphereShapeComponentBus.h>
+
+namespace AZ::Render
+{
+    void FogVolumeComponentController::Reflect(AZ::ReflectContext* context)
+    {
+        FogVolumeComponentConfig::Reflect(context);
+
+        if (auto* sc = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            sc->Class<FogVolumeComponentController>()
+                ->Version(1)
+                ->Field("Configuration", &FogVolumeComponentController::m_config);
+        }
+
+        if (auto* bc = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            bc->EBus<FogVolumeRequestsBus>("FogVolumeRequestsBus")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Category, "Render")
+                ->Attribute(AZ::Script::Attributes::Module, "Render")
+// Auto-gen behavior context events
+#define PARAM_EVENT_BUS FogVolumeRequestsBus::Events
+#define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)  \
+                ->Event("Set" #Name, &PARAM_EVENT_BUS::Set##Name)       \
+                ->Event("Get" #Name, &PARAM_EVENT_BUS::Get##Name)       \
+                ->VirtualProperty(#Name, "Get" #Name, "Set" #Name)      \
+
+#include <Atom/Feature/ParamMacros/MapParamCommon.inl>
+#include <Atom/Feature/VolumetricFog/FogVolumeParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+#undef PARAM_EVENT_BUS
+                ;
+        }
+    }
+
+    void FogVolumeComponentController::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
+    {
+        provided.push_back(AZ_CRC_CE("FogVolumeService"));
+    }
+
+    void FogVolumeComponentController::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
+    {
+        incompatible.push_back(AZ_CRC_CE("FogVolumeService"));
+        incompatible.push_back(AZ_CRC_CE("NonUniformScaleService"));
+    }
+
+    void FogVolumeComponentController::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        required.push_back(AZ_CRC_CE("TransformService"));
+    }
+
+    void FogVolumeComponentController::GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent)
+    {
+        // The shape component provides the volume bounds and editor visualization.
+        // It's listed as dependent (not required) so the component can activate even
+        // before a shape is added; PushShape() will just early-out if none is present.
+        dependent.push_back(AZ_CRC_CE("ShapeService"));
+    }
+
+    FogVolumeComponentController::FogVolumeComponentController(const FogVolumeComponentConfig& config)
+        : m_config(config)
+    {
+    }
+
+    void FogVolumeComponentController::Activate(AZ::EntityId entityId)
+    {
+        m_entityId = entityId;
+
+        m_featureProcessor =
+            RPI::Scene::GetFeatureProcessorForEntity<FogVolumeFeatureProcessorInterface>(entityId);
+
+        if (!m_featureProcessor)
+        {
+            AZ_Warning("FogVolumeComponentController", false,
+                "FogVolumeFeatureProcessor not found for entity %s.",
+                entityId.ToString().c_str());
+            return;
+        }
+
+        m_handle = m_featureProcessor->AcquireVolume();
+
+        AZ::TransformNotificationBus::Handler::BusConnect(entityId);
+        LmbrCentral::ShapeComponentNotificationsBus::Handler::BusConnect(entityId);
+        FogVolumeRequestsBus::Handler::BusConnect(entityId);
+
+        PushAllToFeatureProcessor();
+    }
+
+    void FogVolumeComponentController::Deactivate()
+    {
+        FogVolumeRequestsBus::Handler::BusDisconnect();
+        LmbrCentral::ShapeComponentNotificationsBus::Handler::BusDisconnect();
+        AZ::TransformNotificationBus::Handler::BusDisconnect();
+
+        if (m_featureProcessor)
+        {
+            m_featureProcessor->ReleaseVolume(m_handle);
+            m_featureProcessor = nullptr;
+        }
+    }
+
+    void FogVolumeComponentController::SetConfiguration(const FogVolumeComponentConfig& config)
+    {
+        m_config = config;
+        OnConfigChanged();
+    }
+
+    const FogVolumeComponentConfig& FogVolumeComponentController::GetConfiguration() const
+    {
+        return m_config;
+    }
+
+    // -------------------------------------------------------------------------
+    // Bus handlers
+    // -------------------------------------------------------------------------
+
+    void FogVolumeComponentController::OnTransformChanged(
+        [[maybe_unused]] const AZ::Transform& local, const AZ::Transform& world)
+    {
+        if (m_featureProcessor)
+        {
+            m_featureProcessor->SetVolumeTransform(m_handle, world);
+            PushShape(); // extents may depend on entity scale
+        }
+    }
+
+    void FogVolumeComponentController::OnShapeChanged(
+        [[maybe_unused]] LmbrCentral::ShapeComponentNotifications::ShapeChangeReasons reason)
+    {
+        PushShape();
+    }
+
+    // -------------------------------------------------------------------------
+    // Config propagation
+    // -------------------------------------------------------------------------
+
+    void FogVolumeComponentController::OnConfigChanged()
+    {
+        if (!m_featureProcessor || !m_handle.IsValid())
+        {
+            return;
+        }
+#define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)      \
+        m_featureProcessor->SetVolume##Name(m_handle, m_config.Get##Name()); \
+
+#include <Atom/Feature/ParamMacros/MapParamCommon.inl>
+#include <Atom/Feature/VolumetricFog/FogVolumeParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+    }
+
+    void FogVolumeComponentController::PushTransform()
+    {
+        if (!m_featureProcessor || !m_handle.IsValid())
+        {
+            return;
+        }
+        AZ::Transform worldTM = AZ::Transform::CreateIdentity();
+        AZ::TransformBus::EventResult(worldTM, m_entityId, &AZ::TransformBus::Events::GetWorldTM);
+        m_featureProcessor->SetVolumeTransform(m_handle, worldTM);
+    }
+
+    void FogVolumeComponentController::PushShape()
+    {
+        if (!m_featureProcessor || !m_handle.IsValid())
+        {
+            return;
+        }       
+
+        switch (m_config.GetShape())
+        {
+        case FogVolumeShape::Box:
+            {
+                AZ::Vector3 boxDimensions = AZ::Vector3(1.0f);
+                LmbrCentral::BoxShapeComponentRequestsBus::EventResult(
+                    boxDimensions, m_entityId, &LmbrCentral::BoxShapeComponentRequestsBus::Events::GetBoxDimensions);
+                m_featureProcessor->SetVolumeExtents(m_handle, boxDimensions * 0.5f);
+            }
+            break;
+        case FogVolumeShape::Sphere:
+            {
+                float radius = 1.0f;
+                LmbrCentral::SphereShapeComponentRequestsBus::EventResult(
+                    radius, m_entityId, &LmbrCentral::SphereShapeComponentRequestsBus::Events::GetRadius);
+
+                // For the shader, sphere half-extents are (radius, radius, radius); only X is used for edge fade.
+                m_featureProcessor->SetVolumeExtents(m_handle, AZ::Vector3(radius));
+            }
+        break;
+        default:
+            break;
+        }
+    }
+
+    void FogVolumeComponentController::PushAllToFeatureProcessor()
+    {
+        PushTransform();
+        PushShape();
+        OnConfigChanged();
+    }
+
+    // -------------------------------------------------------------------------
+    // Auto-gen FogVolumeRequestsBus getter/setter implementations.
+    // Each setter updates the config and calls SetVolume<Name>(m_handle, val)
+    // directly on the FP — one property, one call, no full flush needed.
+    // -------------------------------------------------------------------------
+#define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)      \
+    ValueType FogVolumeComponentController::Get##Name() const               \
+    {                                                                       \
+        return m_config.Get##Name();                                        \
+    }                                                                       \
+    void FogVolumeComponentController::Set##Name(ValueType val)             \
+    {                                                                       \
+        m_config.Set##Name(val);                                            \
+        if (m_featureProcessor && m_handle.IsValid())                       \
+        {                                                                   \
+            m_featureProcessor->SetVolume##Name(m_handle, val);             \
+        }                                                                   \
+    }                                                                       \
+
+#include <Atom/Feature/ParamMacros/MapParamCommon.inl>
+#include <Atom/Feature/VolumetricFog/FogVolumeParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+
+} // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/FogVolumeComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/FogVolumeComponentController.cpp
@@ -218,7 +218,7 @@ namespace AZ::Render
     // -------------------------------------------------------------------------
     // Auto-gen FogVolumeRequestsBus getter/setter implementations.
     // Each setter updates the config and calls SetVolume<Name>(m_handle, val)
-    // directly on the FP — one property, one call, no full flush needed.
+    // directly on the FP one property, one call, no full flush needed.
     // -------------------------------------------------------------------------
 #define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)      \
     ValueType FogVolumeComponentController::Get##Name() const               \

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/FogVolumeComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/FogVolumeComponentController.cpp
@@ -88,7 +88,7 @@ namespace AZ::Render
 
         if (!m_featureProcessor)
         {
-            AZ_Warning("FogVolumeComponentController", false,
+            AZ_Error("FogVolumeComponentController", false,
                 "FogVolumeFeatureProcessor not found for entity %s.",
                 entityId.ToString().c_str());
             return;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/FogVolumeComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/FogVolumeComponentController.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AtomLyIntegration/CommonFeatures/VolumetricFog/FogVolumeComponentConfig.h>
+#include <AtomLyIntegration/CommonFeatures/VolumetricFog/FogVolumeBus.h>
+#include <Atom/Feature/VolumetricFog/FogVolumeFeatureProcessorInterface.h>
+
+#include <AzCore/Component/Component.h>
+#include <AzCore/Component/TransformBus.h>
+#include <LmbrCentral/Shape/ShapeComponentBus.h>
+
+namespace AZ::Render
+{
+    class FogVolumeComponentController final
+        : public FogVolumeRequestsBus::Handler
+        , private AZ::TransformNotificationBus::Handler
+        , private LmbrCentral::ShapeComponentNotificationsBus::Handler
+    {
+    public:
+        friend class EditorFogVolumeComponent;
+
+        AZ_TYPE_INFO(FogVolumeComponentController, "{8C2F5A3D-E7B1-4D9F-A2E8-5C0B7F3D9A1C}");
+        static void Reflect(AZ::ReflectContext* context);
+        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
+        static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+        static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
+
+        FogVolumeComponentController() = default;
+        explicit FogVolumeComponentController(const FogVolumeComponentConfig& config);
+
+        void Activate(AZ::EntityId entityId);
+        void Deactivate();
+        void SetConfiguration(const FogVolumeComponentConfig& config);
+        const FogVolumeComponentConfig& GetConfiguration() const;
+
+        // Auto-gen FogVolumeRequestsBus::Handler override declarations
+#define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)  \
+        ValueType Get##Name() const override;                           \
+        void Set##Name(ValueType val) override;                         \
+
+#include <Atom/Feature/ParamMacros/MapParamCommon.inl>
+#include <Atom/Feature/VolumetricFog/FogVolumeParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+
+    private:
+        AZ_DISABLE_COPY(FogVolumeComponentController);
+
+        // TransformNotificationBus::Handler
+        void OnTransformChanged(const AZ::Transform& local, const AZ::Transform& world) override;
+
+        // ShapeComponentNotificationsBus::Handler
+        void OnShapeChanged(LmbrCentral::ShapeComponentNotifications::ShapeChangeReasons reason) override;
+
+        void OnConfigChanged();
+        void PushTransform();
+        void PushShape();
+        void PushAllToFeatureProcessor();
+
+        FogVolumeFeatureProcessorInterface*              m_featureProcessor = nullptr;
+        FogVolumeFeatureProcessorInterface::VolumeHandle m_handle;
+        FogVolumeComponentConfig                         m_config;
+        AZ::EntityId                                     m_entityId;
+    };
+
+} // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/FogVolumeComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/FogVolumeComponentController.h
@@ -18,6 +18,8 @@
 
 namespace AZ::Render
 {
+    //! Handles FogVolumeRequestsBus, TransformNotificationBus, and ShapeComponentNotificationsBus
+    //! Forwards position, extents, and property changes to FogVolumeFeatureProcessorInterface.
     class FogVolumeComponentController final
         : public FogVolumeRequestsBus::Handler
         , private AZ::TransformNotificationBus::Handler
@@ -54,18 +56,23 @@ namespace AZ::Render
         AZ_DISABLE_COPY(FogVolumeComponentController);
 
         // TransformNotificationBus::Handler
+        //! Re-uploads world transform of the volume to the feature processor.
         void OnTransformChanged(const AZ::Transform& local, const AZ::Transform& world) override;
 
         // ShapeComponentNotificationsBus::Handler
+        //! Re-uploads shape extents (half-extents extracted from the attached Shape component).
         void OnShapeChanged(LmbrCentral::ShapeComponentNotifications::ShapeChangeReasons reason) override;
 
         void OnConfigChanged();
+        //! Incremental update helper to avoid redundant uploads when only the transform changes.
         void PushTransform();
+        //! Incremental update helper to avoid redundant uploads when only the shape extents change.
         void PushShape();
+        //! Pushes transform, extents, and all config properties to the feature processor in one pass.
         void PushAllToFeatureProcessor();
 
         FogVolumeFeatureProcessorInterface*              m_featureProcessor = nullptr;
-        FogVolumeFeatureProcessorInterface::VolumeHandle m_handle;
+        FogVolumeFeatureProcessorInterface::VolumeHandle m_handle; // handle returned by FogVolumeFeatureProcessorInterface::AcquireVolume; released in Deactivate
         FogVolumeComponentConfig                         m_config;
         AZ::EntityId                                     m_entityId;
     };

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/VolumetricFogComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/VolumetricFogComponent.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <VolumetricFog/VolumetricFogComponent.h>
+
+namespace AZ::Render
+{
+    VolumetricFogComponent::VolumetricFogComponent(const VolumetricFogComponentConfig& config)
+        : BaseClass(config)
+    {
+    }
+
+    void VolumetricFogComponent::Reflect(AZ::ReflectContext* context)
+    {
+        BaseClass::Reflect(context);
+
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<VolumetricFogComponent, BaseClass>();
+        }
+
+        if (auto* behaviorContext = azrtti_cast<BehaviorContext*>(context))
+        {
+            behaviorContext->Class<VolumetricFogComponent>()
+                ->RequestBus("VolumetricFogRequestsBus");
+        }
+    }
+} // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/VolumetricFogComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/VolumetricFogComponent.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzFramework/Components/ComponentAdapter.h>
+#include <VolumetricFog/VolumetricFogComponentController.h>
+
+namespace AZ::Render
+{
+    class VolumetricFogComponent final
+        : public AzFramework::Components::ComponentAdapter<VolumetricFogComponentController, VolumetricFogComponentConfig>
+    {
+    public:
+        using BaseClass = AzFramework::Components::ComponentAdapter<VolumetricFogComponentController, VolumetricFogComponentConfig>;
+        AZ_COMPONENT(AZ::Render::VolumetricFogComponent, "{BAC79FA8-C018-4841-ACED-ABCAE395C51F}" , BaseClass);
+
+        VolumetricFogComponent() = default;
+        VolumetricFogComponent(const VolumetricFogComponentConfig& config);
+
+        static void Reflect(AZ::ReflectContext* context);
+    };
+} // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/VolumetricFogComponentConfig.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/VolumetricFogComponentConfig.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AtomLyIntegration/CommonFeatures/VolumetricFog/VolumetricFogComponentConfig.h>
+#include <AzCore/Asset/AssetSerializer.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <Atom/Feature/VolumetricFog/VolumetricFogFeatureProcessorInterface.h>
+#include <Atom/RPI.Reflect/Asset/AssetUtils.h>
+
+namespace AZ::Render
+{
+    void VolumetricFogComponentConfig::Reflect(ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<VolumetricFogComponentConfig, ComponentConfig>()->Version(0)
+            // Auto-gen serialize context code...
+#define SERIALIZE_CLASS VolumetricFogComponentConfig
+#define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)      \
+            ->Field(#Name, &SERIALIZE_CLASS::MemberName)                    \
+
+#include <Atom/Feature/ParamMacros/MapParamCommon.inl>
+#include <Atom/Feature/VolumetricFog/VolumetricFogParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+#undef SERIALIZE_CLASS
+                ;
+        }
+    }   
+
+    void VolumetricFogComponentConfig::CopySettingsFrom(VolumetricFogFeatureProcessorInterface * settings)
+    {
+        if (!settings)
+        {
+            return;
+        }
+
+#define COPY_SOURCE settings
+#define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)      \
+        MemberName = COPY_SOURCE->Get##Name();                              \
+
+#include <Atom/Feature/ParamMacros/MapParamCommon.inl>
+#include <Atom/Feature/VolumetricFog/VolumetricFogParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+#undef COPY_SOURCE
+    }
+
+    void VolumetricFogComponentConfig::CopySettingsTo(VolumetricFogFeatureProcessorInterface * settings)
+    {
+        if (!settings)
+        {
+            return;
+        }
+
+#define COPY_TARGET settings
+#define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)      \
+        COPY_TARGET->Set##Name(MemberName);                                 \
+
+#include <Atom/Feature/ParamMacros/MapParamCommon.inl>
+#include <Atom/Feature/VolumetricFog/VolumetricFogParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+#undef COPY_TARGET
+    }
+} // AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/VolumetricFogComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/VolumetricFogComponentController.cpp
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <VolumetricFog/VolumetricFogComponentController.h>
+
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+#include <Atom/RPI.Public/Scene.h>
+
+namespace AZ::Render
+{
+    void VolumetricFogComponentController::Reflect(ReflectContext* context)
+    {
+        VolumetricFogComponentConfig::Reflect(context);
+
+        if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))
+        {
+            serializeContext->Class<VolumetricFogComponentController>()
+                ->Version(1)
+                ->Field("Configuration", &VolumetricFogComponentController::m_configuration);
+        }
+
+        if (auto* behaviorContext = azrtti_cast<BehaviorContext*>(context))
+        {
+            behaviorContext->EBus<VolumetricFogRequestsBus>("VolumetricFogRequestsBus")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Category, "Render")
+                ->Attribute(AZ::Script::Attributes::Module, "Render")
+
+// Auto-gen behavior context...
+#define PARAM_EVENT_BUS VolumetricFogRequestsBus::Events
+#define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)                                  \
+        ->Event("Set" #Name, &PARAM_EVENT_BUS::Set##Name)                                               \
+        ->Event("Get" #Name, &PARAM_EVENT_BUS::Get##Name)                                               \
+        ->VirtualProperty(#Name, "Get" #Name, "Set" #Name)                                              \
+
+#include <Atom/Feature/ParamMacros/MapParamCommon.inl>
+// Asset params are not scriptable via behavior context
+#undef AZ_GFX_TEXTURE_ASSET_PARAM
+#define AZ_GFX_TEXTURE_ASSET_PARAM(Name, MemberName, DefaultValue)
+#include <Atom/Feature/VolumetricFog/VolumetricFogParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+#undef PARAM_EVENT_BUS
+                ;
+
+        }
+    }
+
+    void VolumetricFogComponentController::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
+    {
+        provided.push_back(AZ_CRC("VolumetricFogService"));
+    }
+
+    void VolumetricFogComponentController::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
+    {
+        incompatible.push_back(AZ_CRC_CE("NonUniformScaleService"));
+    }
+
+    void VolumetricFogComponentController::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        required.push_back(AZ_CRC("TransformService"));
+    }
+
+    VolumetricFogComponentController::VolumetricFogComponentController(const VolumetricFogComponentConfig& config)
+        : m_configuration(config)
+    {
+    }
+
+    void VolumetricFogComponentController::OnConfigChanged()
+    {
+        if (m_featureProcessorInterface)
+        {
+            // Set SRG constants
+            m_configuration.CopySettingsTo(m_featureProcessorInterface);
+        }
+    }
+
+    void VolumetricFogComponentController::Activate(EntityId entityId)
+    {
+        VolumetricFogRequestsBus::Handler::BusConnect(entityId);
+        m_featureProcessorInterface = RPI::Scene::GetFeatureProcessorForEntity<VolumetricFogFeatureProcessorInterface>(entityId);
+
+        if (m_featureProcessorInterface)
+        {
+            m_entityId = entityId;
+            OnConfigChanged();
+        }
+    }
+
+    void VolumetricFogComponentController::Deactivate()
+    {
+        VolumetricFogRequestsBus::Handler::BusDisconnect();
+
+        if (m_featureProcessorInterface)
+        {
+            m_featureProcessorInterface->SetEnable(false);
+            m_featureProcessorInterface = nullptr;
+        }
+    }
+
+    void VolumetricFogComponentController::SetConfiguration(const VolumetricFogComponentConfig& config)
+    {
+        m_configuration = config;
+    }
+
+    const VolumetricFogComponentConfig& VolumetricFogComponentController::GetConfiguration() const
+    {
+        return m_configuration;
+    }
+
+    // Auto generated getter/setter functions
+    // The setter functions will set the values on the Atom settings class, then get the value back
+    // from the settings class to set the local configuration. This is in case the settings class
+    // applies some custom logic that results in the set value being different from the input
+#define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)                              \
+    ValueType VolumetricFogComponentController::Get##Name() const                                   \
+    {                                                                                               \
+        return m_configuration.Get##Name();                                                         \
+    }                                                                                               \
+    void VolumetricFogComponentController::Set##Name(ValueType val)                                 \
+    {                                                                                               \
+        if (m_featureProcessorInterface)                                                            \
+        {                                                                                           \
+            m_configuration.Set##Name( val );                                                       \
+            m_featureProcessorInterface->Set##Name(val);                                            \
+        }                                                                                           \
+        else                                                                                        \
+        {                                                                                           \
+            m_configuration.Set##Name( val );                                                       \
+        }                                                                                           \
+    }                                                                                               \
+
+#include <Atom/Feature/ParamMacros/MapParamCommon.inl>
+#include <Atom/Feature/VolumetricFog/VolumetricFogParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+} // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/VolumetricFogComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/VolumetricFogComponentController.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <Atom/Feature/VolumetricFog/VolumetricFogFeatureProcessorInterface.h>
+#include <AtomLyIntegration/CommonFeatures/VolumetricFog/VolumetricFogBus.h>
+
+namespace AZ::Render
+{
+    class VolumetricFogComponentController final
+        : public VolumetricFogRequestsBus::Handler
+    {
+    public:
+        friend class EditorVolumetricFogComponent;
+
+        AZ_TYPE_INFO(AZ::Render::VolumetricFogComponentController, "{79545B74-F14F-4AAA-8861-DBDF67802EEA}");
+        static void Reflect(AZ::ReflectContext* context);
+        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
+        static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+
+        VolumetricFogComponentController() = default;
+        VolumetricFogComponentController(const VolumetricFogComponentConfig& config);
+
+        void Activate(EntityId entityId);
+        void Deactivate();
+        void SetConfiguration(const VolumetricFogComponentConfig& config);
+        const VolumetricFogComponentConfig& GetConfiguration() const;
+
+         // Getter / Setter methods override declarations
+         // Generate Get / Set methods
+            
+#define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)                                  \
+        ValueType Get##Name() const override;                                                           \
+        void Set##Name(ValueType val) override;                                                         \
+
+#include <Atom/Feature/ParamMacros/MapParamCommon.inl>
+#include <Atom/Feature/VolumetricFog/VolumetricFogParams.inl>
+#include <Atom/Feature/ParamMacros/EndParams.inl>
+
+    private:
+        AZ_DISABLE_COPY(VolumetricFogComponentController);
+
+        void OnConfigChanged();
+
+        VolumetricFogFeatureProcessorInterface* m_featureProcessorInterface = nullptr;
+        VolumetricFogComponentConfig m_configuration;
+        EntityId m_entityId;
+    };
+} // namespace AZ::Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/VolumetricFogComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/VolumetricFog/VolumetricFogComponentController.h
@@ -14,6 +14,8 @@
 
 namespace AZ::Render
 {
+    //! Handles VolumetricFogRequestsBus and forwards property changes to VolumetricFogFeatureProcessorInterface
+    //! One instance per active VolumetricFog component.
     class VolumetricFogComponentController final
         : public VolumetricFogRequestsBus::Handler
     {
@@ -29,14 +31,16 @@ namespace AZ::Render
         VolumetricFogComponentController() = default;
         VolumetricFogComponentController(const VolumetricFogComponentConfig& config);
 
+        //! Connects to the bus and acquires VolumetricFogFeatureProcessorInterface from the scene.
         void Activate(EntityId entityId);
+        //! Disconnects from the bus and releases the feature processor pointer.
         void Deactivate();
         void SetConfiguration(const VolumetricFogComponentConfig& config);
         const VolumetricFogComponentConfig& GetConfiguration() const;
 
          // Getter / Setter methods override declarations
          // Generate Get / Set methods
-            
+
 #define AZ_GFX_COMMON_PARAM(ValueType, Name, MemberName, DefaultValue)                                  \
         ValueType Get##Name() const override;                                                           \
         void Set##Name(ValueType val) override;                                                         \
@@ -48,9 +52,10 @@ namespace AZ::Render
     private:
         AZ_DISABLE_COPY(VolumetricFogComponentController);
 
+        //! Pushes all config values to the feature processor; called after any setter.
         void OnConfigChanged();
 
-        VolumetricFogFeatureProcessorInterface* m_featureProcessorInterface = nullptr;
+        VolumetricFogFeatureProcessorInterface* m_featureProcessorInterface = nullptr; // non-owning pointer; valid only between Activate / Deactivate
         VolumetricFogComponentConfig m_configuration;
         EntityId m_entityId;
     };

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/atomlyintegration_commonfeatures_editor_files.cmake
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/atomlyintegration_commonfeatures_editor_files.cmake
@@ -128,7 +128,10 @@ set(FILES
 #if defined(CARBONATED)
     Source/Silhouette/EditorSilhouetteSystemComponent.cpp
     Source/Silhouette/EditorSilhouetteSystemComponent.h
+    Source/VolumetricFog/EditorVolumetricFogComponent.cpp
+    Source/VolumetricFog/EditorVolumetricFogComponent.h
+    Source/VolumetricFog/EditorFogVolumeComponent.cpp
+    Source/VolumetricFog/EditorFogVolumeComponent.h
 #endif
-
     Resources/AtomLyIntegrationResources.qrc
 )

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/atomlyintegration_commonfeatures_editor_files.cmake
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/atomlyintegration_commonfeatures_editor_files.cmake
@@ -125,13 +125,13 @@ set(FILES
     Source/Scripting/EditorEntityReferenceComponent.h
     Source/SurfaceData/EditorSurfaceDataMeshComponent.cpp
     Source/SurfaceData/EditorSurfaceDataMeshComponent.h
-#if defined(CARBONATED)
+# Begin CARBONATED
     Source/Silhouette/EditorSilhouetteSystemComponent.cpp
     Source/Silhouette/EditorSilhouetteSystemComponent.h
     Source/VolumetricFog/EditorVolumetricFogComponent.cpp
     Source/VolumetricFog/EditorVolumetricFogComponent.h
     Source/VolumetricFog/EditorFogVolumeComponent.cpp
     Source/VolumetricFog/EditorFogVolumeComponent.h
-#endif
+# End CARBONATED
     Resources/AtomLyIntegrationResources.qrc
 )

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/atomlyintegration_commonfeatures_files.cmake
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/atomlyintegration_commonfeatures_files.cmake
@@ -193,4 +193,16 @@ set(FILES
     Source/Scripting/EntityReferenceComponentController.h
     Source/SurfaceData/SurfaceDataMeshComponent.cpp
     Source/SurfaceData/SurfaceDataMeshComponent.h
+#if defined(CARBONATED)
+    Source/VolumetricFog/VolumetricFogComponentConfig.cpp
+    Source/VolumetricFog/VolumetricFogComponentController.cpp
+    Source/VolumetricFog/VolumetricFogComponentController.h
+    Source/VolumetricFog/VolumetricFogComponent.cpp
+    Source/VolumetricFog/VolumetricFogComponent.h
+    Source/VolumetricFog/FogVolumeComponentConfig.cpp
+    Source/VolumetricFog/FogVolumeComponentController.cpp
+    Source/VolumetricFog/FogVolumeComponentController.h
+    Source/VolumetricFog/FogVolumeComponent.cpp
+    Source/VolumetricFog/FogVolumeComponent.h
+#endif
 )

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/atomlyintegration_commonfeatures_files.cmake
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/atomlyintegration_commonfeatures_files.cmake
@@ -193,7 +193,7 @@ set(FILES
     Source/Scripting/EntityReferenceComponentController.h
     Source/SurfaceData/SurfaceDataMeshComponent.cpp
     Source/SurfaceData/SurfaceDataMeshComponent.h
-#if defined(CARBONATED)
+# Begin CARBONATED
     Source/VolumetricFog/VolumetricFogComponentConfig.cpp
     Source/VolumetricFog/VolumetricFogComponentController.cpp
     Source/VolumetricFog/VolumetricFogComponentController.h
@@ -204,5 +204,5 @@ set(FILES
     Source/VolumetricFog/FogVolumeComponentController.h
     Source/VolumetricFog/FogVolumeComponent.cpp
     Source/VolumetricFog/FogVolumeComponent.h
-#endif
+# End CARBONATED
 )

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/atomlyintegration_commonfeatures_public_files.cmake
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/atomlyintegration_commonfeatures_public_files.cmake
@@ -82,4 +82,10 @@ set(FILES
     Include/AtomLyIntegration/CommonFeatures/Scripting/EntityReferenceRequestBus.h
     Include/AtomLyIntegration/CommonFeatures/Scripting/EntityReferenceConstants.h
     Include/AtomLyIntegration/CommonFeatures/Scripting/EntityReferenceComponentConfig.h
+#if defined(CARBONATED)
+    Include/AtomLyIntegration/CommonFeatures/VolumetricFog/VolumetricFogBus.h
+    Include/AtomLyIntegration/CommonFeatures/VolumetricFog/VolumetricFogComponentConfig.h
+    Include/AtomLyIntegration/CommonFeatures/VolumetricFog/FogVolumeBus.h
+    Include/AtomLyIntegration/CommonFeatures/VolumetricFog/FogVolumeComponentConfig.h
+#endif
 )

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/atomlyintegration_commonfeatures_public_files.cmake
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/atomlyintegration_commonfeatures_public_files.cmake
@@ -82,10 +82,10 @@ set(FILES
     Include/AtomLyIntegration/CommonFeatures/Scripting/EntityReferenceRequestBus.h
     Include/AtomLyIntegration/CommonFeatures/Scripting/EntityReferenceConstants.h
     Include/AtomLyIntegration/CommonFeatures/Scripting/EntityReferenceComponentConfig.h
-#if defined(CARBONATED)
+# Begin CARBONATED
     Include/AtomLyIntegration/CommonFeatures/VolumetricFog/VolumetricFogBus.h
     Include/AtomLyIntegration/CommonFeatures/VolumetricFog/VolumetricFogComponentConfig.h
     Include/AtomLyIntegration/CommonFeatures/VolumetricFog/FogVolumeBus.h
     Include/AtomLyIntegration/CommonFeatures/VolumetricFog/FogVolumeComponentConfig.h
-#endif
+# End CARBONATED
 )


### PR DESCRIPTION
## What does this PR do?

### Overview
  
  This PR introduces a froxel-based volumetric fog system into the Atom render pipeline. The implementation uses a 3D voxel grid (froxel = frustum voxel) aligned to the camera frustum to accumulate in-scattered light, apply temporal anti-aliasing to amortize cost across frames, and composite the result over the scene at full resolution.

  The system exposes two new O3DE editor components:
  - Volumetric Fog — placed on a Level or Game entity; controls the global fog grid and medium.
  - Fog Volume — placed on any Game entity with a Box or Sphere shape; overrides the fog medium locally within its bounds.

  Light interaction is physically based: the Henyey-Greenstein phase function models forward/backward scattering anisotropy, and the Beer-Lambert law governs transmittance accumulation. All Atom light types (directional, point, simple point, disk, capsule, quad,  polygon, simple spot) contribute to in-scattering, using the existing light culling tile iterator so no additional culling pass is needed.

A good resource for understanding volumentric rendering [here](https://www.scratchapixel.com/lessons/3d-basic-rendering/volume-rendering-for-developers/intro-volume-rendering.html)

  ---
###   System Architecture

####   Feature Processors

  **VolumetricFogFeatureProcessor** is the central owner. It:
  - Manages the global froxel grid dimensions (sized per quality preset), the scene SRG constants, and the Halton jitter sequence  for temporal anti-aliasing.
  - Submits two fullscreen draw packets (min/max depth transparent) so the light culling system doesn't cull lights needed for calculating the in-scattering for the volumetric fog.
  - Owns the VolumetricFogSettings struct, which holds all global fog parameters and is kept in sync with the scene SRG.

  **FogVolumeFeatureProcessor** manages the array of local fog volumes. It:
  - Maintains a pool of Fog Volumes.
  - Each frame it process all available fog volumes, cull them against the camera, and sort them by shape and blend mode. This way we only emit one draw call per shape and blend mode, and use instancing to render each fog volume.
  - Uploads proxy mesh geometry (unit cube for boxes, icosphere for spheres) used by the local volume rasterization pass.
  - Handles noise texture assignment per volume.

####   Render Pass Pipeline                                                                                                              
  The FroxelParent pass lives between the opaque and transparent passes.  In contains all the passes needed for populating the froxel buffer which will be use to apply (composite) fog to the scene.

  - **FroxelInject**: Seeds each froxel with medium information (scattering and extinction coefficients). This represents how much the medium will scatter, absorbs and emit when light goes through the fog. It uses an optional 3D texture to generate heterogeneous fog density. If not present, the fog density is the same in the whole volume and the height falloff is the only parameter affecting the density. 
  - **FroxelLocalVolume**:  Fog volumes are rasterized directly into the froxel grid (3D texture) in order to contribute to the global medium.  Since we are rasterizing we can use the add, overwrite, min and max blending modes. Fog Volumes can "remove" density from the global  density if needed. One use case is for interiors where fog could be 0 or wind is not present. In order to cover the different depths that a fog volume occupies in space, each volume is rasterized at different depths using the SV_RenderTargetArrayIndex semantic. Each depth corresponds to a different slice of the 3D froxel medium texture that we are rendering to. The depths that a fog volume uses are calculated on CPU and pass as arguments in a Buffer to the vertex shader. Fog Volumes are grouped by shape and blend mode, and instancing is used for rendering all of them in one draw call. The geometry (vertex and index) are passed as buffers and read from the vertex shader using the instance and vertex ID.
  - **FroxelScatter**: Evaluates in-scattered light at each froxel from all Atom light types (directional, point, disk, capsule, quad,
  polygon, spot) plus IBL ambient contribution, using the Henyey-Greenstein phase function. This pass uses the already constructed light culling information in order to apply the lighting to each froxel in the same way we do it at pixel level for all geometry. This is generally the most expensive pass because of the heavy lighting calculations. The calculation is done per froxel and not per pixel.
  - **FroxelIntegrate**: This pass is in charge of accumulating the fog for each froxel from the position of the camera. It uses the  Beer-Lambert equation to calculate along a path (front to back) how much lighting each froxel accumulates. To help with antialiasing it also uses temporal reprojection from the previous frame's results. This creates some instability (flickering) for froxels that are close to bright lights due to the jittering and abrupt intensity variations frame to frame.
  - **FroxelComposite**: Applies the integrated froxel volume from the FroxelIntegrate pass into the scene. For this it uses the previous scene output along the depth buffer to calculate how much fog has accumulated in that specific position. Transparent objects need to apply their own volumetric fog, since they don't write to the depth buffer. To do this they use the already built froxel accumulation buffer.  A helper function was added for transparent objects (ApplyVolumetricFog.azsli).

<img width="647" height="490" alt="image" src="https://github.com/user-attachments/assets/30e43ed8-be62-45f7-a73e-14d41372af2f" />

The medium passes (FroxelInject and FroxelLocalVolume) can run in parallel with the light accumulation (FroxelScatter). The Froxel Integrate is the point where both join, so the Froxel composite can apply it at the end.

#### Supporting Changes

Some small changes/fixes had to be done in order to support Volumetric Fog.

-  **Image Processing** (ImageProcessingAtom): A new FlipbookSettings class and editor widget were added. This allows a texture atlas to be exported as a 3D Texture3D asset usable as the fog noise texture.
-  **Vulkan RHI**: ImageView was updated to correctly handle 3D image views, which are required for the RWTexture3D / Texture3D resources used by the froxel passes.
- **Transparent pass shaders**: All forward transparent shaders (ForwardPass_StandardLighting, Transparent_StandardLighting, etc.) now  #include "ApplyVolumetricFog.azsli" to correctly attenuate and fog transparent geometry using the integrated froxel volume.
-  **ComputePass:** Minor extension to expose SetShaderOption() publicly, used by FroxelPass to configure quality-dependent dispatch  parameters.

### How to use it?

As previously mentioned, 2 new components are exposed to the user. The first one is the Volumetric Fog Component. This component controls the settings for the global fog volume. It also allows enabling disabling the fog. This component must exist in the level in order for Volumetric Fog to work (Level or Game entity)

<img width="321" height="258" alt="Screenshot 2026-05-05 124810" src="https://github.com/user-attachments/assets/085e3ec5-cec6-4856-93b7-07864f14ad2e" />

<img width="321" height="568" alt="image" src="https://github.com/user-attachments/assets/48ccecd0-5336-44c5-b8da-fb87333a596b" />

Properties:

- **Enable**: Master on/off toggle for the entire fog system. 
-  **Quality**: Froxel tile size: Low (16x16x64), Mid (8x8x128), High (4x4x128). Higher quality increases froxel count and GPU cost. 
- **Start Distance:**  How far from the camera the fog volume begins. Objects closer than this are unaffected.
- **End Distance**:  Distance at which the fog fully covers the background. Must be greater than Start Distance. 
- **Albedo**: Single-scattering albedo per RGB channel. White produces a bright neutral mist; tinted values color the fog; dark values create an absorbing, smoky appearance. 
- **Density**:  Extinction coefficient σ_t. Controls how quickly light is attenuated through the fog. Higher values make the fog thicker and more opaque.
- **Base Height**: World-space height at which the fog layer starts. Fog below this height is at full density.
- **Falloff**: Rate at which fog density decreases above Base Height. Higher values make the fog thin out quickly. 
- **Noise Texture:** 3D noise texture used to add spatial turbulence to the fog density. Leave empty for uniform fog. See section about importing a 3D texture.
- **Noise Scale:** UV tiling scale for the noise texture. Smaller values produce larger fog banks; larger values produce fine wisps.
- **Noise Wind Velocity**: World-space wind direction and speed that scrolls the noise texture over time, simulating animated fog movement. Density must not be uniform in order to see the wind effect.
- **Anisotropy**: Henyey-Greenstein asymmetry parameter g. 0 = isotropic (equal scattering in all directions); values approaching 1 produce strong forward scattering (a halo around light sources).
- **Ambient Intensity**: scale applied to the IBL diffuse ambient contribution sampled from the scene's environment cubemap. Controls how much the sky/environment tints the fog ambient color.
- **Emissive Color**: Self-illumination color. The fog emits this color proportionally to its local density.
- **Emissive Intensity**: Scale on the emissive color. Values above 1 produce HDR glow.
- **Lighting Channels:** Which lighting channels contribute in-scattering to the fog.
- **Sequence Length**: Number of frames in the Halton sub-pixel jitter sequence. Longer sequences improve temporal quality at the cost of slower convergence after camera cuts.
- **Blend** Percentage: How much of the previous frame's result to blend in during temporal reprojection. Higher values reduce noise but can cause ghosting.

The second component that was created is the Fog Volume Component. A Fog Volume locally overrides the fog medium within its shape bounds. Multiple overlapping volumes are resolved by priority and blend mode.  In order for fog volumes to work, the Volumetric Fog **MUST** be enable for the level. This means that you need a Volumetric Fog somewhere, even if it's not adding anything.

<img width="313" height="253" alt="Screenshot 2026-05-05 130927" src="https://github.com/user-attachments/assets/edffcb60-8cda-4ada-8422-32d557599ca1" />
<img width="313" height="694" alt="image" src="https://github.com/user-attachments/assets/4c0bc772-7466-4803-bb97-601f0b1ca6d4" />

Properties:

- **Shape**: Box or Sphere. Automatically adds the corresponding Shape component to the entity. Size of the fog volume is controlled by the size of the Shape component.
- **Blend Mode**: How this volume composites with the existing froxel medium. Additive adds on top (thickens fog). Multiply  multiplies into existing fog (thins or tints). Overwrite replaces fog inside the volume entirely. Min / Max per-froxel minimum or maximum.
- **Edge Fade**: Per-axis soft edge fade fraction. 0 = hard boundary at the volume edge. 1 = fog fades to zero at the volume's center axis. For Sphere volumes only the X component is used (radial fade).
- Density, Turbulence and Lighting are the same properties as the Volumetric Fog component.

#### How to import a 3D texture

There's two ways of importing a 3D texture. The first one was already supported by the engine. O3de support 3D textures from DDS files. You can create them using different software. One way is using the Nvidia Texture Tools Exporter. This allows you to convert a vertical flipbook of images into a 3D texture. It also allows you to create mipmaps. The second way of importing was added in this PR. You can create a 3D texture directly from a flipbook texture, where each cell represents a slice of the 3D texture. In order to import it you need to tell the engine how many rows and columns the flipbook has. You can do this from the texture settings in the editor.
<img width="392" height="472" alt="Screenshot 2026-05-05 132107" src="https://github.com/user-attachments/assets/49a1c0e4-0ad5-4144-861c-8943807a54c0" />
<img width="998" height="732" alt="image" src="https://github.com/user-attachments/assets/304a8752-dd82-4100-84e0-1a741804f57f" />

Since the noise texture only uses one channel, you can set the Preset to "Greyscale".
A couple of example noise textures were added to the "Gems\Atom\Feature\Common\Assets\Textures\VolumetricFog" folder.

A good site to generate 3D noise that I found is this [one](https://noisegen.bubblebirdstudio.com/). Just select 3D as dimension, and resolution to 256. This will generate a 2D image with 256 cells (16x16) of 256x256 pixels that can be used in the engine.

### Examples

Global Fog with 3D noise texture and wind

https://github.com/user-attachments/assets/cccf45e7-45b6-43a8-8432-06cda1e21061

Fog Volume with no fog

https://github.com/user-attachments/assets/bd68d479-05ce-435f-8bb5-747dea366909

Fog Volume with red emissive

https://github.com/user-attachments/assets/58a70e3e-9362-47c2-bc2e-78b0212a7bc0

Interior with less fog and no wind. You can see the fog moving through the roof windows.

https://github.com/user-attachments/assets/ca67e0ab-f1ec-433d-ba78-135c8f25767d

PopcornFX particles with fog

https://github.com/user-attachments/assets/ecfce206-9aa6-4f7b-91b5-5a82da69a61c

## How was this PR tested?

Run on Windows (Editor and GameLauncher) on Vulkan and DX12