### PR TITLE
Avoid ANR strike from OS while loading a large level (noticket)

### DIFF
--- a/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
@@ -36,6 +36,7 @@
 #include <AzCore/Memory/MemoryMarker.h>
 #if defined(CARBONATED_ASSET_WAIT_TIMEOUT)
 #include <AzCore/Time/ITime.h>
+#include <AzFramework/API/ApplicationAPI.h>
 #endif
 #endif
 
@@ -354,7 +355,9 @@ namespace AZ::Data
         {
             AZ_PROFILE_SCOPE(AzCore, "WaitForAsset - %s", m_assetData.GetHint().c_str());
 #if defined(CARBONATED) && defined(CARBONATED_ASSET_WAIT_TIMEOUT)
-            const int64_t startTime = m_timeoutMillis ? static_cast<int64_t>(AZ::GetRealElapsedTimeMs()) : 0;
+            //const int64_t startTime = m_timeoutMillis ? static_cast<int64_t>(AZ::GetRealElapsedTimeMs()) : 0;
+            const int64_t startTime = static_cast<int64_t>(AZ::GetRealElapsedTimeMs());
+            int64_t eventTime = startTime;
             int jobCount = 0;
 #endif
 
@@ -383,13 +386,23 @@ namespace AZ::Data
 #endif
                         AssetManager::Instance().DispatchEvents();
 #if defined(CARBONATED) && defined(CARBONATED_ASSET_WAIT_TIMEOUT)
+
+                        const int64_t curTime = static_cast<int64_t>(AZ::GetRealElapsedTimeMs());
+                        const unsigned int deltaEvent = (unsigned int)(curTime - eventTime);
+                        if (deltaEvent >= 200u)
+                        {
+                            AZ_Info("lll", "delat=%u, pump system events", deltaEvent);
+                            eventTime = curTime;
+                            AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::PumpSystemEventLoopUntilEmpty);
+                        }
+
                         if (m_timeoutMillis)
                         {
-                            const int64_t curTime = static_cast<int64_t>(AZ::GetRealElapsedTimeMs());
-                            if ((unsigned int)(curTime - startTime) > m_timeoutMillis)
+                            const unsigned int delta = (unsigned int)(curTime - startTime);
+                            if (delta > m_timeoutMillis)
                             {
                                 AZ_Info("AssetManager", "Main thread blocking loading wait timeout %d exceeded for %s, time %u",
-                                        m_timeoutMillis, m_assetData.GetHint().c_str(), (unsigned int)(curTime - startTime));
+                                        m_timeoutMillis, m_assetData.GetHint().c_str(), delta);
                                 break;
                             }
                         }

