### PR TITLE
[CAR-32680] In BasePBR and StandardPBR: adjust defaults for Rain-wetness and Snow-cover factors, add wetness roughness,

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/BasePBR_SnowCoverFeature.lua
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/BasePBR_SnowCoverFeature.lua
@@ -129,6 +129,7 @@ function ProcessEditor(context)
     context:SetMaterialPropertyVisibility("normalStrength", mainVisibility)
     
     context:SetMaterialPropertyVisibility("roughness", mainVisibility)
+    context:SetMaterialPropertyVisibility("roughnessAmount", mainVisibility)
     context:SetMaterialPropertyVisibility("roughnessMap", mainVisibility)
     context:SetMaterialPropertyVisibility("useRoughnessMap", mainVisibility)
     context:SetMaterialPropertyVisibility("roughnessMapUv", mainVisibility)

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/BasePBR_WetFeature.lua
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/BasePBR_WetFeature.lua
@@ -13,20 +13,54 @@
 -- This functor controls the flag that enables the overall feature for the shader.
 
 function GetMaterialPropertyDependencies()
-    return { "enable", "textureMap", "useTexture" }
+    return {
+        "enable",
+        "factorMap",
+        "useFactorMap",
+        "roughnessMap",
+        "useRoughnessMap",
+        }
 end
 
 function GetShaderOptionDependencies()
-    return { "o_useWet", "o_wet_useTexture" }
+    return {
+        "o_wet_enabled",
+        "o_wet_factor_useTexture",
+        "o_wet_roughness_useTexture",
+        }
+end
+
+function UpdateUseTextureState(context, enable, textureMapPropertyName, useTexturePropertyName, shaderOptionName) 
+    local textureMap = context:GetMaterialPropertyValue_Image(textureMapPropertyName)
+    local useTextureMap = context:GetMaterialPropertyValue_bool(useTexturePropertyName)
+    context:SetShaderOptionValue_bool(shaderOptionName, enable and useTextureMap and textureMap ~= nil)
 end
 
 function Process(context)
     local enable = context:GetMaterialPropertyValue_bool("enable")
-    context:SetShaderOptionValue_bool("o_useWet", enable)
+    context:SetShaderOptionValue_bool("o_wet_enabled", enable)
 
-    local textureMap = context:GetMaterialPropertyValue_Image("textureMap")
-    local useTexture = context:GetMaterialPropertyValue_bool("useTexture")
-    context:SetShaderOptionValue_bool("o_wet_useTexture", useTexture and textureMap ~= nil)
+    UpdateUseTextureState(context, enable, "factorMap",    "useFactorMap",    "o_wet_factor_useTexture")
+    UpdateUseTextureState(context, enable, "roughnessMap", "useRoughnessMap", "o_wet_roughness_useTexture")
+end
+
+-- Note: property is excluded / hidden if a texture is used.
+function UpdateTextureDependentPropertyVisibility(context, propertyName, textureMapPropertyName, useTexturePropertyName, uvPropertyName, uvScalePropertyName)
+    local textureMap = context:GetMaterialPropertyValue_Image(textureMapPropertyName)
+    local useTexture = context:GetMaterialPropertyValue_bool(useTexturePropertyName)
+
+    if(textureMap == nil) then
+        context:SetMaterialPropertyVisibility(propertyName, MaterialPropertyVisibility_Enabled)
+        context:SetMaterialPropertyVisibility(useTexturePropertyName, MaterialPropertyVisibility_Hidden)
+        context:SetMaterialPropertyVisibility(uvPropertyName, MaterialPropertyVisibility_Hidden)
+        context:SetMaterialPropertyVisibility(uvScalePropertyName, MaterialPropertyVisibility_Hidden)
+    elseif(not useTexture) then
+        context:SetMaterialPropertyVisibility(propertyName, MaterialPropertyVisibility_Enabled)
+        context:SetMaterialPropertyVisibility(uvPropertyName, MaterialPropertyVisibility_Hidden)
+        context:SetMaterialPropertyVisibility(uvScalePropertyName, MaterialPropertyVisibility_Hidden)
+    else
+        context:SetMaterialPropertyVisibility(propertyName, MaterialPropertyVisibility_Hidden)
+    end
 end
 
 function ProcessEditor(context)
