### PR TITLE
[CAR-31757] Update BasePBR and StandardPBR wetness parameters, add wetness and snow-cover effects to MaterialCanvas

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/BasePBR_WetFeature.lua
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/BasePBR_WetFeature.lua
@@ -13,7 +13,7 @@
 -- This functor controls the flag that enables the overall feature for the shader.
 
 function GetMaterialPropertyDependencies()
-    return { "useWet", "textureMap", "useTexture" }
+    return { "enable", "textureMap", "useTexture" }
 end
 
 function GetShaderOptionDependencies()
@@ -21,8 +21,8 @@ function GetShaderOptionDependencies()
 end
 
 function Process(context)
-    local useWet = context:GetMaterialPropertyValue_bool("useWet")
-    context:SetShaderOptionValue_bool("o_useWet", useWet)
+    local enable = context:GetMaterialPropertyValue_bool("enable")
+    context:SetShaderOptionValue_bool("o_useWet", enable)
 
     local textureMap = context:GetMaterialPropertyValue_Image("textureMap")
     local useTexture = context:GetMaterialPropertyValue_bool("useTexture")
@@ -30,17 +30,17 @@ function Process(context)
 end
 
 function ProcessEditor(context)
-    local useWet = context:GetMaterialPropertyValue_bool("useWet")
+    local enable = context:GetMaterialPropertyValue_bool("enable")
     
     local mainVisibility
-    if(useWet) then
+    if(enable) then
         mainVisibility = MaterialPropertyVisibility_Enabled
     else
         mainVisibility = MaterialPropertyVisibility_Hidden
     end
 
-    context:SetMaterialPropertyVisibility("wetAmount", mainVisibility)
-    context:SetMaterialPropertyVisibility("wetFactor", mainVisibility)
+    context:SetMaterialPropertyVisibility("amount", mainVisibility)
+    context:SetMaterialPropertyVisibility("factor", mainVisibility)
     context:SetMaterialPropertyVisibility("useTexture", mainVisibility)
     context:SetMaterialPropertyVisibility("textureMap", mainVisibility)
     context:SetMaterialPropertyVisibility("textureMapUv", mainVisibility)
@@ -49,7 +49,7 @@ function ProcessEditor(context)
     local textureMap = context:GetMaterialPropertyValue_Image("textureMap")
     local useTexture = context:GetMaterialPropertyValue_bool("useTexture")
 