--- a/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
@@ -355,7 +355,6 @@ namespace AZ::Data
         {
             AZ_PROFILE_SCOPE(AzCore, "WaitForAsset - %s", m_assetData.GetHint().c_str());
 #if defined(CARBONATED) && defined(CARBONATED_ASSET_WAIT_TIMEOUT)
-            //const int64_t startTime = m_timeoutMillis ? static_cast<int64_t>(AZ::GetRealElapsedTimeMs()) : 0;
             const int64_t startTime = static_cast<int64_t>(AZ::GetRealElapsedTimeMs());
             int64_t eventTime = startTime;
             int jobCount = 0;

--- a/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
@@ -398,7 +398,7 @@ namespace AZ::Data
                         if (m_timeoutMillis)
                         {
                             const unsigned int delta = (unsigned int)(curTime - startTime);
-                            if (delta > m_timeoutMillis)
+                            if (delta >= m_timeoutMillis)
                             {
                                 AZ_Info("AssetManager", "Main thread blocking loading wait timeout %d exceeded for %s, time %u",
                                         m_timeoutMillis, m_assetData.GetHint().c_str(), delta);

--- a/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
@@ -389,9 +389,9 @@ namespace AZ::Data
 
                         const int64_t curTime = static_cast<int64_t>(AZ::GetRealElapsedTimeMs());
                         const unsigned int deltaEvent = (unsigned int)(curTime - eventTime);
-                        if (deltaEvent >= 200u)
+                        const unsigned int delayBetweenEventPump = 10;  // in seconds
+                        if (deltaEvent >= delayBetweenEventPump * 1000)  // pump system events to avoid ANR system detector
                         {
-                            AZ_Info("lll", "delat=%u, pump system events", deltaEvent);
                             eventTime = curTime;
                             AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::PumpSystemEventLoopUntilEmpty);
                         }

--- a/Code/Framework/AzCore/CMakeLists.txt
+++ b/Code/Framework/AzCore/CMakeLists.txt
@@ -87,6 +87,8 @@ ly_add_target(
             ${pal_dir}
             ${common_dir}
     BUILD_DEPENDENCIES
+        PRIVATE
+            AZ::AzFramework  # CARBONATED to pump system events (which is in AZFramework) while waiting for a level to load
         PUBLIC
             3rdParty::Lua
             3rdParty::RapidJSON

--- a/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
+++ b/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
@@ -354,7 +354,14 @@ namespace LegacyLevelSystem
             // when we call AssetBus::QueuedEventCount() immediately after Asset::QueueLoad(), it returns the number of level assets for loading
             m_queuedAssetsCountMax = static_cast<int>(AZ::Data::AssetBus::QueuedEventCount());
             m_queuedAssetsCount = -1;
+
+            const auto levelLoadBegin = static_cast<int64_t>(AZ::GetRealElapsedTimeMs());
+            AZ_Info("lll", "level load begin at %llu", levelLoadBegin);
+
             rootSpawnable.BlockUntilLoadComplete();
+
+            const auto levelLoadEnd = static_cast<int64_t>(AZ::GetRealElapsedTimeMs());
+            AZ_Info("lll", "level load end at %llu, elapsed %u", levelLoadEnd, (unsigned int)(levelLoadEnd - levelLoadBegin));
 #endif
 // Gruber patch end. // LVB
 

--- a/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
+++ b/Code/Legacy/CrySystem/LevelSystem/SpawnableLevelSystem.cpp
@@ -354,14 +354,7 @@ namespace LegacyLevelSystem
             // when we call AssetBus::QueuedEventCount() immediately after Asset::QueueLoad(), it returns the number of level assets for loading
             m_queuedAssetsCountMax = static_cast<int>(AZ::Data::AssetBus::QueuedEventCount());
             m_queuedAssetsCount = -1;
-
-            const auto levelLoadBegin = static_cast<int64_t>(AZ::GetRealElapsedTimeMs());
-            AZ_Info("lll", "level load begin at %llu", levelLoadBegin);
-
             rootSpawnable.BlockUntilLoadComplete();
-
-            const auto levelLoadEnd = static_cast<int64_t>(AZ::GetRealElapsedTimeMs());
-            AZ_Info("lll", "level load end at %llu, elapsed %u", levelLoadEnd, (unsigned int)(levelLoadEnd - levelLoadBegin));
 #endif
 // Gruber patch end. // LVB
 

--- a/cmake/Platform/Common/RuntimeDependencies_common.cmake
+++ b/cmake/Platform/Common/RuntimeDependencies_common.cmake
@@ -114,6 +114,14 @@ function(o3de_get_dependencies_for_target)
             continue()
         endif()
 
+        # CARBONATED skip recursive dependencies
+        set(target_dependency_stack_pos -1)
+        list(FIND target_dependency_stack ${link_dependency} target_dependency_stack_pos)
+        if(target_dependency_stack_pos GREATER_EQUAL 0)
+            message("Skip recursive dependency ${link_dependency}, which is at the position ${target_dependency_stack_pos} in the dependency stack ${target_dependency_stack}")
+            continue()
+        endif()
+
         if(TARGET ${link_dependency})
             get_target_property(is_imported ${link_dependency} IMPORTED)
             get_target_property(is_system_library ${link_dependency} LY_SYSTEM_LIBRARY)
@@ -133,6 +141,9 @@ function(o3de_get_dependencies_for_target)
         unset(dependent_target_dependencies)
         unset(dependent_link_dependencies)
         unset(dependent_imported_dependencies)
+        
+        list(APPEND target_dependency_stack ${link_dependency})  # CARBONATED maintain dependency stack to skip recursive dependencies
+        
         o3de_get_dependencies_for_target(
             TARGET "${link_dependency}"
             COPY_DEPENDENCIES_VAR dependent_copy_dependencies
@@ -140,6 +151,9 @@ function(o3de_get_dependencies_for_target)
             LINK_DEPENDENCIES_VAR dependent_link_dependencies
             IMPORTED_DEPENDENCIES_VAR dependent_imported_dependencies
         )
+        
+        list(POP_BACK target_dependency_stack)  # CARBONATED maintain dependency stack to skip recursive dependencies
+        
         list(APPEND all_copy_dependencies ${dependent_copy_dependencies})
         list(APPEND all_target_dependencies ${dependent_target_dependencies})
         list(APPEND all_link_dependencies ${dependent_link_dependencies})
@@ -437,6 +451,11 @@ function(ly_delayed_generate_runtime_dependencies)
         unset(target_target_dependencies)
         unset(target_link_dependencies)
         unset(target_imported_dependencies)
+        
+        # CARBONATED maintain dependency stack to skip recursive dependencies
+        set(target_dependency_stack)
+        list(APPEND target_dependency_stack ${target})
+        
         o3de_get_dependencies_for_target(
             TARGET "${target}"
             COPY_DEPENDENCIES_VAR target_copy_dependencies
@@ -444,6 +463,8 @@ function(ly_delayed_generate_runtime_dependencies)
             LINK_DEPENDENCIES_VAR target_link_dependencies
             IMPORTED_DEPENDENCIES_VAR target_imported_dependencies
         )
+
+        set(target_dependency_stack)  # CARBONATED maintain dependency stack to skip recursive dependencies
 
         # Convert dependencies to files or generator expressions that can transform to files
         o3de_transform_dependencies_to_files(FILES_VAR target_copy_files


### PR DESCRIPTION
## What does this PR do?

Pump system events while waiting too long for an asset to load. That avoids ANR strike from OS.

## How was this PR tested?

Tested on Windows and linux.
NOT tested on Android & iOS, there might be issues.
Should be tested on OCGA before merge.
