### PR TITLE
[Car-32732] Re-enable saving Editor VisibilityFlag into prefabs.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityHelpers.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityHelpers.cpp
@@ -28,6 +28,10 @@
 #include <AzToolsFramework/ToolsComponents/GenericComponentWrapper.h>
 #include <AzToolsFramework/ToolsComponents/EditorInspectorComponentBus.h>
 
+#if defined(CARBONATED) // Re-enable saving VisibilityFlag into prefabs.
+#include <AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h> // Needed for Undo/Redo safety checks
+#endif
+
 namespace AzToolsFramework
 {
     namespace Internal
@@ -970,10 +974,26 @@ namespace AzToolsFramework
         {
             bool visible = IsEntitySetToBeVisible(entityId);
 
-#if !defined(CARBONATED)
-            // undo mechanism causes the affected entities to be deleted then created again, this brakes the entity visiility (white objects bug)
+#if defined(CARBONATED) // Re-enable saving VisibilityFlag into prefabs. 
+            // The hack applied on Nov 16, 2024, in https://github.com/carbonated-dev/o3de/pull/345. with the comment:
+            //  undo mechanism causes the affected entities to be deleted then created again, this brakes the entity visibility (white objects bug)
+            // was just commenting out creation of the ScopedUndoBatch undo("Toggle Entity Visibility");
+
+            // The Undo/Redo stack is broken if an Undo batch is started while an Undo/Redo operation is in progress or
+            // while an InstanceUpdateExecutor is currently Updating Template Instances In Queue, removing Entities in the clean-up of in-memory DOM template.
+            // So create Undo batch only when both conditions are false.
+            AZStd::unique_ptr<AzToolsFramework::ScopedUndoBatch> undoBatch;
+            const auto instanceUpdateExecutorInterface = AZ::Interface<AzToolsFramework::Prefab::InstanceUpdateExecutorInterface>::Get();
+            const bool isUpdatingTemplates = instanceUpdateExecutorInterface && instanceUpdateExecutorInterface->IsUpdatingTemplateInstancesInQueue();
+            if (!AzToolsFramework::UndoRedoOperationInProgress() && !isUpdatingTemplates)
+            {
+                undoBatch = AZStd::make_unique<AzToolsFramework::ScopedUndoBatch>("Toggle Entity Visibility");
+            }
+#else
             AzToolsFramework::ScopedUndoBatch undo("Toggle Entity Visibility");
-#endif
+#endif //defined(CARBONATED)
+
+            AZ_Info("EditorEntityHelpers", "ToggleEntityVisibility(): %s, was %d", GetEntity(entityId)->GetName().c_str(), visible);
 
             if (IsSelected(entityId))
             {
@@ -988,6 +1008,12 @@ namespace AzToolsFramework
                 for (AZ::EntityId selectedId : selectedEntityIds)
                 {
                     SetEntityVisibility(selectedId, !visible);
+#if defined(CARBONATED) // Re-enable saving VisibilityFlag into prefabs.
+                    if (undoBatch)
+                    {
+                        undoBatch->MarkEntityDirty(selectedId);
+                    }
+#endif
                 }
             }
             else
@@ -995,6 +1021,12 @@ namespace AzToolsFramework
                 // just change the single clicked entity in the outliner
                 // without affecting the current selection (should one exist)
                 SetEntityVisibility(entityId, !visible);
+#if defined(CARBONATED) // Re-enable saving VisibilityFlag into prefabs.
+                if (undoBatch)
+                {
+                    undoBatch->MarkEntityDirty(entityId);
+                }
+#endif
             }
         }
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityHelpers.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityHelpers.cpp
@@ -993,8 +993,6 @@ namespace AzToolsFramework
             AzToolsFramework::ScopedUndoBatch undo("Toggle Entity Visibility");
 #endif //defined(CARBONATED)
 
-            AZ_Info("EditorEntityHelpers", "ToggleEntityVisibility(): %s, was %d", GetEntity(entityId)->GetName().c_str(), visible);
-
             if (IsSelected(entityId))
             {
                 // handles the case where we have multiple entities selected but

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
@@ -305,6 +305,13 @@ namespace AzToolsFramework
             return isUpdateSuccessful;
         }
 