-    if(useWet) then
+    if(enable) then
         if(nil == textureMap) then
             context:SetMaterialPropertyVisibility("useTexture", MaterialPropertyVisibility_Hidden)
             context:SetMaterialPropertyVisibility("textureMapUv", MaterialPropertyVisibility_Hidden)

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/WetPropertyGroup.json
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/WetPropertyGroup.json
@@ -4,14 +4,14 @@
     "description": "Rain wetness overlay properties controlled by the Weather Gem.",
     "properties": [
         {
-            "name": "useWet",
-            "displayName": "Apply Wet",
-            "description": "Use Wet properties or not.",
+            "name": "enable",
+            "displayName": "Enable Wetness",
+            "description": "Use Wetness properties or not.",
             "type": "Bool",
             "defaultValue": false
         },
         {
-            "name": "wetAmount",
+            "name": "amount",
             "displayName": "Wetness Amount",
             "description": "Wetting factor, for example rain intensity, [0..1]: 0 is no wetting, 1 is maximal wetting.",
             "type": "Float",
@@ -24,7 +24,7 @@
             }
         },
         {
-            "name": "wetFactor",
+            "name": "factor",
             "displayName": "Wetness Factor",
             "description": "Moistening factor of surface material, [0..1]: 0 surface remains waterless, 1 surface is completely soaked.",
             "type": "Float",

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_SurfaceEval.azsli
@@ -130,14 +130,7 @@ Surface EvaluateSurface_BasePBR(
         // Vanishing wetness with distance from weather provider center, - non-linear.
         const float rainRadius =  clamp(SceneSrg::m_weatherRadius, 10.0f, 10000.0f);
         const float relativeDistance = length(positionWS.xy - SceneSrg::m_weatherCenter) / rainRadius;
-        if (relativeDistance > 1.0f)
-        {
-            wetAmount = 0.0f;
-        }
-        else if (relativeDistance > 0.75f)
-        {
-            wetAmount *= (1.0f - relativeDistance) * 4.0f;
-        }
+        wetAmount *= clamp((1.0f - relativeDistance) * 4.0f, 0.0f, 1.0f);        
         
         // Overall amount depends on setup amount, surface properties and surface normal
         const float effectiveWetness = saturate(wetFactor + 0.1f) * wetAmount * saturate(surface.normal.z + 0.25f);
@@ -181,14 +174,7 @@ Surface EvaluateSurface_BasePBR(
         // Vanishing snow cover with distance from weather provider center, - non-linear.
         const float snowRadius = clamp(SceneSrg::m_weatherRadius, 10.0f, 10000.0f);
         const float relativeDistance = length(positionWS.xy - SceneSrg::m_weatherCenter) / snowRadius;
-        if (relativeDistance > 1.0f)
-        {
-            snowAmount = 0.0f;
-        }
-        else if (relativeDistance > 0.75f)
-        {
-            snowAmount *= (1.0f - relativeDistance) * 4.0f;
-        }
+        snowAmount *= clamp((1.0f - relativeDistance) * 4.0f, 0.0f, 1.0f);        
 
         float snowFactor = saturate(MaterialSrg::m_snowFactor);
         if (o_snow_factor_useTexture)

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/SnowInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/SnowInput.azsli
@@ -19,9 +19,6 @@
 
 #define COMMON_SRG_INPUTS_SNOW(prefix) \
 float prefix##m_snowAmount; \
-float prefix##m_snowCenterX; \
-float prefix##m_snowCenterY; \
-float prefix##m_snowRadius; \
 Texture2D prefix##m_snowOpacityMap; \
 uint prefix##m_snowOpacityMapUvIndex; \
 float prefix##m_snowOpacityMapUvScale; \

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/WetInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/WetInput.azsli
@@ -18,9 +18,6 @@
 // You can optionally provide a prefix for the set of inputs which corresponds to a prefix string supplied by the .materialtype file. This is common for multi-layered material types.
 
 #define COMMON_SRG_INPUTS_WET(prefix) \
-float prefix##m_wetCenterX; \
-float prefix##m_wetCenterY; \
-float prefix##m_wetRadius; \
 float prefix##m_wetAmount;  \
 float prefix##m_wetFactor;  \
 Texture2D prefix##m_wetMap; \

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/BasePBR.materialgraphnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/BasePBR.materialgraphnode
@@ -335,6 +335,121 @@
                         "SLOTTYPE SLOTNAME = SLOTVALUE;"
                     ]
                 }
+            },
+            {
+                "name": "inSnowEnable",
+                "displayName": "Snow Enable",
+                "description": "Use Snow-cover values from material inputs.",
+                "supportedDataTypeRegex": "(color|bool|int|uint|float)([1-4])?",
+                "defaultDataType": "bool",
+                "defaultValue": {
+                    "$type": "bool",
+                    "Value": false
+                },
+                "allowNameSubstitution": false,
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE SLOTNAME = SLOTVALUE;"
+                    ]
+                }
+            },
+            {
+                "name": "inSnowAmount",
+                "displayName": "Snow Amount",
+                "description": "Snow Amount",
+                "supportedDataTypeRegex": "(color|bool|int|uint|float)([1-4])?",
+                "defaultDataType": "float",
+                "allowNameSubstitution": false,
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE SLOTNAME = SLOTVALUE;"
+                    ]
+                }
+            },
+            {
+                "name": "inSnowColor",
+                "displayName": "Snow Color",
+                "description": "Snow Color",
+                "supportedDataTypeRegex": "(color|bool|int|uint|float)([1-4])?",
+                "defaultDataType": "float3",
+                "defaultValue": {
+                    "$type": "Vector3",
+                    "Value": [
+                        0.92,
+                        0.98,
+                        1.0
+                    ]
+                },
+                "allowNameSubstitution": false,
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE SLOTNAME = SLOTVALUE;"
+                    ]
+                }
+            },
+            {
+                "name": "inSnowFactor",
+                "displayName": "Snow Factor",
+                "description": "Snow-covering properties",
+                "supportedDataTypeRegex": "(color|bool|int|uint|float)([1-4])?",
+                "defaultDataType": "float",
+                "allowNameSubstitution": false,
+                "defaultValue": {
+                    "$type": "float",
+                    "Value": 1.0
+                },
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE SLOTNAME = SLOTVALUE;"
+                    ]
+                }
+            },
+            {
+                "name": "inWetEnable",
+                "displayName": "Wet Enable",
+                "description": "Use rain wetness values from material inputs.",
+                "supportedDataTypeRegex": "(color|bool|int|uint|float)([1-4])?",
+                "defaultDataType": "bool",
+                "defaultValue": {
+                    "$type": "bool",
+                    "Value": false
+                },
+                "allowNameSubstitution": false,
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE SLOTNAME = SLOTVALUE;"
+                    ]
+                }
+            },
+            {
+                "name": "inWetAmount",
+                "displayName": "Wet Amount",
+                "description": "Wetness Amount",
+                "supportedDataTypeRegex": "(color|bool|int|uint|float)([1-4])?",
+                "defaultDataType": "float",
+                "allowNameSubstitution": false,
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE SLOTNAME = SLOTVALUE;"
+                    ]
+                }
+            },
+            {
+                "name": "inWetFactor",
+                "displayName": "Wet Factor",
+                "description": "Moistening properties",
+                "supportedDataTypeRegex": "(color|bool|int|uint|float)([1-4])?",
+                "defaultDataType": "float",
+                "defaultValue": {
+                    "$type": "float",
+                    "Value": 0.61
+                },
+                "allowNameSubstitution": false,
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE SLOTNAME = SLOTVALUE;"
+                    ]
+                }
             }
         ]
     }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/BasePBR.materialgraphtemplate
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/BasePBR.materialgraphtemplate
@@ -265,7 +265,88 @@
                                     "Value": 0.0
                                 }
                             }
