### PR TITLE
Reduce shader creation log time threshold for linux platform

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/MeshDrawPacket.cpp
@@ -511,7 +511,13 @@ namespace AZ
                         const int64_t startTime = static_cast<int64_t>(AZ::GetRealElapsedTimeMs());
                         appendShader(shaderItem, materialPipelineName);
                         const int64_t dt = static_cast<int64_t>(AZ::GetRealElapsedTimeMs()) - startTime;
-                        if (dt > 50)
+                        const int64_t threshold =
+#if defined(AZ_PLATFORM_LINUX)
+                                                  20;
+#else
+                                                  50;
+#endif
+                        if (dt > threshold)
                         {
                             AZ_Info("PrimitiveLoadTime", "appended shader '%s' for pipeline '%s' in  %d ms", shaderItem.GetShaderAsset().GetHint().c_str(), materialPipelineName.GetCStr(), dt);
                         }


### PR DESCRIPTION
## What does this PR do?

Decrease shader creation log time threshold for linux platform

## How was this PR tested?

Local build test