+#if defined(CARBONATED) // Fixes for Undo/Redo stack stability in 2505 with https://github.com/o3de/o3de/pull/18788
+        bool InstanceUpdateExecutor::IsUpdatingTemplateInstancesInQueue() const
+        {
+            return m_updatingTemplateInstancesInQueue;
+        }
+#endif
+
         void InstanceUpdateExecutor::QueueRootPrefabLoadedNotificationForNextPropagation()
         {
             m_isRootPrefabInstanceLoaded = false;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
@@ -40,6 +40,9 @@ namespace AzToolsFramework
 
             // Note, this function destroys and re-creates Entity* and Component*, do not assume your pointers are still good after this.
             bool UpdateTemplateInstancesInQueue() override;
+#if defined(CARBONATED) // Fixes for Undo/Redo stack stability in 2505 with https://github.com/o3de/o3de/pull/18788
+            bool IsUpdatingTemplateInstancesInQueue() const override;
+#endif
             void RemoveTemplateInstanceFromQueue(Instance* instance) override;
             void QueueRootPrefabLoadedNotificationForNextPropagation() override;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h
@@ -35,6 +35,10 @@ namespace AzToolsFramework
             //! Updates instances in the waiting queue.
             //! @return bool on whether the operation succeeds.
             virtual bool UpdateTemplateInstancesInQueue() = 0;
+#if defined(CARBONATED) // Fixes for Undo/Redo stack stability in 2505 with https://github.com/o3de/o3de/pull/18788
+            //! @return bool on whether instances are currently updated in the waiting queue.
+            virtual bool IsUpdatingTemplateInstancesInQueue() const = 0;
+#endif
 
             //! Removes an instance from the waiting queue.
             //! @param instance The instance to be removed from queue.

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshComponent.cpp
@@ -12,6 +12,10 @@
 #include <AzToolsFramework/Entity/EditorEntityInfoBus.h>
 #include <AzToolsFramework/API/EntityCompositionRequestBus.h>
 #include <AtomLyIntegration/CommonFeatures/Material/MaterialComponentConstants.h>
+#if defined(CARBONATED) // Re-enable saving VisibilityFlag into prefabs. 
+  // Fix in 2505 https://github.com/o3de/o3de/pull/18926 : Fixes mesh visibility flag not being restored on level load
+  #include <AzToolsFramework/ToolsComponents/EditorVisibilityBus.h>
+#endif
 
 namespace AZ
 {
@@ -140,6 +144,16 @@ namespace AZ
             AzToolsFramework::EditorComponentSelectionRequestsBus::Handler::BusConnect(GetEntityId());
             AzFramework::EntityDebugDisplayEventBus::Handler::BusConnect(GetEntityId());
             MeshComponentNotificationBus::Handler::BusConnect(GetEntityId());
+
+#if defined(CARBONATED) // Re-enable saving VisibilityFlag into prefabs.
+            // Fix in 2505 https://github.com/o3de/o3de/pull/18926 : Fixes mesh visibility flag not being restored on level load.
+            // Unlike the 2505 fix, this one is placed after BaseClass::Activate(); so that MeshFeatureProcessor has been created.
+            using EditorVisibilityRequestBus = AzToolsFramework::EditorVisibilityRequestBus;
+            bool isVisible = true;
+            AzToolsFramework::EditorVisibilityRequestBus::EventResult(
+                isVisible, GetEntityId(), &EditorVisibilityRequestBus::Events::GetVisibilityFlag);
+            m_controller.SetVisibility(isVisible);
+#endif
         }
 
         void EditorMeshComponent::Deactivate()
@@ -278,6 +292,7 @@ namespace AZ
 
         void EditorMeshComponent::OnEntityVisibilityChanged(bool visibility)
         {
+            AZ_Info("EditorMeshComponent", "OnEntityVisibilityChanged(): %d", visibility);
             m_controller.SetVisibility(visibility);
         }
 


### PR DESCRIPTION
#### What does this PR do?
Closes [Car-32732](https://favro.com/organization/ab098f3312254434882b4396/579ee0f4d0168dab8e8d0252?card=Car-32732)

* Clones (under `#if defined(CARBONATED)` fence) addition for Undo/Redo stack stability fixes made in O3DE v.2505 with the [PR](https://github.com/o3de/o3de/pull/18788) to the `InstanceUpdateExecutor`;

* Substitutes the hack made in `EditorEntityHelpers::ToggleEntityVisibility()`, applied on Nov 16, 2024, in https://github.com/carbonated-dev/o3de/pull/345, which simply commented out creation of Undo batch, because glitches in Undo/Redo flow raised the ["white objects bug"](https://carbonated.slack.com/archives/C04NW5D7K6D/p1731528303334399?thread_ts=1731528284.740199&cid=C04NW5D7K6D), and thus the hack disabled the Editor VisibilityFlag saving and loading, 
with the safe conditional creation of Undo batch. This legal fix restores the Editor VisibilityFlag saving and loading.

* Clones the fix added to O3DE v.2505 in the [PR](https://github.com/o3de/o3de/pull/18926) : fixes mesh visibility flag not being restored on level load.

#### How was this PR tested?

On PC the correct evaluation of Editor VisibilityFlag noted.
#### Note:
The Editor VisibilityFlag cannot be deliberately changed for `Silhouette` entities having `EditorHighlightComponent`, which resets the  Editor VisibilityFlag depending on `Highlight Type`.


Builds run on Jenkins using this branch and the test Red-game branch:

* PC build [#45446](http://10.0.1.100:8080/job/Extraction/job/Client/job/build%252Fastarykh%252FCAR-32732-fix-saving-VisibilityFlag/3/pipeline-overview/) - succeeded; PC build binaries are to be stored with "nfe-dev" tag.

* iOS, Android and Linux build [#45461](http://10.0.1.100:8080/job/Extraction/job/Client/job/build%252Fastarykh%252FCAR-32732-fix-saving-VisibilityFlag/4/pipeline-overview/): succeeded.
