### PR TITLE
backdrop-capture UV mapping fix for translucent UI feature

### DIFF
--- a/Gems/LyShine/Code/Source/UiImageComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiImageComponent.cpp
@@ -364,8 +364,9 @@ void UiImageComponent::Render(LyShine::IRenderGraph* renderGraph)
     ISprite* sprite = (m_overrideSprite) ? m_overrideSprite : m_sprite;
     const bool isBackdrop = IsSpriteTypeBackdrop();
     const AZ::Vector2 backdropCaptureSize = isBackdrop ? GetBackdropCaptureSize() : AZ::Vector2::CreateZero();
+    const AZ::Vector2 backdropViewportSize = isBackdrop ? GetBackdropViewportSize() : AZ::Vector2::CreateZero();
 
-    if (isBackdrop && m_cachedBackdropCaptureSize != backdropCaptureSize)
+    if (isBackdrop && (m_cachedBackdropCaptureSize != backdropCaptureSize || m_cachedBackdropViewportSize != backdropViewportSize))
     {
         m_isRenderCacheDirty = true;
     }
@@ -390,8 +391,9 @@ void UiImageComponent::Render(LyShine::IRenderGraph* renderGraph)
 
         if (isBackdrop)
         {
-            RenderBackdrop(backdropCaptureSize, packedColor);
+            RenderBackdrop(backdropViewportSize, packedColor);
             m_cachedBackdropCaptureSize = backdropCaptureSize;
+            m_cachedBackdropViewportSize = backdropViewportSize;
         }
         else
         {
@@ -2691,6 +2693,17 @@ AZ::Vector2 UiImageComponent::GetBackdropCaptureSize() const
     AZ::Vector2 backdropCaptureSize = AZ::Vector2::CreateZero();
     UiCanvasBus::EventResult(backdropCaptureSize, canvasEntityId, &UiCanvasBus::Events::GetBackdropCaptureSize);
     return backdropCaptureSize;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+AZ::Vector2 UiImageComponent::GetBackdropViewportSize() const
+{
+    AZ::EntityId canvasEntityId;
+    UiElementBus::EventResult(canvasEntityId, GetEntityId(), &UiElementBus::Events::GetCanvasEntityId);
+
+    AZ::Vector2 backdropViewportSize = AZ::Vector2::CreateZero();
+    UiCanvasBus::EventResult(backdropViewportSize, canvasEntityId, &UiCanvasBus::Events::GetCanvasSize);
+    return backdropViewportSize;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Gems/LyShine/Code/Source/UiImageComponent.h
+++ b/Gems/LyShine/Code/Source/UiImageComponent.h
@@ -260,6 +260,7 @@ private: // member functions
 
     AZ::Data::Instance<AZ::RPI::Image> GetBackdropImage() const;
     AZ::Vector2 GetBackdropCaptureSize() const;
+    AZ::Vector2 GetBackdropViewportSize() const;
 
 private: // static member functions
 
@@ -303,5 +304,6 @@ private: // data
     // cached rendering data for performance optimization
     LyShine::UiPrimitive m_cachedPrimitive;
     AZ::Vector2 m_cachedBackdropCaptureSize = AZ::Vector2::CreateZero();
+    AZ::Vector2 m_cachedBackdropViewportSize = AZ::Vector2::CreateZero();
     bool m_isRenderCacheDirty = true;
 };


### PR DESCRIPTION
## What does this PR do?

This PR fixes backdrop-capture UV mapping for LyShine translucent UI so the blurred background lines up correctly with the visible scene.

Previously, backdrop UI panels derived their sampling UVs using the backdrop capture texture size directly. In cases where the captured backdrop texture size did not exactly match the actual viewport/canvas size, the sampled image could appear offset, stretched, or slightly mismatched relative to the scene behind the panel.

With this change:
- backdrop UV generation uses the viewport/canvas size for screen-space mapping
- backdrop capture texture size remains available separately for sampling/blur behavior
- cached backdrop sizing is tracked independently for capture size vs viewport size

In practice, this makes the translucent/blurred panel better match what the player actually sees behind it on screen.

## How was this PR tested?

Tested locally with rebuilt LyShine/editor runtime and manual in-game verification.

Validation performed:
- verified backdrop panels still render correctly
- verified the blurred backdrop aligns more closely with the visible scene behind the panel
- verified the issue reproduced previously with noticeable scene mismatch / perspective offset was improved by the new mapping