-                        }
+                        },
+                        {
+                            "Key": {
+                                "m_name": "inSnowEnable"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "bool",
+                                    "Value": false
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "m_name": "inSnowAmount"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "float",
+                                    "Value": 0.75
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "m_name": "inSnowFactor"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "float",
+                                    "Value": 1.0
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "m_name": "inSnowColor"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "Vector3",
+                                    "Value": [
+                                        0.92,
+                                        0.98,
+                                        1.0
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "m_name": "inWetEnable"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "bool",
+                                    "Value": false
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "m_name": "inWetAmount"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "float",
+                                    "Value": 0.75
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "m_name": "inWetFactor"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "float",
+                                    "Value": 0.61
+                                }
+                            }
+                        }                        
                     ],
                     "toolId": {
                         "Value": 2034248906

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_Common.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_Common.azsli
@@ -21,6 +21,14 @@
 #define UvSetCount 2
 #endif
 
+#ifndef CARBONATED_ENABLE_WETNESS
+#define CARBONATED_ENABLE_WETNESS 1
+#endif
+
+#ifndef CARBONATED_ENABLE_SNOW_OVERLAY
+#define CARBONATED_ENABLE_SNOW_OVERLAY 1
+#endif
+
 #include <Atom/Features/ShaderQualityOptions.azsli>
 #include <Atom/Features/PBR/LightingOptions.azsli>
 #include <Atom/Features/PBR/AlphaUtils.azsli>

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_SurfaceEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/BasePBR/MaterialGraphName_SurfaceEval.azsli
@@ -48,12 +48,19 @@ Surface EvaluateSurface_MaterialGraphName(
     // m_placeHolder keeps MaterialSrg from being compiled out when iterating on graphs
     const bool placeHolder = MaterialSrg::m_placeHolder;
 
-    // O3DE_GENERATED_INSTRUCTIONS_BEGIN: inNormal, inBaseColor, inMetallic, inRoughness, inSpecularF0Factor
+    // O3DE_GENERATED_INSTRUCTIONS_BEGIN: inNormal, inBaseColor, inMetallic, inRoughness, inSpecularF0Factor, inSnowEnable, inSnowAmount, inSnowFactor, inSnowColor, inWetEnable, inWetAmount, inWetFactor,
     real3 inNormal = normalWS;
     real3 inBaseColor = {1.0, 1.0, 1.0};
     real inMetallic = 0.0;
     real inRoughness = 0.0;
     real inSpecularF0Factor = 0.0;
+    bool inSnowEnable = false;
+    real inSnowAmount = 0.0;
+    real inSnowFactor = 1.0;
+    real3 inSnowColor = { 0.92, 0.98, 1.0 };
+    bool inWetEnable = false;
+    real inWetAmount = 0.0;
+    real inWetFactor = 0.61;
     // O3DE_GENERATED_INSTRUCTIONS_END
 
     #undef O3DE_MC_UV
@@ -65,6 +72,66 @@ Surface EvaluateSurface_MaterialGraphName(
     surface.normal *= real(mad(isFrontFace, 2.0, -1.0));
 
     surface.roughnessLinear = inRoughness;
+    
+#ifdef CARBONATED_ENABLE_WETNESS
+    if (inWetEnable)
+    {
+        float wetFactor = saturate(inWetFactor);
+        float wetAmount = saturate(inWetAmount);
+        
+        // The wetFactor is describing Moistening properties of a surface material.
+        // For Metals:              wetFactor < 0.3         -> porosity <= 0.1; maxDarken <= 0.2;
+        // For Smooth Dielectrics:  0.3 >= wetFactor < 0.6  -> porosity <= 0.5; maxDarken <= 0.5;
+        // For Porous Dielectrics:  0.6 >= wetFactor < 1.0  -> porosity <= 0.9; maxDarken <= 0.95;
+        // Approximation:
+        const float porosity = saturate(pow(1.15f, wetFactor) - 0.1f);
+        const float maxDarken = pow(1.25f, wetFactor) * 0.95f;
+
+        // Vanishing wetness with distance from weather provider center, - non-linear.
+        const float rainRadius =  clamp(SceneSrg::m_weatherRadius, 10.0f, 10000.0f);
+        const float relativeDistance = length(positionWS.xy - SceneSrg::m_weatherCenter) / rainRadius;
+        wetAmount *= clamp((1.0f - relativeDistance) * 4.0f, 0.0f, 1.0f);        
+        
+        // Overall amount depends on setup amount, surface properties and surface normal
+        const float effectiveWetness = saturate(wetFactor + 0.1f) * wetAmount * saturate(surface.normal.z + 0.25f);
+        const float darkening = 1.0f - effectiveWetness * porosity * maxDarken;
+        const float3 waterTint = float3(0.96f, 0.98f, 1.0f);
+        inBaseColor = inBaseColor * darkening * lerp(1.0, waterTint, effectiveWetness * 0.3f);
+        
+        const float smoothFactor = lerp(0.7f, 0.3f, saturate(surface.roughnessLinear * 2.0f));
+        surface.roughnessLinear = lerp(surface.roughnessLinear, 0.02f, effectiveWetness * smoothFactor);
+        
+        const float waterF0 = 0.02f;
+        if (inMetallic > 0.5f)
+        {
+            inSpecularF0Factor = lerp(inSpecularF0Factor, max(inSpecularF0Factor, waterF0), effectiveWetness * 0.5f);
+        }
+        else
+        {
+            inSpecularF0Factor = lerp(inSpecularF0Factor, waterF0, effectiveWetness * (1.0f - porosity * 0.5f));
+        }
+    }
+#endif
+    
+#ifdef CARBONATED_ENABLE_SNOW_OVERLAY
+    if (inSnowEnable)
+    {
+        float snowAmount = saturate(inSnowAmount);
+        // Vanishing snow cover with distance from weather provider center, - non-linear.
+        const float snowRadius = clamp(SceneSrg::m_weatherRadius, 10.0f, 10000.0f);
+        const float relativeDistance = length(positionWS.xy - SceneSrg::m_weatherCenter) / snowRadius;
+        snowAmount *= clamp((1.0f - relativeDistance) * 4.0f, 0.0f, 1.0f);        
+
+        // Overall amount depends on setup amount, surface properties and surface normal
+        snowAmount *= inSnowFactor * sqrt(saturate(surface.normal.z));
+               
+        //inBaseColor = lerp(inBaseColor, inSnowColor, snowAmount);
+        inBaseColor = real3(0.92, 0.98, 1.0);
+        inSpecularF0Factor = lerp(inSpecularF0Factor, 0.98f, snowAmount);
+        inMetallic = lerp(inMetallic, 0.01f, snowAmount);
+    }
+#endif
+    
     surface.SetAlbedoAndSpecularF0(inBaseColor, inSpecularF0Factor, inMetallic);
     surface.CalculateRoughnessA();
     return surface;

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_Common.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_Common.azsli
@@ -25,6 +25,14 @@
 #define UvSetCount 2
 #endif
 
+#ifndef CARBONATED_ENABLE_WETNESS
+#define CARBONATED_ENABLE_WETNESS 1
+#endif
+
+#ifndef CARBONATED_ENABLE_SNOW_OVERLAY
+#define CARBONATED_ENABLE_SNOW_OVERLAY 1
+#endif
+
 #include <Atom/Features/ShaderQualityOptions.azsli>
 #include <Atom/Features/PBR/LightingOptions.azsli>
 #include <Atom/Features/PBR/AlphaUtils.azsli>

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_SurfaceEval.azsli
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/MaterialGraphName_SurfaceEval.azsli
@@ -50,7 +50,7 @@ Surface EvaluateSurface_MaterialGraphName(
     // m_placeHolder keeps MaterialSrg from being compiled out when iterating on graphs
     const bool placeHolder = MaterialSrg::m_placeHolder;
 
-    // O3DE_GENERATED_INSTRUCTIONS_BEGIN: inNormal, inBaseColor, inMetallic, inRoughness, inSpecularF0Factor, inEmissive, inAlpha, inOpacityFactor, inDiffuseAmbientOcclusion, inSpecularOcclusion, inClearCoatFactor, inClearCoatRoughness, inClearCoatNormal, 
+    // O3DE_GENERATED_INSTRUCTIONS_BEGIN: inNormal, inBaseColor, inMetallic, inRoughness, inSpecularF0Factor, inEmissive, inAlpha, inOpacityFactor, inDiffuseAmbientOcclusion, inSpecularOcclusion, inClearCoatFactor, inClearCoatRoughness, inClearCoatNormal, inSnowEnable, inSnowAmount, inSnowFactor, inSnowColor, inWetEnable, inWetAmount, inWetFactor,
     real3 inNormal = normalWS;
     real3 inBaseColor = {1.0, 1.0, 1.0};
     real inMetallic = 0.0;
@@ -64,6 +64,13 @@ Surface EvaluateSurface_MaterialGraphName(
     real inClearCoatFactor = 0.0;
     real inClearCoatRoughness = 0.0;
     real3 inClearCoatNormal = normalWS;
+    bool inSnowEnable = false;
+    real inSnowAmount = 0.0;
+    real inSnowFactor = 1.0;
+    real3 inSnowColor = { 0.92, 0.98, 1.0 };
+    bool inWetEnable = false;
+    real inWetAmount = 0.0;
+    real inWetFactor = 0.61;
     // O3DE_GENERATED_INSTRUCTIONS_END
 
     #undef O3DE_MC_UV
@@ -76,6 +83,65 @@ Surface EvaluateSurface_MaterialGraphName(
     surface.normal = normalize(o_normal_override_enabled ? GetWorldSpaceNormal((real2)inNormal, normalWS, tangents[0], bitangents[0]) : normalWS);
     surface.normal *= real(mad(isFrontFace, 2.0, -1.0));
     surface.roughnessLinear = inRoughness;
+    
+#ifdef CARBONATED_ENABLE_WETNESS
+    if (inWetEnable)
+    {
+        float wetFactor = saturate(inWetFactor);
+        float wetAmount = saturate(inWetAmount);
+        
+        // The wetFactor is describing Moistening properties of a surface material.
+        // For Metals:              wetFactor < 0.3         -> porosity <= 0.1; maxDarken <= 0.2;
+        // For Smooth Dielectrics:  0.3 >= wetFactor < 0.6  -> porosity <= 0.5; maxDarken <= 0.5;
+        // For Porous Dielectrics:  0.6 >= wetFactor < 1.0  -> porosity <= 0.9; maxDarken <= 0.95;
+        // Approximation:
+        const float porosity = saturate(pow(1.15f, wetFactor) - 0.1f);
+        const float maxDarken = pow(1.25f, wetFactor) * 0.95f;
+
+        // Vanishing wetness with distance from weather provider center, - non-linear.
+        const float rainRadius =  clamp(SceneSrg::m_weatherRadius, 10.0f, 10000.0f);
+        const float relativeDistance = length(positionWS.xy - SceneSrg::m_weatherCenter) / rainRadius;
+        wetAmount *= clamp((1.0f - relativeDistance) * 4.0f, 0.0f, 1.0f);        
+        
+        // Overall amount depends on setup amount, surface properties and surface normal
+        const float effectiveWetness = saturate(wetFactor + 0.1f) * wetAmount * saturate(surface.normal.z + 0.25f);
+        const float darkening = 1.0f - effectiveWetness * porosity * maxDarken;
+        const float3 waterTint = float3(0.96f, 0.98f, 1.0f);
+        inBaseColor = inBaseColor * darkening * lerp(1.0, waterTint, effectiveWetness * 0.3f);
+        
+        const float smoothFactor = lerp(0.7f, 0.3f, saturate(surface.roughnessLinear * 2.0f));
+        surface.roughnessLinear = lerp(surface.roughnessLinear, 0.02f, effectiveWetness * smoothFactor);
+        
+        const float waterF0 = 0.02f;
+        if (inMetallic > 0.5f)
+        {
+            inSpecularF0Factor = lerp(inSpecularF0Factor, max(inSpecularF0Factor, waterF0), effectiveWetness * 0.5f);
+        }
+        else
+        {
+            inSpecularF0Factor = lerp(inSpecularF0Factor, waterF0, effectiveWetness * (1.0f - porosity * 0.5f));
+        }
+    }
+#endif
+    
+#ifdef CARBONATED_ENABLE_SNOW_OVERLAY
+    if (inSnowEnable)
+    {
+        float snowAmount = saturate(inSnowAmount);
+        // Vanishing snow cover with distance from weather provider center, - non-linear.
+        const float snowRadius = clamp(SceneSrg::m_weatherRadius, 10.0f, 10000.0f);
+        const float relativeDistance = length(positionWS.xy - SceneSrg::m_weatherCenter) / snowRadius;
+        snowAmount *= clamp((1.0f - relativeDistance) * 4.0f, 0.0f, 1.0f);        
+
+        // Overall amount depends on setup amount, surface properties and surface normal
+        snowAmount *= inSnowFactor * sqrt(saturate(surface.normal.z));
+               
+        inBaseColor = lerp(inBaseColor, inSnowColor, snowAmount);
+        inSpecularF0Factor = lerp(inSpecularF0Factor, 0.98f, snowAmount);
+        inMetallic = lerp(inMetallic, 0.01f, snowAmount);
+    }
+#endif
+    
     surface.SetAlbedoAndSpecularF0(inBaseColor, inSpecularF0Factor, inMetallic);
     surface.CalculateRoughnessA();
 

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/StandardPBR.materialgraphnode
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/StandardPBR.materialgraphnode
@@ -566,6 +566,121 @@
                         "SLOTTYPE SLOTNAME = SLOTVALUE;"
                     ]
                 }
+            },
+            {
+                "name": "inSnowEnable",
+                "displayName": "Snow Enable",
+                "description": "Use Snow-cover values from material inputs, input group.name: 'snow.enable'.",
+                "supportedDataTypeRegex": "(color|bool|int|uint|float)([1-4])?",
+                "defaultDataType": "bool",
+                "allowNameSubstitution": false,
+                "defaultValue": {
+                    "$type": "bool",
+                    "Value": false
+                },
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE SLOTNAME = SLOTVALUE;"
+                    ]
+                }
+            },
+            {
+                "name": "inSnowAmount",
+                "displayName": "Snow Amount",
+                "description": "Snow-cover Amount, input group.name: 'snow.amount'",
+                "supportedDataTypeRegex": "(color|bool|int|uint|float)([1-4])?",
+                "defaultDataType": "float",
+                "allowNameSubstitution": false,
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE SLOTNAME = SLOTVALUE;"
+                    ]
+                }
+            },
+            {
+                "name": "inSnowColor",
+                "displayName": "Snow Color",
+                "description": "Snow-cover Color, input group.name: 'snow.color'",
+                "supportedDataTypeRegex": "(color|bool|int|uint|float)([1-4])?",
+                "defaultDataType": "float3",
+                "defaultValue": {
+                    "$type": "Vector3",
+                    "Value": [
+                        0.92,
+                        0.98,
+                        1.0
+                    ]
+                },
+                "allowNameSubstitution": false,
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE SLOTNAME = SLOTVALUE;"
+                    ]
+                }
+            },
+            {
+                "name": "inSnowFactor",
+                "displayName": "Snow Factor",
+                "description": "Snow-covering properties, input group.name: 'snow.factor'.",
+                "supportedDataTypeRegex": "(color|bool|int|uint|float)([1-4])?",
+                "defaultDataType": "float",
+                "allowNameSubstitution": false,
+                "defaultValue": {
+                    "$type": "float",
+                    "Value": 1.0
+                },
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE SLOTNAME = SLOTVALUE;"
+                    ]
+                }
+            },
+            {
+                "name": "inWetEnable",
+                "displayName": "Wet Enable",
+                "description": "Use rain wetness values from material inputs, input group.name: 'wet.useWet'.",
+                "supportedDataTypeRegex": "(color|bool|int|uint|float)([1-4])?",
+                "defaultDataType": "bool",
+                "defaultValue": {
+                    "$type": "bool",
+                    "Value": false
+                },
+                "allowNameSubstitution": false,
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE SLOTNAME = SLOTVALUE;"
+                    ]
+                }
+            },
+            {
+                "name": "inWetAmount",
+                "displayName": "Wet Amount",
+                "description": "Wetness Amount, input group.name: 'wet.wetAmount'",
+                "supportedDataTypeRegex": "(color|bool|int|uint|float)([1-4])?",
+                "defaultDataType": "float",
+                "allowNameSubstitution": false,
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE SLOTNAME = SLOTVALUE;"
+                    ]
+                }
+            },
+            {
+                "name": "inWetFactor",
+                "displayName": "Wet Factor",
+                "description": "Moistening properties, input group.name: 'wet.wetFactor'",
+                "supportedDataTypeRegex": "(color|bool|int|uint|float)([1-4])?",
+                "defaultDataType": "float",
+                "defaultValue": {
+                    "$type": "float",
+                    "Value": 0.61
+                },
+                "allowNameSubstitution": false,
+                "settings": {
+                    "instructions": [
+                        "SLOTTYPE SLOTNAME = SLOTVALUE;"
+                    ]
+                }
             }
         ]
     }