@@ -40,31 +74,22 @@ function ProcessEditor(context)
     end
 
     context:SetMaterialPropertyVisibility("amount", mainVisibility)
-    context:SetMaterialPropertyVisibility("factor", mainVisibility)
-    context:SetMaterialPropertyVisibility("useTexture", mainVisibility)
-    context:SetMaterialPropertyVisibility("textureMap", mainVisibility)
-    context:SetMaterialPropertyVisibility("textureMapUv", mainVisibility)
-    context:SetMaterialPropertyVisibility("textureMapUvScale", mainVisibility)
 
-    local textureMap = context:GetMaterialPropertyValue_Image("textureMap")
-    local useTexture = context:GetMaterialPropertyValue_bool("useTexture")
+    context:SetMaterialPropertyVisibility("factor", mainVisibility)
+    context:SetMaterialPropertyVisibility("factorMap", mainVisibility)
+    context:SetMaterialPropertyVisibility("factorMapUv", mainVisibility)
+    context:SetMaterialPropertyVisibility("factorMapUvScale", mainVisibility)
+    context:SetMaterialPropertyVisibility("useRoughnessMap", mainVisibility)
+    
+    context:SetMaterialPropertyVisibility("roughness", mainVisibility)
+    context:SetMaterialPropertyVisibility("roughnessAmount", mainVisibility)
+    context:SetMaterialPropertyVisibility("roughnessMap", mainVisibility)
+    context:SetMaterialPropertyVisibility("roughnessMapUv", mainVisibility)
+    context:SetMaterialPropertyVisibility("roughnessMapUvScale", mainVisibility)
+    context:SetMaterialPropertyVisibility("useRoughnessMap", mainVisibility)
 
     if(enable) then