--- a/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/StandardPBR.materialgraphtemplate
+++ b/Gems/Atom/Tools/MaterialCanvas/Assets/MaterialCanvas/GraphData/Nodes/MaterialOutputs/StandardPBR/StandardPBR.materialgraphtemplate
@@ -349,6 +349,87 @@
                                     "Value": 1.0
                                 }
                             }
+                        },
+                        {
+                            "Key": {
+                                "m_name": "inSnowEnable"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "bool",
+                                    "Value": false
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "m_name": "inSnowAmount"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "float",
+                                    "Value": 0.75
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "m_name": "inSnowFactor"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "float",
+                                    "Value": 1.0
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "m_name": "inSnowColor"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "Vector3",
+                                    "Value": [
+                                        0.92,
+                                        0.98,
+                                        1.0
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "m_name": "inWetEnable"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "bool",
+                                    "Value": false
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "m_name": "inWetAmount"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "float",
+                                    "Value": 0.75
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "m_name": "inWetFactor"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "float",
+                                    "Value": 0.61
+                                }
+                            }
                         }
                     ],
                     "toolId": {
@@ -565,6 +646,33 @@
                         "Value": 2034248906
                     },
                     "configId": "{2E53F7CC-3C6D-4737-B092-2FB41204ECAC}"
+                }
+            },
+            {
+                "Key": 11,
+                "Value": {
+                    "$type": "DynamicNode",
+                    "m_inputDataSlots": [
+                        {
+                            "Key": {
+                                "m_name": "inValue"
+                            },
+                            "Value": {
+                                "m_value": {
+                                    "$type": "Vector3",
+                                    "Value": [
+                                        0.0,
+                                        0.0,
+                                        0.0
+                                    ]
+                                }
+                            }
+                        }
+                    ],
+                    "toolId": {
+                        "Value": 2034248906
+                    },
+                    "configId": "{CE1EF97A-5BFE-4459-8967-53878C7F074F}"
                 }
             }
         ],


### PR DESCRIPTION
### What does this PR do?
Closes [Car-31757](https://favro.com/organization/ab098f3312254434882b4396/579ee0f4d0168dab8e8d0252?card=Car-31757)

This PR must be coupled with the PR https://github.com/carbonated-dev/o3de-gems/pull/65 "Update surface effects managers with updated BasePBR and StandardPBR wetness parameters"

* Updates `BasePBR` and `StandardPBR` materials:
* * Renames wetness inputs: `"useWet"` into `"enable"`,` "wetAmount"` into` "amount"` and `"wetFactor"` into  `"factor"`; - this ensures uniformity and compatibility with `materialgraph` inputs in `MaterialCanvas`;
* * Cleans-up obsolete `MaterialSrg` members for weather surface effects center and radius (which were moved to `SceneSrg` in https://github.com/carbonated-dev/o3de/pull/523);
* * Optimizes distance blending - substituting "`if-else`" with the single line arithmetic.

* Updates `BasePBR` and `StandardPBR` material outputs in `MaterialCanvas` `materialgraph`s to have snow-cover and rain-wetness inputs and corresponding surface evaluation;

#### How does control of wetness and snow-cover work for `materialgraph`-based materials?

##### The final `materialgraph` should have inputs for weather surface effects' controlling parameters:
* For rain-wetness, - 2 mandatory and 1 optional parameters, all belonging to the `"wet"` group:
* * `"enable"`, - mandatory, switches rain-wetness effects on and off;
* * `"amount"`, - mandatory, controls volume of wetness;
* * `"factor"`, - optional, controls ability of this surface to receive wetness / moistening;
* * * may be omitted, then default value of 0.61 (Porous Dielectric) is used;
* * * may be omitted but calculated, for example, using a material-specific 'factor texture' input, and then propagated to the `"Wet Factor"` input of a `BasePBR` or `StandardPBR` output node;

* For snow-cover, - 2 mandatory and 1 optional parameters, all belonging to the `"snow"` group:
* * `"enable"`, - mandatory, switches snow-cover effects on and off;
* * `"amount"`, - mandatory, controls volume of snow-cover;
* * `"factor"`, - optional, controls ability of this surface to receive snow cover;
* * * may be omitted, then default value of 1.0 (full amount) is used;
* * * may be omitted but calculated, for example, using a material-specific 'factor texture' input, and then propagated to the `"Snow Factor"` input of a `BasePBR` or `StandardPBR` output node;

* For snow-cover, - both `BasePBR` or `StandardPBR` output nodes have the `'Snow Color"` RGB input, which is used as color to overlay on upward-facing triangles depending on `amount` and `factor`:
* * The default value is `{ 0.92, 0.98, 1.0 }`;
* * Another value may be calculated for each pixel using combination of material-specific 'texture' inputs (for example, for albedo, normals and roughness), and then then propagated to this input.

<img width="615" height="413" alt="UpdatedMaterialCanvas" src="https://github.com/user-attachments/assets/fbe983c6-74ae-4172-96a7-dc6bfb015dca" />

<img width="1318" height="507" alt="PlantsMaterialGraph" src="https://github.com/user-attachments/assets/ca8c5011-6b6c-4c36-b123-4ead402f98d3" />

##### Entities using such `materialgraph`-based materials should be marked by `Tag`s:
* either with `"rain_wetness"` and / or `"snow_cover"` tags in the `Tag` component of each Entity;
* or with `"rain_wetness_all"` and / or `"snow_cover_all"` tags in the `Tag` component of a parent Entity in the level hierarchy;

### How was this PR tested?
On PC the correct evaluation of weather-induced surface effects (rain-wetness and snow-cover) noted for prefabs using both `BasePBR`- and `StandardPBR`- based materials, and for `MaterialCanvas`-built `materialgraph`-based materials with appropriate inputs, both in Editor and in Editor-GameMode.

Builds run on Jenkins using this branch and corresponding Weather GEM and Red-game branches:
* [#44307](http://10.0.1.100:8080/job/Extraction/job/Client/job/build%252Fastarykh%252FCAR-31757-rain-snow-materials/2/pipeline-overview/) succeeded for iOS, Android and OC, Linux build failed with
CMake Error at cmake/EngineFinder.cmake:167 (message):
`[BUILD > SHELL] [build-linux] :   The project.json engine is 'o3de.carbonated.0' but no engine with that name and version was found.
`

In order to prepare the tutorial clip, some changes were made to Red-game materials and prefabs, please refer to the attached archive: [o3de-red-game_changes.zip](https://github.com/user-attachments/files/28147152/o3de-red-game_changes.zip)

https://github.com/user-attachments/assets/2fa69864-2845-4644-a5dc-364565752921