-        if(nil == textureMap) then
-            context:SetMaterialPropertyVisibility("useTexture", MaterialPropertyVisibility_Hidden)
-            context:SetMaterialPropertyVisibility("textureMapUv", MaterialPropertyVisibility_Hidden)
-            context:SetMaterialPropertyVisibility("textureMapUvScale", MaterialPropertyVisibility_Hidden)
-            context:SetMaterialPropertyVisibility("wetFactor", MaterialPropertyVisibility_Enabled)
-        elseif(not useTexture) then
-            context:SetMaterialPropertyVisibility("useTexture", MaterialPropertyVisibility_Enabled)
-            context:SetMaterialPropertyVisibility("textureMapUv", MaterialPropertyVisibility_Disabled)
-            context:SetMaterialPropertyVisibility("textureMapUvScale", MaterialPropertyVisibility_Disabled)
-            context:SetMaterialPropertyVisibility("wetFactor", MaterialPropertyVisibility_Enabled)
-        else
-            context:SetMaterialPropertyVisibility("useTexture", MaterialPropertyVisibility_Enabled)
-            context:SetMaterialPropertyVisibility("textureMapUv", MaterialPropertyVisibility_Enabled)
-            context:SetMaterialPropertyVisibility("textureMapUvScale", MaterialPropertyVisibility_Enabled)
-            context:SetMaterialPropertyVisibility("wetFactor", MaterialPropertyVisibility_Hidden)
-        end
+        UpdateTextureDependentPropertyVisibility(context, "factor",    "factorMap",     "useFactorMap",    "factorMapUv",    "factorMapUvScale")
+        UpdateTextureDependentPropertyVisibility(context, "roughness", "roughnessMap",  "useRoughnessMap", "roughnessMapUv", "roughnessMapUvScale")
     end
 end

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/SnowPropertyGroup.json
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/SnowPropertyGroup.json
@@ -1,21 +1,21 @@
 {
     "name": "snow",
     "displayName": "Snow cover",
-    "description": "Snow cover overlay properties controlled by the Weather Gem",
+    "description": "Snow cover overlay properties, parially controlled by the Weather Gem",
     "properties": [
         {
             "name": "enable",
             "displayName": "Enable",
-            "description": "Option whether to enable snow cover overlay.",
+            "description": "Option whether to enable snow cover overlay, code-controllable.",
             "type": "Bool",
             "defaultValue": false
         },
         {
             "name": "amount",
             "displayName": "Amount",
-            "description": "Snow cover amount, for example snowfall intensity, [0..1]: 0 is no snow cover, 1 is snow cover all-over.",
+            "description": "Snow cover amount, for example snowfall intensity, code-controllable, 0 - no snow cover, 1 - snow cover all-over.",
             "type": "Float",
-            "defaultValue": 0.0,
+            "defaultValue": 1.0,
             "min": 0.0,
             "max": 1.0,
             "connection": {
@@ -70,9 +70,9 @@
         {
             "name": "factor",
             "displayName": "Factor",
-            "description": "Snow Cover factor of a surface material (blending), [0..1]: 0 no snow cover, 1 full snow cover.",
+            "description": "Snow Cover factor of a surface material (blending), 0 - no snow cover, 1 - full snow cover.",
             "type": "Float",
-            "defaultValue": 0.5,
+            "defaultValue": 1.0,
             "min": 0.0,
             "max": 1.0,
             "connection": {
@@ -178,7 +178,7 @@
         {
             "name": "normalMap",
             "displayName": "Normal Map",
-            "description": "Normal map for snow cover overlay, as top layer material snow cover isn't affected by base layer normal map",
+            "description": "Normal map for snow cover overlay, as top layer material snow cover isn't affected by base layer normal map.",
             "type": "Image",
             "optional": true,
             "connection": {
@@ -196,7 +196,7 @@
         {
             "name": "normalMapUv",
             "displayName": "    UV",
-            "description": "Snow cover normal map UV set",
+            "description": "Snow cover normal map UV set.",
             "type": "Enum",
             "enumIsUv": true,
             "optional": true,
@@ -222,7 +222,7 @@
         {
             "name": "normalStrength",
             "displayName": "    Normal Strength",
-            "description": "Scales the impact of the snow cover normal map,",
+            "description": "Scales the impact of the snow cover normal map, [0.0 .. 3.0].",
             "type": "Float",
             "defaultValue": 1.0,
             "min": 0.0,
@@ -238,7 +238,7 @@
             "displayName": "Roughness",
             "description": "Snow cover overlay roughness.",
             "type": "Float",
-            "defaultValue": 0.0,
+            "defaultValue": 0.75,
             "min": 0.0,
             "max": 1.0,
             "optional": true,
@@ -248,9 +248,22 @@
             }
         },
         {
+            "name": "roughnessAmount",
+            "displayName": "Roughness amount.",
+            "description": "Snow cover overlay roughness amount, code-controllable.",
+            "type": "Float",
+            "defaultValue": 1.0,
+            "min": 0.0,
+            "max": 1.0,
+            "connection": {
+                "type": "ShaderInput",
+                "name": "m_snowRoughnessAmount"
+            }
+        },
+        {
             "name": "roughnessMap",
             "displayName": "    Roughness Map",
-            "description": "Texture for defining surface roughness.",
+            "description": "Texture for defining snow cover roughness.",
             "type": "Image",
             "optional": true,
             "connection": {
@@ -260,8 +273,8 @@
         },
         {
             "name": "useRoughnessMap",
-            "displayName": "    Use Texture",
-            "description": "Option whether to use the texture, or just default to the roughness value.",
+            "displayName": "    Use Roughness Map",
+            "description": "Option whether to use the roughness texture, or just default to the roughness value.",
             "type": "Bool",
             "defaultValue": true
         },

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/WetPropertyGroup.json
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/WetPropertyGroup.json
@@ -1,21 +1,21 @@
 {
     "name": "wet",
     "displayName": "Wet",
-    "description": "Rain wetness overlay properties controlled by the Weather Gem.",
+    "description": "Rain wetness overlay properties, partially controlled by the Weather Gem.",
     "properties": [
         {
             "name": "enable",
             "displayName": "Enable Wetness",
-            "description": "Use Wetness properties or not.",
+            "description": "Use Wetness properties or not, code-controllable.",
             "type": "Bool",
             "defaultValue": false
         },
         {
             "name": "amount",
             "displayName": "Wetness Amount",
-            "description": "Wetting factor, for example rain intensity, [0..1]: 0 is no wetting, 1 is maximal wetting.",
+            "description": "Wetting amount, for example rain intensity, code-controllable, 0 - no wetting, 1 - maximal wetting.",
             "type": "Float",
-            "defaultValue": 0.0,
+            "defaultValue": 1.0,
             "min": 0.0,
             "max": 1.0,
             "connection": {
@@ -26,9 +26,9 @@
         {
             "name": "factor",
             "displayName": "Wetness Factor",
-            "description": "Moistening factor of surface material, [0..1]: 0 surface remains waterless, 1 surface is completely soaked.",
+            "description": "Moistening factor of surface material, 0 surface remains waterless, 1 surface is completely soaked.",
             "type": "Float",
-            "defaultValue": 0.0,
+            "defaultValue": 0.61,
             "min": 0.0,
             "max": 1.0,
             "connection": {
@@ -37,24 +37,17 @@
             }
         },
         {
-            "name": "useTexture",
-            "displayName": "Use Texture",
-            "description": "Whether to use the texture, or just default to the wetFactor value.",
-            "type": "Bool",
-            "defaultValue": true
-        },
-        {
-            "name": "textureMap",
-            "displayName": "Texture",
+            "name": "factorMap",
+            "displayName": "    Factor Map",
             "description": "Texture defining surface Moistening properties.",
             "type": "Image",
             "connection": {
                 "type": "ShaderInput",
-                "name": "m_wetMap"
+                "name": "m_wetFactorMap"
             }
         },
         {
-            "name": "textureMapUv",
+            "name": "factorMapUv",
             "displayName": "    UV",
             "description": "Moistening properties map UV set",
             "type": "Enum",
@@ -62,21 +55,96 @@
             "defaultValue": "Unwrapped",
             "connection": {
                 "type": "ShaderInput",
-                "name": "m_wetMapUvIndex"
+                "name": "m_wetFactorMapUvIndex"
             }
         },
         {
-            "name": "textureMapUvScale",
+            "name": "factorMapUvScale",
             "displayName": "    UV Scale",
-            "description": "Moistening properties map UV scale, [0.2 .. 20.0]",
+            "description": "Moistening properties map UV scale, [0.2 .. 20.0].",
             "type": "Float",
             "defaultValue": 1.0,
             "min": 0.2,
             "max": 20.0,
             "connection": {
                 "type": "ShaderInput",
-                "name": "m_wetMapUvScale"
+                "name": "m_wetFactorMapUvScale"
             }
+        },
+        {
+            "name": "useFactorMap",
+            "displayName": "    Use Factor Map",
+            "description": "Whether to use the factor texture, or just default to the factor value.",
+            "type": "Bool",
+            "defaultValue": true
+        },
+        {
+            "name": "roughness",
+            "displayName": "Wetness roughness",
+            "description": "Wetted surface roughness.",
+            "type": "Float",
+            "defaultValue": 0.5,
+            "min": 0.0,
+            "max": 1.0,
+            "connection": {
+                "type": "ShaderInput",
+                "name": "m_wetRoughness"
+            }
+        },
+        {
+            "name": "roughnessAmount",
+            "displayName": "Wetness roughness amount.",
+            "description": "Wetted surface roughness amount, code-controllable.",
+            "type": "Float",
+            "defaultValue": 1.0,
+            "min": 0.0,
+            "max": 1.0,
+            "connection": {
+                "type": "ShaderInput",
+                "name": "m_wetRoughnessAmount"
+            }
+        },
+        {
+            "name": "roughnessMap",
+            "displayName": "    Roughness Map",
+            "description": "Texture for re-defining wetted surface roughness.",
+            "type": "Image",
+            "connection": {
+                "type": "ShaderInput",
+                "name": "m_wetRoughnessMap"
+            }
+        },
+        {
+            "name": "roughnessMapUv",
+            "displayName": "    UV",
+            "description": "Wetted surface roughness map UV set.",
+            "type": "Enum",
+            "enumIsUv": true,
+            "defaultValue": "Unwrapped",
+            "connection": {
+                "type": "ShaderInput",
+                "name": "m_wetRoughnessMapUvIndex"
+            }
+        },
+        {
+            "name": "roughnessMapUvScale",
+            "displayName": "    UV Scale",
+            "description": "Wetted surface roughness map UV scale, [0.2 .. 20.0].",
+            "type": "Float",
+            "defaultValue": 1.0,
+            "min": 0.2,
+            "max": 20.0,
+            "connection": {
+                "type": "ShaderInput",
+                "name": "m_wetRoughnessMapUvScale"
+            }
+        },
+        {
+            "name": "useRoughnessMap",
+            "displayName": "    Use Roughness Map",
+            "description": "Whether to use the roughness texture, or just default to the roughness value.",
+            "type": "Bool",
+            "defaultValue": true
         }
     ],
     "functors": [

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_SurfaceEval.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/BasePBR/BasePBR_SurfaceEval.azsli
@@ -108,17 +108,16 @@ Surface EvaluateSurface_BasePBR(
 
 #if CARBONATED_ENABLE_WETNESS
     // ------- Wetness ------- affects baseColor, specularF0Factor, surface.roughnessLinear
-    if (o_useWet)
+    if (o_wet_enabled)
     {
-        float wetFactor = saturate(MaterialSrg::m_wetFactor);
-        float wetAmount = saturate(MaterialSrg::m_wetAmount);
-        
-        if (o_wet_useTexture)
+        real wetAmount = saturate(MaterialSrg::m_wetAmount);
+
+        real wetFactor = saturate(MaterialSrg::m_wetFactor);
+        if (o_wet_factor_useTexture)
         {
-            const float2 wetMapUv = uvs[MaterialSrg::m_wetMapUvIndex] * MaterialSrg::m_wetMapUvScale;
-            wetFactor = GetWetInput(MaterialSrg::m_wetMap, MaterialSrg::m_sampler, wetMapUv);
+            const float2 wetFactorMapUv = uvs[MaterialSrg::m_wetFactorMapUvIndex] * MaterialSrg::m_wetFactorMapUvScale;
+            wetFactor = GetWetInput(MaterialSrg::m_wetFactorMap, MaterialSrg::m_sampler, wetFactorMapUv);
         }
-        
         // The wetFactor is describing Moistening properties of a surface material.
         // For Metals:              wetFactor < 0.3         -> porosity <= 0.1; maxDarken <= 0.2;
         // For Smooth Dielectrics:  0.3 >= wetFactor < 0.6  -> porosity <= 0.5; maxDarken <= 0.5;
@@ -137,11 +136,18 @@ Surface EvaluateSurface_BasePBR(
         const float darkening = 1.0f - effectiveWetness * porosity * maxDarken;
         const float3 waterTint = float3(0.96f, 0.98f, 1.0f);
         baseColor = baseColor * darkening * lerp(1.0, waterTint, effectiveWetness * 0.3f);
+
+        real wetRoughness = saturate(MaterialSrg::m_wetRoughness);
+        if (o_wet_roughness_useTexture)
+        {
+            const float2 wetRoughnessMapUv = uvs[MaterialSrg::m_wetRoughnessMapUvIndex] * MaterialSrg::m_wetRoughnessMapUvScale;
+            wetRoughness = GetWetInput(MaterialSrg::m_wetRoughnessMap, MaterialSrg::m_sampler, wetRoughnessMapUv);
+        }
+        const real wetRoughnessAmount = saturate(MaterialSrg::m_wetRoughnessAmount);
+        wetRoughness *= wetRoughnessAmount;
+        surface.roughnessLinear = lerp(surface.roughnessLinear, wetRoughness, effectiveWetness);
         
-        const float smoothFactor = lerp(0.7f, 0.3f, saturate(surface.roughnessLinear * 2.0f));
-        surface.roughnessLinear = lerp(surface.roughnessLinear, 0.02f, effectiveWetness * smoothFactor);
-        
-        const float waterF0 = 0.02f;
+        const float waterF0 = 0.5f;
         if (metallic > 0.5f)
         {
             specularF0Factor = lerp(specularF0Factor, max(specularF0Factor, waterF0), effectiveWetness * 0.5f);
@@ -151,19 +157,13 @@ Surface EvaluateSurface_BasePBR(
             specularF0Factor = lerp(specularF0Factor, waterF0, effectiveWetness * (1.0f - porosity * 0.5f));
         }
     }
-    
-    // Delayed calculations
-    surface.SetAlbedoAndSpecularF0(baseColor, specularF0Factor, metallic);
-
-    surface.CalculateRoughnessA();
-    
 #endif // CARBONATED_ENABLE_WETNESS
 
 #if CARBONATED_ENABLE_SNOW_OVERLAY
     // ------- Snow Cover Overlay ------- affects baseColor, surface.normal, specularF0Factor, surface.roughnessLinear, metallic
     if (o_snow_enabled)
     {
-        float snowAmount = saturate(MaterialSrg::m_snowAmount);
+        real snowAmount = saturate(MaterialSrg::m_snowAmount);
         if (o_snow_opacity_useTexture)
         {
             const float2 snowOpacityMapUv = uvs[MaterialSrg::m_snowOpacityMapUvIndex] * MaterialSrg::m_snowOpacityMapUvScale;
@@ -176,7 +176,7 @@ Surface EvaluateSurface_BasePBR(
         const float relativeDistance = length(positionWS.xy - SceneSrg::m_weatherCenter) / snowRadius;
         snowAmount *= clamp((1.0f - relativeDistance) * 4.0f, 0.0f, 1.0f);        
 
-        float snowFactor = saturate(MaterialSrg::m_snowFactor);
+        real snowFactor = saturate(MaterialSrg::m_snowFactor);
         if (o_snow_factor_useTexture)
         {
             const float2 snowFactorMapUv = uvs[MaterialSrg::m_snowFactorMapUvIndex] * MaterialSrg::m_snowFactorMapUvScale;
@@ -203,12 +203,14 @@ Surface EvaluateSurface_BasePBR(
                                            o_snow_normal_useTexture, real(MaterialSrg::m_snowNormalStrength), float4(0.0f, 0.0f, 0.0f, 0.0f), false);
         }
 
-        real snowRoughness = MaterialSrg::m_snowRoughness;
+        real snowRoughness = saturate(MaterialSrg::m_snowRoughness);
         if (o_snow_roughness_useTexture)
         {
             const float2 snowRoughnessMapUv = uvs[MaterialSrg::m_snowRoughnessMapUvIndex] * MaterialSrg::m_snowRoughnessMapUvScale;;
             snowRoughness = GetSnowRoughnessInput(MaterialSrg::m_snowRoughnessMap, MaterialSrg::m_sampler, snowRoughnessMapUv);
         }
+        const real snowRoughnessAmount = saturate(MaterialSrg::m_snowRoughnessAmount);
+        snowRoughness *= snowRoughnessAmount;
         
         baseColor = lerp(baseColor, snowColor, snowAmount);
         surface.normal  = lerp(surface.normal, snowNormal, snowAmount);
@@ -216,13 +218,14 @@ Surface EvaluateSurface_BasePBR(
         surface.roughnessLinear = lerp(surface.roughnessLinear, snowRoughness, snowAmount);
         metallic = lerp(metallic, 0.01f, snowAmount);
     }
-    
+#endif // CARBONATED_ENABLE_SNOW_OVERLAY
+
+#if (CARBONATED_ENABLE_WETNESS || CARBONATED_ENABLE_SNOW_OVERLAY)
     // Delayed calculations
     surface.SetAlbedoAndSpecularF0(baseColor, specularF0Factor, metallic);
 
     surface.CalculateRoughnessA();
-   
-#endif // CARBONATED_ENABLE_SNOW_OVERLAY
+#endif // !(CARBONATED_ENABLE_WETNESS || CARBONATED_ENABLE_SNOW_OVERLAY)
 
     return surface;
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/SnowInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/SnowInput.azsli
@@ -35,6 +35,7 @@ uint prefix##m_snowNormalMapUvIndex; \
 float prefix##m_snowNormalMapUvScale; \
 float prefix##m_snowNormalStrength; \
 float prefix##m_snowRoughness; \
+float prefix##m_snowRoughnessAmount; \
 Texture2D prefix##m_snowRoughnessMap; \
 uint prefix##m_snowRoughnessMapUvIndex; \
 float prefix##m_snowRoughnessMapUvScale; 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/WetInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Materials/MaterialInputs/WetInput.azsli
@@ -18,15 +18,21 @@
 // You can optionally provide a prefix for the set of inputs which corresponds to a prefix string supplied by the .materialtype file. This is common for multi-layered material types.
 
 #define COMMON_SRG_INPUTS_WET(prefix) \
-float prefix##m_wetAmount;  \
-float prefix##m_wetFactor;  \
-Texture2D prefix##m_wetMap; \
-uint prefix##m_wetMapUvIndex; \
-float prefix##m_wetMapUvScale; 
+float prefix##m_wetAmount; \
+float prefix##m_wetFactor; \
+Texture2D prefix##m_wetFactorMap; \
+uint prefix##m_wetFactorMapUvIndex; \
+float prefix##m_wetFactorMapUvScale; \
+float prefix##m_wetRoughness; \
+float prefix##m_wetRoughnessAmount; \
+Texture2D prefix##m_wetRoughnessMap; \
+uint prefix##m_wetRoughnessMapUvIndex; \
+float prefix##m_wetRoughnessMapUvScale;
 
 #define COMMON_OPTIONS_WET(prefix) \
-option bool prefix##o_useWet; \
-option bool prefix##o_wet_useTexture; 
+option bool prefix##o_wet_enabled; \
+option bool prefix##o_wet_factor_useTexture; \
+option bool prefix##o_wet_roughness_useTexture;
  
 real GetWetInput(Texture2D map, sampler mapSampler, float2 uv)
 {


### PR DESCRIPTION
### What does this PR do?
Closes: [Car-32680](https://favro.com/organization/ab098f3312254434882b4396/579ee0f4d0168dab8e8d0252?card=Car-32680)

* Adjusts defaults for Wetness and Snow-cover factors in BasePBR and StandardPBR:
* * "wet.factor" - to default of 0.61;
* * "snow.factor" - to default of 1.0;

* Renames (due to adding more textures as described below) several Wetness material properties:
* * "wet.textureMap" to "wet.factorMap";
* * "wet.textureMapUv" to "wet.factorMapUv";
* * "wet.textureMapUvScale" to "wet.factorMapUvScale";
* * "wet.useTexture" to "wet.useFactorMap";

* Adds parameters to Wetness  material properties:
* * "wet.roughness", default: 0.5:
* * "wet.roughnessAmount", default: 1.0, designed to be controllable across all corresponding Entities / materials in the loaded Level:
* * "wet.roughnessMap", - Texture for re-defining wetted surface roughness.;
* * "wet.roughnessMapUv", = Wetted surface roughness map UV set, default: "Unwrapped".;
* * "wet.roughnessMapUvScale", - Wetted surface roughness map UV scale, [0.2 .. 20.0], default: 1.0;
* * "wet.useRoughnessMap", - Whether to use the roughness texture, or just default to the roughness value.

* Updates desriptions of Wetness material properties for MaterialEditor:

* Updates desriptions of Snow-cover material properties for MaterialEditor and adds one property:
* * "snow.roughnessAmount", default: 1.0, designed to be controllable across all corresponding Entities / materials in the loaded Level:

### How was this PR tested?
Changes to 3 reppositories (o3de, o3dr-gems and o3de-red-game) were tested simultaneously with corresponding branches.

On PC the correct evaluation of weather-induced surface effects (rain-wetness and snow-cover) noted for prefabs using both `BasePBR`- and `StandardPBR`- based materials, and for `MaterialCanvas`-built `materialgraph`-based materials with appropriate inputs, both in Editor and in Editor-GameMode.

Notably, BasePBR- and StandardPBR- based materials now can be untouched, and then weather-induced surface effects use the new defaults.

Build run on Jenkins using this branch and corresponding Weather GEM and Red-game branches:
* [#44937](http://10.0.1.100:8080/job/Extraction/job/Client/job/build%252Fastarykh%252FCAR-32409-cleanup-weather-gem-adjust-materials/2/pipeline-overview/) succeeded for iOS, Android. Linux and PC. PC build binaries are to be storted with "nfe-dev" tag.
* After addressing comments [#45011](http://10.0.1.100:8080/job/Extraction/job/Client/job/build%252Fastarykh%252FCAR-32409-cleanup-weather-gem-adjust-materials/4/pipeline-overview/) -  succeeded for iOS, Android; Linux build succeded, but failed todeploy to Hathora,, PC build succeeded, binaries are to be storted with "nfe-dev" tag. 

* After addressing comments(2):
* * PC build [#45080](http://10.0.1.100:8080/job/Extraction/job/Client/job/build%252Fastarykh%252FCAR-32409-cleanup-weather-gem-adjust-materials/5/pipeline-overview/) -  succeeded, binaries are to be storted with "nfe-dev" tag. 
* * iOS, Android and; Linux build [#45113](http://10.0.1.100:8080/job/Extraction/job/Client/job/build%252Fastarykh%252FCAR-32409-cleanup-weather-gem-adjust-materials/6/pipeline-overview/) -  succeeded.

