### PR TITLE
[CAR-32524] Engine changes for the Water gem

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/CameraPipeline.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/CameraPipeline.pass
@@ -145,6 +145,19 @@
                     ]
                 },
                 {
+                    "Name": "ReflectionPreviousFramePass",
+                    "TemplateName": "ReflectionPreviousFramePassTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "PipelineOutput",
+                            "AttachmentRef": {
+                                "Pass": "PipelineGlobal",
+                                "Attachment": "PipelineOutput"
+                            }
+                        }
+                    ]
+                },
+                {
                     "Name": "OpaquePass",
                     "TemplateName": "OpaqueParentTemplate",
                     "Connections": [
@@ -327,6 +340,13 @@
                             "AttachmentRef": {
                                 "Pass": "DeferredFogPass",
                                 "Attachment": "RenderTargetInputOutput"
+                            }
+                        },
+                        {
+                            "LocalSlot": "Output",
+                            "AttachmentRef": {
+                                "Pass": "ReflectionPreviousFramePass",
+                                "Attachment": "PreviousFrameImage"
                             }
                         }
                     ]

--- a/Gems/Atom/Feature/Common/Assets/Passes/MainPipeline.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/MainPipeline.pass
@@ -145,6 +145,19 @@
                     ]
                 },
                 {
+                    "Name": "ReflectionPreviousFramePass",
+                    "TemplateName": "ReflectionPreviousFramePassTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "PipelineOutput",
+                            "AttachmentRef": {
+                                "Pass": "PipelineGlobal",
+                                "Attachment": "PipelineOutput"
+                            }
+                        }
+                    ]
+                },
+                {
                     "Name": "OpaquePass",
                     "TemplateName": "OpaqueParentTemplate",
                     "Connections": [
@@ -327,6 +340,13 @@
                             "AttachmentRef": {
                                 "Pass": "DeferredFogPass",
                                 "Attachment": "RenderTargetInputOutput"
+                            }
+                        },
+                        {
+                            "LocalSlot": "Output",
+                            "AttachmentRef": {
+                                "Pass": "ReflectionPreviousFramePass",
+                                "Attachment": "PreviousFrameImage"
                             }
                         }
                     ]

--- a/Gems/Atom/Feature/Common/Assets/Passes/PassTemplates.azasset
+++ b/Gems/Atom/Feature/Common/Assets/Passes/PassTemplates.azasset
@@ -357,6 +357,10 @@
                 "Path": "Passes/ReflectionCopyFrameBuffer.pass"
             },
             {
+                "Name": "ReflectionPreviousFramePassTemplate",
+                "Path": "Passes/ReflectionPreviousFrame.pass"
+            },
+            {
                 "Name": "ReflectionScreenSpacePassTemplate",
                 "Path": "Passes/ReflectionScreenSpace.pass"
             },

--- a/Gems/Atom/Feature/Common/Assets/Passes/ReflectionCopyFrameBuffer.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ReflectionCopyFrameBuffer.pass
@@ -5,7 +5,7 @@
     "ClassData": {
         "PassTemplate": {
             "Name": "ReflectionCopyFrameBufferPassTemplate",
-            "PassClass": "ReflectionCopyFrameBufferPass",
+            "PassClass": "FullScreenTriangle",
             "Slots": [
                 {
                     "Name": "Input",

--- a/Gems/Atom/Feature/Common/Assets/Passes/ReflectionPreviousFrame.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ReflectionPreviousFrame.pass
@@ -1,0 +1,56 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "ReflectionPreviousFramePassTemplate",
+            "PassClass": "ReflectionPreviousFramePass",
+            "Slots": [
+                {
+                    "Name": "PreviousFrameImage",
+                    "SlotType": "InputOutput",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                // SwapChain here is only used to reference the frame height and format
+                {
+                    "Name": "PipelineOutput",
+                    "SlotType": "InputOutput"
+                }
+            ],
+            "ImageAttachments": [
+                {
+                    "Name": "PreviousFrameImage",
+                    "SizeSource": {
+                        "Source": {
+                            "Pass": "This",
+                            "Attachment": "PipelineOutput"
+                        }
+                    },
+                    "ImageDescriptor": {
+                        "Format": "R16G16B16A16_FLOAT",
+                        "SharedQueueMask": "Graphics"
+                    }
+                }
+            ],
+            "Connections": [
+                {
+                    "LocalSlot": "PreviousFrameImage",
+                    "AttachmentRef": {
+                        "Pass": "This",
+                        "Attachment": "PreviousFrameImage"
+                    }
+                }
+            ],
+            "PassData": {
+                "$type": "PassData",
+                "PipelineGlobalConnections": [
+                    {
+                        "GlobalName": "ReflectionPreviousFrame",
+                        "Slot": "PreviousFrameImage"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/Gems/Atom/Feature/Common/Assets/Passes/ReflectionScreenSpaceTrace.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ReflectionScreenSpaceTrace.pass
@@ -131,19 +131,6 @@
                         "Format": "R16G16B16A16_FLOAT",
                         "SharedQueueMask": "Graphics"
                     }
-                },
-                {
-                    "Name": "PreviousFrameImage",
-                    "SizeSource": {
-                        "Source": {
-                            "Pass": "Parent",
-                            "Attachment": "SpecularInput"
-                        }
-                    },
-                    "ImageDescriptor": {
-                        "Format": "R16G16B16A16_FLOAT",
-                        "SharedQueueMask": "Graphics"
-                    }
                 }
             ],
             "Connections": [
@@ -164,8 +151,8 @@
                 {
                     "LocalSlot": "PreviousFrameInputOutput",
                     "AttachmentRef": {
-                        "Pass": "This",
-                        "Attachment": "PreviousFrameImage"
+                        "Pass": "PipelineGlobal",
+                        "Attachment": "ReflectionPreviousFrame"
                     }
                 }
             ],

--- a/Gems/Atom/Feature/Common/Assets/Passes/ToolsPipeline.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ToolsPipeline.pass
@@ -152,6 +152,19 @@
                     ]
                 },
                 {
+                    "Name": "ReflectionPreviousFramePass",
+                    "TemplateName": "ReflectionPreviousFramePassTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "PipelineOutput",
+                            "AttachmentRef": {
+                                "Pass": "PipelineGlobal",
+                                "Attachment": "PipelineOutput"
+                            }
+                        }
+                    ]
+                },
+                {
                     "Name": "OpaquePass",
                     "TemplateName": "OpaqueParentTemplate",
                     "Connections": [
@@ -334,6 +347,13 @@
                             "AttachmentRef": {
                                 "Pass": "DeferredFogPass",
                                 "Attachment": "RenderTargetInputOutput"
+                            }
+                        },
+                        {
+                            "LocalSlot": "Output",
+                            "AttachmentRef": {
+                                "Pass": "ReflectionPreviousFramePass",
+                                "Attachment": "PreviousFrameImage"
                             }
                         }
                     ]

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/RayTracing/RayTracingGlobalSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/RayTracing/RayTracingGlobalSrg.azsli
@@ -19,6 +19,7 @@ ShaderResourceGroup RayTracingGlobalSrg : SRG_RayTracingGlobal
     RWTexture2D<float4>   m_fallbackAlbedo;
     RWTexture2D<float4>   m_fallbackPosition;
     RWTexture2D<float4>   m_fallbackNormal;
+    Texture2DMS<uint2>    m_stencil;
 
     float m_invOutputScale;
     float m_maxRayLength;

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/RayTracing/RayTracingGlobalSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/RayTracing/RayTracingGlobalSrg.azsli
@@ -19,7 +19,9 @@ ShaderResourceGroup RayTracingGlobalSrg : SRG_RayTracingGlobal
     RWTexture2D<float4>   m_fallbackAlbedo;
     RWTexture2D<float4>   m_fallbackPosition;
     RWTexture2D<float4>   m_fallbackNormal;
+    // Begin Carbonated
     Texture2DMS<uint2>    m_stencil;
+    // End Carbonated
 
     float m_invOutputScale;
     float m_maxRayLength;

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceTrace.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceTrace.azsl
@@ -135,7 +135,13 @@ PSOutput MainPS(VSOutput IN)
     }
     else
     {
-        foundHit = TraceRayScreenSpace(positionVS.xyz, reflectDirVS, fullScreenDimensions, hitCoords);
+        foundHit = TraceRayScreenSpace(
+            positionVS.xyz,
+            reflectDirVS,
+            fullScreenDimensions,
+            PassSrg::m_maxRayDistance,
+            PassSrg::m_maxDepthThreshold,
+            hitCoords);
     }
     
     float4 result = float4(0.0f, 0.0f, 0.0f, 0.0f);

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceTrace.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceTrace.azsl
@@ -135,6 +135,8 @@ PSOutput MainPS(VSOutput IN)
     }
     else
     {
+        // Begin Carbonated
+        // foundHit = TraceRayScreenSpace(positionVS.xyz, reflectDirVS, fullScreenDimensions, hitCoords);
         foundHit = TraceRayScreenSpace(
             positionVS.xyz,
             reflectDirVS,
@@ -142,6 +144,7 @@ PSOutput MainPS(VSOutput IN)
             PassSrg::m_maxRayDistance,
             PassSrg::m_maxDepthThreshold,
             hitCoords);
+        // End Carbonated
     }
     
     float4 result = float4(0.0f, 0.0f, 0.0f, 0.0f);

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceTrace.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceTrace.azsli
@@ -48,6 +48,8 @@ float DistanceSqr(float2 v1, float2 v2)
 static const uint MaxSteps = 96;
 static const uint BinarySearchSteps = 16;
 
+// Begin Carbonated
+// bool TraceRayScreenSpace(float3 rayStartVS, float3 rayDirectionVS, uint2 dimensions, out float2 hitCoords)
 bool TraceRayScreenSpace(
     float3 rayStartVS,
     float3 rayDirectionVS,
@@ -55,8 +57,12 @@ bool TraceRayScreenSpace(
     float maxRayDistance,
     float maxDepthThreshold,
     out float2 hitCoords)
+// End Carbonated
 {
+    // Begin Carbonated
+    // float3 rayEndVS = rayStartVS + rayDirectionVS * PassSrg::m_maxRayDistance;
     float3 rayEndVS = rayStartVS + rayDirectionVS * maxRayDistance;
+    // End Carbonated
 
     // early out if endpoint is behind camera
     if (rayEndVS.z >= 0.0f)
@@ -139,7 +145,10 @@ bool TraceRayScreenSpace(
         }
     
         // a hit occurs when the expected ray depth is beyond the scene depth and within the depth threshold (thickness)
+        // Begin Carbonated
+        // if ((rayZMin < sceneDepth) && (rayZMax >= sceneDepth - PassSrg::m_maxDepthThreshold))
         if ((rayZMin < sceneDepth) && (rayZMax >= sceneDepth - maxDepthThreshold))
+        // End Carbonated
         {
             foundHit = true;
             break;

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceTrace.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceTrace.azsli
@@ -48,9 +48,15 @@ float DistanceSqr(float2 v1, float2 v2)
 static const uint MaxSteps = 96;
 static const uint BinarySearchSteps = 16;
 
-bool TraceRayScreenSpace(float3 rayStartVS, float3 rayDirectionVS, uint2 dimensions, out float2 hitCoords)
+bool TraceRayScreenSpace(
+    float3 rayStartVS,
+    float3 rayDirectionVS,
+    uint2 dimensions,
+    float maxRayDistance,
+    float maxDepthThreshold,
+    out float2 hitCoords)
 {
-    float3 rayEndVS = rayStartVS + rayDirectionVS * PassSrg::m_maxRayDistance;
+    float3 rayEndVS = rayStartVS + rayDirectionVS * maxRayDistance;
 
     // early out if endpoint is behind camera
     if (rayEndVS.z >= 0.0f)
@@ -133,7 +139,7 @@ bool TraceRayScreenSpace(float3 rayStartVS, float3 rayDirectionVS, uint2 dimensi
         }
     
         // a hit occurs when the expected ray depth is beyond the scene depth and within the depth threshold (thickness)
-        if ((rayZMin < sceneDepth) && (rayZMax >= sceneDepth - PassSrg::m_maxDepthThreshold))
+        if ((rayZMin < sceneDepth) && (rayZMax >= sceneDepth - maxDepthThreshold))
         {
             foundHit = true;
             break;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/DirectionalLightFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/DirectionalLightFeatureProcessorInterface.h
@@ -186,6 +186,9 @@ namespace AZ
 
             //! Sets the lighting channel mask
             virtual void SetLightingChannelMask(LightHandle handle, uint32_t lightingChannelMask) = 0;
+
+            //! Returns the direction of the first light.
+            virtual bool GetActiveLightDirection(Vector3& direction) const = 0;
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/DirectionalLightFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/DirectionalLightFeatureProcessorInterface.h
@@ -187,8 +187,10 @@ namespace AZ
             //! Sets the lighting channel mask
             virtual void SetLightingChannelMask(LightHandle handle, uint32_t lightingChannelMask) = 0;
 
+#if defined(CARBONATED)
             //! Returns the direction of the first light.
             virtual bool GetActiveLightDirection(Vector3& direction) const = 0;
+#endif
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/CommonSystemComponent.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CommonSystemComponent.cpp
@@ -109,7 +109,11 @@
 #include <ReflectionScreenSpace/ReflectionScreenSpaceBlurChildPass.h>
 #include <ReflectionScreenSpace/ReflectionScreenSpaceFilterPass.h>
 #include <ReflectionScreenSpace/ReflectionScreenSpaceCompositePass.h>
+#if defined(CARBONATED)
 #include <ReflectionScreenSpace/ReflectionPreviousFramePass.h>
+#else
+#include <ReflectionScreenSpace/ReflectionCopyFrameBufferPass.h>
+#endif
 #include <OcclusionCullingPlane/OcclusionCullingPlaneFeatureProcessor.h>
 #include <Mesh/ModelReloaderSystem.h>
 
@@ -323,7 +327,11 @@ namespace AZ
             passSystem->AddPassCreator(Name("ReflectionScreenSpaceBlurChildPass"), &Render::ReflectionScreenSpaceBlurChildPass::Create);
             passSystem->AddPassCreator(Name("ReflectionScreenSpaceFilterPass"), &Render::ReflectionScreenSpaceFilterPass::Create);
             passSystem->AddPassCreator(Name("ReflectionScreenSpaceCompositePass"), &Render::ReflectionScreenSpaceCompositePass::Create);
+#if defined(CARBONATED)
             passSystem->AddPassCreator(Name("ReflectionPreviousFramePass"), &Render::ReflectionPreviousFramePass::Create);
+#else
+            passSystem->AddPassCreator(Name("ReflectionCopyFrameBufferPass"), &Render::ReflectionCopyFrameBufferPass::Create);
+#endif
 
             // Add RayTracing passes
             passSystem->AddPassCreator(Name("RayTracingAccelerationStructurePass"), &Render::RayTracingAccelerationStructurePass::Create);

--- a/Gems/Atom/Feature/Common/Code/Source/CommonSystemComponent.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CommonSystemComponent.cpp
@@ -109,7 +109,7 @@
 #include <ReflectionScreenSpace/ReflectionScreenSpaceBlurChildPass.h>
 #include <ReflectionScreenSpace/ReflectionScreenSpaceFilterPass.h>
 #include <ReflectionScreenSpace/ReflectionScreenSpaceCompositePass.h>
-#include <ReflectionScreenSpace/ReflectionCopyFrameBufferPass.h>
+#include <ReflectionScreenSpace/ReflectionPreviousFramePass.h>
 #include <OcclusionCullingPlane/OcclusionCullingPlaneFeatureProcessor.h>
 #include <Mesh/ModelReloaderSystem.h>
 
@@ -323,7 +323,7 @@ namespace AZ
             passSystem->AddPassCreator(Name("ReflectionScreenSpaceBlurChildPass"), &Render::ReflectionScreenSpaceBlurChildPass::Create);
             passSystem->AddPassCreator(Name("ReflectionScreenSpaceFilterPass"), &Render::ReflectionScreenSpaceFilterPass::Create);
             passSystem->AddPassCreator(Name("ReflectionScreenSpaceCompositePass"), &Render::ReflectionScreenSpaceCompositePass::Create);
-            passSystem->AddPassCreator(Name("ReflectionCopyFrameBufferPass"), &Render::ReflectionCopyFrameBufferPass::Create);
+            passSystem->AddPassCreator(Name("ReflectionPreviousFramePass"), &Render::ReflectionPreviousFramePass::Create);
 
             // Add RayTracing passes
             passSystem->AddPassCreator(Name("RayTracingAccelerationStructurePass"), &Render::RayTracingAccelerationStructurePass::Create);

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
@@ -703,6 +703,7 @@ namespace AZ
             m_lightBufferNeedsUpdate = true;
         }
 
+#if defined(CARBONATED)
         bool DirectionalLightFeatureProcessor::GetActiveLightDirection(Vector3& direction) const
         {
             if (m_lightData.GetDataCount() == 0)
@@ -719,6 +720,7 @@ namespace AZ
             direction.Normalize();
             return true;
         }
+#endif
 
         void DirectionalLightFeatureProcessor::OnRenderPipelineChanged([[maybe_unused]] RPI::RenderPipeline* pipeline,
             RPI::SceneNotification::RenderPipelineChangeType changeType)

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
@@ -703,6 +703,23 @@ namespace AZ
             m_lightBufferNeedsUpdate = true;
         }
 
+        bool DirectionalLightFeatureProcessor::GetActiveLightDirection(Vector3& direction) const
+        {
+            if (m_lightData.GetDataCount() == 0)
+            {
+                return false;
+            }
+
+            direction = Vector3::CreateFromFloat3(m_lightData.GetDataVector()[0].m_direction.data());
+            if (direction.GetLengthSq() <= Constants::Tolerance)
+            {
+                return false;
+            }
+
+            direction.Normalize();
+            return true;
+        }
+
         void DirectionalLightFeatureProcessor::OnRenderPipelineChanged([[maybe_unused]] RPI::RenderPipeline* pipeline,
             RPI::SceneNotification::RenderPipelineChangeType changeType)
         {

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.h
@@ -251,7 +251,9 @@ namespace AZ
             void SetAffectsGI(LightHandle handle, bool affectsGI) override;
             void SetAffectsGIFactor(LightHandle handle, float affectsGIFactor) override;
             void SetLightingChannelMask(LightHandle handle, uint32_t lightingChannelMask) override;
+#if defined(CARBONATED)
             bool GetActiveLightDirection(Vector3& direction) const override;
+#endif
 
             const Data::Instance<RPI::Buffer> GetLightBuffer() const { return m_lightBufferHandler.GetBuffer(); }
             uint32_t GetLightCount() const { return m_lightBufferHandler.GetElementCount(); }

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.h
@@ -251,6 +251,7 @@ namespace AZ
             void SetAffectsGI(LightHandle handle, bool affectsGI) override;
             void SetAffectsGIFactor(LightHandle handle, float affectsGIFactor) override;
             void SetLightingChannelMask(LightHandle handle, uint32_t lightingChannelMask) override;
+            bool GetActiveLightDirection(Vector3& direction) const override;
 
             const Data::Instance<RPI::Buffer> GetLightBuffer() const { return m_lightBufferHandler.GetBuffer(); }
             uint32_t GetLightCount() const { return m_lightBufferHandler.GetElementCount(); }

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.cpp
@@ -56,9 +56,11 @@ namespace AZ
                 return;
             }
 
+#if defined(CARBONATED)
             m_threadCountX = m_passData->m_threadCountX;
             m_threadCountY = m_passData->m_threadCountY;
             m_threadCountZ = m_passData->m_threadCountZ;
+#endif
             CreatePipelineState();
         }
 
@@ -67,12 +69,14 @@ namespace AZ
             RPI::ShaderReloadNotificationBus::MultiHandler::BusDisconnect();
         }
 
+#if defined(CARBONATED)
         void RayTracingPass::SetTargetThreadCounts(uint32_t threadCountX, uint32_t threadCountY, uint32_t threadCountZ)
         {
             m_threadCountX = threadCountX;
             m_threadCountY = threadCountY;
             m_threadCountZ = threadCountZ;
         }
+#endif
 
         void RayTracingPass::CreatePipelineState()
         {
@@ -149,7 +153,11 @@ namespace AZ
 
             // check to see if the shader requires the View, Scene, or RayTracingMaterial Srgs
             const auto& viewSrgLayout = m_rayGenerationShader->FindShaderResourceGroupLayout(RPI::SrgBindingSlot::View);
+#if defined(CARBONATED)
             m_flags.m_bindViewSrg = (viewSrgLayout != nullptr);
+#else
+            m_requiresViewSrg = (viewSrgLayout != nullptr);
+#endif
 
             const auto& sceneSrgLayout = m_rayGenerationShader->FindShaderResourceGroupLayout(RPI::SrgBindingSlot::Scene);
             m_requiresSceneSrg = (sceneSrgLayout != nullptr);
@@ -422,26 +430,54 @@ namespace AZ
             }
             else
             {
+#if defined(CARBONATED)
                 dispatchRaysItem.m_arguments.m_direct.m_width = m_threadCountX;
                 dispatchRaysItem.m_arguments.m_direct.m_height = m_threadCountY;
                 dispatchRaysItem.m_arguments.m_direct.m_depth = m_threadCountZ;
+#else
+                dispatchRaysItem.m_arguments.m_direct.m_width = m_passData->m_threadCountX;
+                dispatchRaysItem.m_arguments.m_direct.m_height = m_passData->m_threadCountY;
+                dispatchRaysItem.m_arguments.m_direct.m_depth = m_passData->m_threadCountZ;
+#endif
             }
 
             // bind RayTracingGlobal, RayTracingScene, and View Srgs
             // [GFX TODO][ATOM-15610] Add RenderPass::SetSrgsForRayTracingDispatch
+#if defined(CARBONATED)
             AZStd::vector<const RHI::ShaderResourceGroup*> shaderResourceGroups;
+#else
+            AZStd::vector<RHI::ShaderResourceGroup*> shaderResourceGroups = { m_shaderResourceGroup->GetRHIShaderResourceGroup() };
+#endif
 
             if (m_requiresRayTracingSceneSrg)
             {
                 shaderResourceGroups.push_back(rayTracingFeatureProcessor->GetRayTracingSceneSrg()->GetRHIShaderResourceGroup());
             }
 
+#if !defined(CARBONATED)
+            if (m_requiresViewSrg)
+            {
+                RPI::ViewPtr view = m_pipeline->GetFirstView(GetPipelineViewTag());
+                if (view)
+                {
+                    shaderResourceGroups.push_back(view->GetRHIShaderResourceGroup());
+                }
+            }
+
+            if (m_requiresSceneSrg)
+            {
+                shaderResourceGroups.push_back(scene->GetShaderResourceGroup()->GetRHIShaderResourceGroup());
+            }
+#endif
+
             if (m_requiresRayTracingMaterialSrg)
             {
                 shaderResourceGroups.push_back(rayTracingFeatureProcessor->GetRayTracingMaterialSrg()->GetRHIShaderResourceGroup());
             }
 
+#if defined(CARBONATED)
             CollectSrgsToBind(shaderResourceGroups);
+#endif
 
             dispatchRaysItem.m_shaderResourceGroupCount = aznumeric_cast<uint32_t>(shaderResourceGroups.size());
             dispatchRaysItem.m_shaderResourceGroups = shaderResourceGroups.data();

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.cpp
@@ -56,12 +56,22 @@ namespace AZ
                 return;
             }
 
+            m_threadCountX = m_passData->m_threadCountX;
+            m_threadCountY = m_passData->m_threadCountY;
+            m_threadCountZ = m_passData->m_threadCountZ;
             CreatePipelineState();
         }
 
         RayTracingPass::~RayTracingPass()
         {
             RPI::ShaderReloadNotificationBus::MultiHandler::BusDisconnect();
+        }
+
+        void RayTracingPass::SetTargetThreadCounts(uint32_t threadCountX, uint32_t threadCountY, uint32_t threadCountZ)
+        {
+            m_threadCountX = threadCountX;
+            m_threadCountY = threadCountY;
+            m_threadCountZ = threadCountZ;
         }
 
         void RayTracingPass::CreatePipelineState()
@@ -139,7 +149,7 @@ namespace AZ
 
             // check to see if the shader requires the View, Scene, or RayTracingMaterial Srgs
             const auto& viewSrgLayout = m_rayGenerationShader->FindShaderResourceGroupLayout(RPI::SrgBindingSlot::View);
-            m_requiresViewSrg = (viewSrgLayout != nullptr);
+            m_flags.m_bindViewSrg = (viewSrgLayout != nullptr);
 
             const auto& sceneSrgLayout = m_rayGenerationShader->FindShaderResourceGroupLayout(RPI::SrgBindingSlot::Scene);
             m_requiresSceneSrg = (sceneSrgLayout != nullptr);
@@ -412,38 +422,26 @@ namespace AZ
             }
             else
             {
-                dispatchRaysItem.m_arguments.m_direct.m_width = m_passData->m_threadCountX;
-                dispatchRaysItem.m_arguments.m_direct.m_height = m_passData->m_threadCountY;
-                dispatchRaysItem.m_arguments.m_direct.m_depth = m_passData->m_threadCountZ;
+                dispatchRaysItem.m_arguments.m_direct.m_width = m_threadCountX;
+                dispatchRaysItem.m_arguments.m_direct.m_height = m_threadCountY;
+                dispatchRaysItem.m_arguments.m_direct.m_depth = m_threadCountZ;
             }
 
             // bind RayTracingGlobal, RayTracingScene, and View Srgs
             // [GFX TODO][ATOM-15610] Add RenderPass::SetSrgsForRayTracingDispatch
-            AZStd::vector<RHI::ShaderResourceGroup*> shaderResourceGroups = { m_shaderResourceGroup->GetRHIShaderResourceGroup() };
+            AZStd::vector<const RHI::ShaderResourceGroup*> shaderResourceGroups;
 
             if (m_requiresRayTracingSceneSrg)
             {
                 shaderResourceGroups.push_back(rayTracingFeatureProcessor->GetRayTracingSceneSrg()->GetRHIShaderResourceGroup());
             }
 
-            if (m_requiresViewSrg)
-            {
-                RPI::ViewPtr view = m_pipeline->GetFirstView(GetPipelineViewTag());
-                if (view)
-                {
-                    shaderResourceGroups.push_back(view->GetRHIShaderResourceGroup());
-                }
-            }
-
-            if (m_requiresSceneSrg)
-            {
-                shaderResourceGroups.push_back(scene->GetShaderResourceGroup()->GetRHIShaderResourceGroup());
-            }
-
             if (m_requiresRayTracingMaterialSrg)
             {
                 shaderResourceGroups.push_back(rayTracingFeatureProcessor->GetRayTracingMaterialSrg()->GetRHIShaderResourceGroup());
             }
+
+            CollectSrgsToBind(shaderResourceGroups);
 
             dispatchRaysItem.m_shaderResourceGroupCount = aznumeric_cast<uint32_t>(shaderResourceGroups.size());
             dispatchRaysItem.m_shaderResourceGroups = shaderResourceGroups.data();

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.h
@@ -36,6 +36,7 @@ namespace AZ
             static RPI::Ptr<RayTracingPass> Create(const RPI::PassDescriptor& descriptor);
 
             void SetMaxRayLength(float maxRayLength) { m_maxRayLength = maxRayLength; }
+            void SetTargetThreadCounts(uint32_t threadCountX, uint32_t threadCountY, uint32_t threadCountZ);
 
         protected:
             RayTracingPass(const RPI::PassDescriptor& descriptor);
@@ -82,6 +83,9 @@ namespace AZ
             bool m_requiresRayTracingMaterialSrg = false;
             bool m_requiresRayTracingSceneSrg = false;
             float m_maxRayLength = 1e27f;
+            uint32_t m_threadCountX = 1;
+            uint32_t m_threadCountY = 1;
+            uint32_t m_threadCountZ = 1;
         };
     }   // namespace RPI
 }   // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingPass.h
@@ -36,7 +36,9 @@ namespace AZ
             static RPI::Ptr<RayTracingPass> Create(const RPI::PassDescriptor& descriptor);
 
             void SetMaxRayLength(float maxRayLength) { m_maxRayLength = maxRayLength; }
+#if defined(CARBONATED)
             void SetTargetThreadCounts(uint32_t threadCountX, uint32_t threadCountY, uint32_t threadCountZ);
+#endif
 
         protected:
             RayTracingPass(const RPI::PassDescriptor& descriptor);
@@ -83,9 +85,11 @@ namespace AZ
             bool m_requiresRayTracingMaterialSrg = false;
             bool m_requiresRayTracingSceneSrg = false;
             float m_maxRayLength = 1e27f;
+#if defined(CARBONATED)
             uint32_t m_threadCountX = 1;
             uint32_t m_threadCountY = 1;
             uint32_t m_threadCountZ = 1;
+#endif
         };
     }   // namespace RPI
 }   // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionPreviousFramePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionPreviousFramePass.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "ReflectionPreviousFramePass.h"
+#include <Atom/RPI.Public/Image/ImageSystemInterface.h>
+#include <Atom/RPI.Public/Image/AttachmentImagePool.h>
+
+namespace AZ::Render
+{
+    RPI::Ptr<ReflectionPreviousFramePass> ReflectionPreviousFramePass::Create(const RPI::PassDescriptor& descriptor)
+    {
+        RPI::Ptr<ReflectionPreviousFramePass> pass = aznew ReflectionPreviousFramePass(descriptor);
+        return AZStd::move(pass);
+    }
+
+    ReflectionPreviousFramePass::ReflectionPreviousFramePass(const RPI::PassDescriptor& descriptor)
+        : RPI::Pass(descriptor)
+    {
+    }
+
+    void ReflectionPreviousFramePass::BuildInternal()
+    {
+        Data::Instance<RPI::AttachmentImagePool> pool = RPI::ImageSystemInterface::Get()->GetSystemAttachmentPool();
+
+        // retrieve the previous frame image attachment from the pass
+        AZ_Assert(
+            !m_ownedAttachments.empty(),
+            "ReflectionPreviousFramePass must have the PreviousFrameImage attachment image defined");
+        RPI::Ptr<RPI::PassAttachment> previousFrameImageAttachment = m_ownedAttachments.front();
+
+        // update the image attachment descriptor to sync up size and format
+        previousFrameImageAttachment->Update();
+
+        // change the lifetime since we want it to live between frames
+        previousFrameImageAttachment->m_lifetime = RHI::AttachmentLifetimeType::Imported;
+
+        // set the bind flags
+        RHI::ImageDescriptor& imageDesc = previousFrameImageAttachment->m_descriptor.m_image;
+        imageDesc.m_bindFlags |= RHI::ImageBindFlags::Color | RHI::ImageBindFlags::ShaderReadWrite;
+
+        // create the image attachment
+        RHI::ClearValue clearValue = RHI::ClearValue::CreateVector4Float(0, 0, 0, 0);
+        m_previousFrameImageAttachment = RPI::AttachmentImage::Create(
+            *pool.get(), imageDesc, Name(previousFrameImageAttachment->m_path.GetCStr()), &clearValue, nullptr);
+
+        previousFrameImageAttachment->m_name = "PreviousFrame";
+        previousFrameImageAttachment->m_path = m_previousFrameImageAttachment->GetAttachmentId();
+        previousFrameImageAttachment->m_importedResource = m_previousFrameImageAttachment;
+        RPI::Pass::BuildInternal();
+    }
+}   // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionPreviousFramePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionPreviousFramePass.cpp
@@ -6,6 +6,8 @@
  *
  */
 
+#if defined(CARBONATED)
+
 #include "ReflectionPreviousFramePass.h"
 #include <Atom/RPI.Public/Image/ImageSystemInterface.h>
 #include <Atom/RPI.Public/Image/AttachmentImagePool.h>
@@ -54,3 +56,5 @@ namespace AZ::Render
         RPI::Pass::BuildInternal();
     }
 }   // namespace AZ::Render
+
+#endif

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionPreviousFramePass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionPreviousFramePass.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RPI.Public/Pass/Pass.h>
+
+namespace AZ::Render
+{
+    //! This pass holds the image attachment for the previous frame that it's used in the reflections.
+    //! This pass doesn't do the copy, only holds the image attachment. The copy pass cannot hold the image attachment
+    //! because it's goes after the reflection passes and they need to reference it.
+    //! Passes can reference this attachment either directly or by it's global name.
+    class ReflectionPreviousFramePass
+        : public RPI::Pass
+    {
+        AZ_RPI_PASS(ReflectionPreviousFramePass);
+
+    public:
+        AZ_RTTI(ReflectionPreviousFramePass, "{599743AF-C99E-47FD-A4C0-8F1AF86CC730}", RPI::Pass);
+        AZ_CLASS_ALLOCATOR(ReflectionPreviousFramePass, SystemAllocator);
+
+        //! Creates a new pass without a PassTemplate
+        static RPI::Ptr<ReflectionPreviousFramePass> Create(const RPI::PassDescriptor& descriptor);
+
+    private:
+        explicit ReflectionPreviousFramePass(const RPI::PassDescriptor& descriptor);
+
+        // Pass Overrides...
+        void BuildInternal() override;
+
+        Data::Instance<RPI::AttachmentImage> m_previousFrameImageAttachment;
+    };
+}   // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionPreviousFramePass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionPreviousFramePass.h
@@ -7,6 +7,8 @@
  */
 #pragma once
 
+#if defined(CARBONATED)
+
 #include <Atom/RPI.Public/Pass/Pass.h>
 
 namespace AZ::Render
@@ -36,3 +38,5 @@ namespace AZ::Render
         Data::Instance<RPI::AttachmentImage> m_previousFrameImageAttachment;
     };
 }   // namespace AZ::Render
+
+#endif

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceTracePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceTracePass.cpp
@@ -30,6 +30,34 @@ namespace AZ
         {
         }
 
+#if !defined(CARBONATED)
+        void ReflectionScreenSpaceTracePass::BuildInternal()
+        {
+            Data::Instance<RPI::AttachmentImagePool> pool = RPI::ImageSystemInterface::Get()->GetSystemAttachmentPool();
+
+            // retrieve the previous frame image attachment from the pass
+            AZ_Assert(m_ownedAttachments.size() == 3, "ReflectionScreenSpaceTracePass must have the following attachment images defined: ReflectionImage, TraceCoordsImage, and PreviousFrameImage");
+            RPI::Ptr<RPI::PassAttachment> previousFrameImageAttachment = m_ownedAttachments[2];
+
+            // update the image attachment descriptor to sync up size and format
+            previousFrameImageAttachment->Update();
+
+            // change the lifetime since we want it to live between frames
+            previousFrameImageAttachment->m_lifetime = RHI::AttachmentLifetimeType::Imported;
+
+            // set the bind flags
+            RHI::ImageDescriptor& imageDesc = previousFrameImageAttachment->m_descriptor.m_image;
+            imageDesc.m_bindFlags |= RHI::ImageBindFlags::Color | RHI::ImageBindFlags::ShaderReadWrite;
+
+            // create the image attachment
+            RHI::ClearValue clearValue = RHI::ClearValue::CreateVector4Float(0, 0, 0, 0);
+            m_previousFrameImageAttachment = RPI::AttachmentImage::Create(*pool.get(), imageDesc, Name(previousFrameImageAttachment->m_path.GetCStr()), &clearValue, nullptr);
+
+            previousFrameImageAttachment->m_path = m_previousFrameImageAttachment->GetAttachmentId();
+            previousFrameImageAttachment->m_importedResource = m_previousFrameImageAttachment;
+        }
+#endif
+
         void ReflectionScreenSpaceTracePass::CompileResources([[maybe_unused]] const RHI::FrameGraphCompileContext& context)
         {
             if (!m_shaderResourceGroup)

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceTracePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceTracePass.cpp
@@ -30,32 +30,6 @@ namespace AZ
         {
         }
 
-        void ReflectionScreenSpaceTracePass::BuildInternal()
-        {
-            Data::Instance<RPI::AttachmentImagePool> pool = RPI::ImageSystemInterface::Get()->GetSystemAttachmentPool();
-
-            // retrieve the previous frame image attachment from the pass
-            AZ_Assert(m_ownedAttachments.size() == 3, "ReflectionScreenSpaceTracePass must have the following attachment images defined: ReflectionImage, TraceCoordsImage, and PreviousFrameImage");
-            RPI::Ptr<RPI::PassAttachment> previousFrameImageAttachment = m_ownedAttachments[2];
-            
-            // update the image attachment descriptor to sync up size and format
-            previousFrameImageAttachment->Update();
-            
-            // change the lifetime since we want it to live between frames
-            previousFrameImageAttachment->m_lifetime = RHI::AttachmentLifetimeType::Imported;
-            
-            // set the bind flags
-            RHI::ImageDescriptor& imageDesc = previousFrameImageAttachment->m_descriptor.m_image;
-            imageDesc.m_bindFlags |= RHI::ImageBindFlags::Color | RHI::ImageBindFlags::ShaderReadWrite;
-            
-            // create the image attachment
-            RHI::ClearValue clearValue = RHI::ClearValue::CreateVector4Float(0, 0, 0, 0);
-            m_previousFrameImageAttachment = RPI::AttachmentImage::Create(*pool.get(), imageDesc, Name(previousFrameImageAttachment->m_path.GetCStr()), &clearValue, nullptr);
-
-            previousFrameImageAttachment->m_path = m_previousFrameImageAttachment->GetAttachmentId();
-            previousFrameImageAttachment->m_importedResource = m_previousFrameImageAttachment;
-        }
-
         void ReflectionScreenSpaceTracePass::CompileResources([[maybe_unused]] const RHI::FrameGraphCompileContext& context)
         {
             if (!m_shaderResourceGroup)

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceTracePass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceTracePass.h
@@ -29,16 +29,11 @@ namespace AZ
             //! Creates a new pass without a PassTemplate
             static RPI::Ptr<ReflectionScreenSpaceTracePass> Create(const RPI::PassDescriptor& descriptor);
 
-            Data::Instance<RPI::AttachmentImage>& GetPreviousFrameImageAttachment() { return m_previousFrameImageAttachment; }
-
         private:
             explicit ReflectionScreenSpaceTracePass(const RPI::PassDescriptor& descriptor);
 
             // Pass behavior overrides...
-            void BuildInternal() override;
             void CompileResources(const RHI::FrameGraphCompileContext& context) override;
-
-            Data::Instance<RPI::AttachmentImage> m_previousFrameImageAttachment;
 
             RHI::ShaderInputNameIndex m_invOutputScaleNameIndex = "m_invOutputScale";
             RHI::ShaderInputNameIndex m_outputWidthNameIndex = "m_outputWidth";

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceTracePass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceTracePass.h
@@ -29,11 +29,22 @@ namespace AZ
             //! Creates a new pass without a PassTemplate
             static RPI::Ptr<ReflectionScreenSpaceTracePass> Create(const RPI::PassDescriptor& descriptor);
 
+#if !defined(CARBONATED)
+            Data::Instance<RPI::AttachmentImage>& GetPreviousFrameImageAttachment() { return m_previousFrameImageAttachment; }
+#endif
+
         private:
             explicit ReflectionScreenSpaceTracePass(const RPI::PassDescriptor& descriptor);
 
             // Pass behavior overrides...
+#if !defined(CARBONATED)
+            void BuildInternal() override;
+#endif
             void CompileResources(const RHI::FrameGraphCompileContext& context) override;
+
+#if !defined(CARBONATED)
+            Data::Instance<RPI::AttachmentImage> m_previousFrameImageAttachment;
+#endif
 
             RHI::ShaderInputNameIndex m_invOutputScaleNameIndex = "m_invOutputScale";
             RHI::ShaderInputNameIndex m_outputWidthNameIndex = "m_outputWidth";

--- a/Gems/Atom/Feature/Common/Code/Source/SpecularReflections/SpecularReflectionsFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SpecularReflections/SpecularReflectionsFeatureProcessor.cpp
@@ -12,6 +12,7 @@
 #include <Atom/RPI.Public/Pass/PassFilter.h>
 #include <RayTracing/RayTracingPass.h>
 #include <ReflectionScreenSpace/ReflectionScreenSpacePass.h>
+#include <Atom/RPI.Public/Scene.h>
 
 namespace AZ
 {

--- a/Gems/Atom/Feature/Common/Code/Source/SpecularReflections/SpecularReflectionsFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SpecularReflections/SpecularReflectionsFeatureProcessor.cpp
@@ -12,7 +12,9 @@
 #include <Atom/RPI.Public/Pass/PassFilter.h>
 #include <RayTracing/RayTracingPass.h>
 #include <ReflectionScreenSpace/ReflectionScreenSpacePass.h>
+#if defined(CARBONATED)
 #include <Atom/RPI.Public/Scene.h>
+#endif
 
 namespace AZ
 {

--- a/Gems/Atom/Feature/Common/Code/atom_feature_common_files.cmake
+++ b/Gems/Atom/Feature/Common/Code/atom_feature_common_files.cmake
@@ -319,8 +319,8 @@ set(FILES
     Source/ReflectionScreenSpace/ReflectionScreenSpaceFilterPass.h
     Source/ReflectionScreenSpace/ReflectionScreenSpaceCompositePass.cpp
     Source/ReflectionScreenSpace/ReflectionScreenSpaceCompositePass.h
-    Source/ReflectionScreenSpace/ReflectionCopyFrameBufferPass.cpp
-    Source/ReflectionScreenSpace/ReflectionCopyFrameBufferPass.h
+    Source/ReflectionScreenSpace/ReflectionPreviousFramePass.cpp
+    Source/ReflectionScreenSpace/ReflectionPreviousFramePass.h
     Source/ScreenSpace/DeferredFogSettings.cpp
     Source/ScreenSpace/DeferredFogSettings.h
     Source/ScreenSpace/DeferredFogPass.cpp

--- a/Gems/Atom/Feature/Common/Code/atom_feature_common_files.cmake
+++ b/Gems/Atom/Feature/Common/Code/atom_feature_common_files.cmake
@@ -319,8 +319,12 @@ set(FILES
     Source/ReflectionScreenSpace/ReflectionScreenSpaceFilterPass.h
     Source/ReflectionScreenSpace/ReflectionScreenSpaceCompositePass.cpp
     Source/ReflectionScreenSpace/ReflectionScreenSpaceCompositePass.h
+# Begin Carbonated
     Source/ReflectionScreenSpace/ReflectionPreviousFramePass.cpp
     Source/ReflectionScreenSpace/ReflectionPreviousFramePass.h
+# End Carbonated
+    # Source/ReflectionScreenSpace/ReflectionCopyFrameBufferPass.cpp
+    # Source/ReflectionScreenSpace/ReflectionCopyFrameBufferPass.h
     Source/ScreenSpace/DeferredFogSettings.cpp
     Source/ScreenSpace/DeferredFogSettings.h
     Source/ScreenSpace/DeferredFogPass.cpp

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.cpp
@@ -372,6 +372,7 @@ namespace AZ
 
                 // retrieve binding
                 const size_t srgBindingIndex = globalPipelineLayout->GetIndexBySlot(srgBindingSlot);
+#if defined(CARBONATED)
                 if (srgBindingIndex < RHI::Limits::Pipeline::ShaderResourceGroupCountMax)
                 {
                     RootParameterBinding binding = globalPipelineLayout->GetRootParameterBindingByIndex(srgBindingIndex);
@@ -403,6 +404,33 @@ namespace AZ
                             binding.m_constantBuffer.GetIndex(), compiledData.m_gpuConstantAddress);
                     }
                 }
+#else
+                RootParameterBinding binding = globalPipelineLayout->GetRootParameterBindingByIndex(srgBindingIndex);
+                const ShaderResourceGroup* srg = static_cast<const ShaderResourceGroup*>(dispatchRaysItem.m_shaderResourceGroups[srgIndex]);
+                const ShaderResourceGroupCompiledData& compiledData = srg->GetCompiledData();
+
+                if (binding.m_resourceTable.IsValid()
+                    && compiledData.m_gpuViewsDescriptorHandle.ptr)
+                {
+                    GetCommandList()->SetComputeRootDescriptorTable(binding.m_resourceTable.GetIndex(), compiledData.m_gpuViewsDescriptorHandle);
+                }
+
+                for (uint32_t unboundedArrayIndex = 0; unboundedArrayIndex < ShaderResourceGroupCompiledData::MaxUnboundedArrays; ++unboundedArrayIndex)
+                {
+                    if (binding.m_bindlessTable.IsValid()
+                        && compiledData.m_gpuUnboundedArraysDescriptorHandles[unboundedArrayIndex].ptr)
+                    {
+                        GetCommandList()->SetComputeRootDescriptorTable(
+                            binding.m_bindlessTable.GetIndex(),
+                            compiledData.m_gpuUnboundedArraysDescriptorHandles[unboundedArrayIndex]);
+                    }
+                }
+
+                if (binding.m_constantBuffer.IsValid())
+                {
+                    GetCommandList()->SetComputeRootConstantBufferView(binding.m_constantBuffer.GetIndex(), compiledData.m_gpuConstantAddress);
+                }
+#endif
             }
 
             // set the bindless descriptor table if required by the shader

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.cpp
@@ -372,30 +372,36 @@ namespace AZ
 
                 // retrieve binding
                 const size_t srgBindingIndex = globalPipelineLayout->GetIndexBySlot(srgBindingSlot);
-                RootParameterBinding binding = globalPipelineLayout->GetRootParameterBindingByIndex(srgBindingIndex);
-                const ShaderResourceGroup* srg = static_cast<const ShaderResourceGroup*>(dispatchRaysItem.m_shaderResourceGroups[srgIndex]);
-                const ShaderResourceGroupCompiledData& compiledData = srg->GetCompiledData();
-
-                if (binding.m_resourceTable.IsValid()
-                    && compiledData.m_gpuViewsDescriptorHandle.ptr)
+                if (srgBindingIndex < RHI::Limits::Pipeline::ShaderResourceGroupCountMax)
                 {
-                    GetCommandList()->SetComputeRootDescriptorTable(binding.m_resourceTable.GetIndex(), compiledData.m_gpuViewsDescriptorHandle);
-                }
+                    RootParameterBinding binding = globalPipelineLayout->GetRootParameterBindingByIndex(srgBindingIndex);
+                    const ShaderResourceGroup* srg =
+                        static_cast<const ShaderResourceGroup*>(dispatchRaysItem.m_shaderResourceGroups[srgIndex]);
+                    const ShaderResourceGroupCompiledData& compiledData = srg->GetCompiledData();
 
-                for (uint32_t unboundedArrayIndex = 0; unboundedArrayIndex < ShaderResourceGroupCompiledData::MaxUnboundedArrays; ++unboundedArrayIndex)
-                {
-                    if (binding.m_bindlessTable.IsValid()
-                        && compiledData.m_gpuUnboundedArraysDescriptorHandles[unboundedArrayIndex].ptr)
+                    if (binding.m_resourceTable.IsValid() && compiledData.m_gpuViewsDescriptorHandle.ptr)
                     {
                         GetCommandList()->SetComputeRootDescriptorTable(
-                            binding.m_bindlessTable.GetIndex(),
-                            compiledData.m_gpuUnboundedArraysDescriptorHandles[unboundedArrayIndex]);
+                            binding.m_resourceTable.GetIndex(), compiledData.m_gpuViewsDescriptorHandle);
                     }
-                }
 
-                if (binding.m_constantBuffer.IsValid())
-                {
-                    GetCommandList()->SetComputeRootConstantBufferView(binding.m_constantBuffer.GetIndex(), compiledData.m_gpuConstantAddress);
+                    for (uint32_t unboundedArrayIndex = 0; unboundedArrayIndex < ShaderResourceGroupCompiledData::MaxUnboundedArrays;
+                         ++unboundedArrayIndex)
+                    {
+                        if (binding.m_bindlessTable.IsValid() &&
+                            compiledData.m_gpuUnboundedArraysDescriptorHandles[unboundedArrayIndex].ptr)
+                        {
+                            GetCommandList()->SetComputeRootDescriptorTable(
+                                binding.m_bindlessTable.GetIndex(),
+                                compiledData.m_gpuUnboundedArraysDescriptorHandles[unboundedArrayIndex]);
+                        }
+                    }
+
+                    if (binding.m_constantBuffer.IsValid())
+                    {
+                        GetCommandList()->SetComputeRootConstantBufferView(
+                            binding.m_constantBuffer.GetIndex(), compiledData.m_gpuConstantAddress);
+                    }
                 }
             }
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/ParentPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/ParentPass.h
@@ -56,6 +56,13 @@ namespace AZ
             //! Return owning attachment
             Ptr<PassAttachment> GetOwnedAttachment(const Name& attachmentName) const;
 
+            //! Updates a binding that is using an old value with a new PassAttachmentBinding starting from child with startChildIndex.
+            //! Useful for updating passes that are using an attachment and a new pass is inserted in between, so all subsequent passes using
+            //! that attachment must now point to the new inserted pass.
+            bool UpdateConnectedBinding(uint32_t startChildIndex, PassAttachmentBinding* oldValue, PassAttachmentBinding* newValue);
+            //! Updates the binding starting from the first child.
+            bool UpdateConnectedBinding(PassAttachmentBinding* oldValue, PassAttachmentBinding* newValue) override;
+
             // --- Children related functions ---
 
             //! Adds pass to list of children. NOTE: skipStateCheckWhenRunningTests is only used to support manual adding of passing in unit tests, do not use this variable otherwise

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/ParentPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/ParentPass.h
@@ -56,12 +56,14 @@ namespace AZ
             //! Return owning attachment
             Ptr<PassAttachment> GetOwnedAttachment(const Name& attachmentName) const;
 
+#if defined(CARBONATED)
             //! Updates a binding that is using an old value with a new PassAttachmentBinding starting from child with startChildIndex.
             //! Useful for updating passes that are using an attachment and a new pass is inserted in between, so all subsequent passes using
             //! that attachment must now point to the new inserted pass.
             bool UpdateConnectedBinding(uint32_t startChildIndex, PassAttachmentBinding* oldValue, PassAttachmentBinding* newValue);
             //! Updates the binding starting from the first child.
             bool UpdateConnectedBinding(PassAttachmentBinding* oldValue, PassAttachmentBinding* newValue) override;
+#endif
 
             // --- Children related functions ---
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
@@ -315,10 +315,12 @@ namespace AZ
             // Update output bindings on this pass that are connected to bindings on other passes
             void UpdateConnectedOutputBindings();
 
+#if defined(CARBONATED)
             // Update a binding that is using an old value with a new PassAttachmentBinding.
             // Useful when inserting a new pass and wants to update all subsequent passes to use a PassAttachmentBinding
             // of the new inserted pass. 
             virtual bool UpdateConnectedBinding(PassAttachmentBinding* oldValue, PassAttachmentBinding* newValue);
+#endif
 
         protected:
             explicit Pass(const PassDescriptor& descriptor);

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
@@ -315,6 +315,11 @@ namespace AZ
             // Update output bindings on this pass that are connected to bindings on other passes
             void UpdateConnectedOutputBindings();
 
+            // Update a binding that is using an old value with a new PassAttachmentBinding.
+            // Useful when inserting a new pass and wants to update all subsequent passes to use a PassAttachmentBinding
+            // of the new inserted pass. 
+            virtual bool UpdateConnectedBinding(PassAttachmentBinding* oldValue, PassAttachmentBinding* newValue);
+
         protected:
             explicit Pass(const PassDescriptor& descriptor);
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassAttachment.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassAttachment.h
@@ -10,7 +10,9 @@
 #include <AtomCore/Instance/Instance.h>
 #include <AtomCore/Instance/InstanceData.h>
 
+#if defined(CARBONATED)
 #include <Atom/RHI.Reflect/BufferScopeAttachmentDescriptor.h>
+#endif
 #include <Atom/RHI.Reflect/ShaderInputNameIndex.h>
 
 #include <Atom/RPI.Reflect/Pass/PassAttachmentReflect.h>
@@ -158,11 +160,13 @@ namespace AZ
             //! Updates the set attachment from the binding connection
             void UpdateConnection(bool useFallback);
 
+#if defined(CARBONATED)
             //! Returns the buffer scope descriptor for this binding.
             //! For pass assets, a buffer view element count of 0 means "use the rest of
             //! the attached buffer from element offset". The returned descriptor resolves
             //! that shorthand to a concrete nonzero element count before RHI submission.
             RHI::BufferScopeAttachmentDescriptor GetResolvedBufferScopeAttachmentDescriptor(const char* passPath) const;
+#endif
 
             //! Name of the attachment binding so we can find it in a list of attachment binding
             Name m_name;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassAttachment.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassAttachment.h
@@ -10,6 +10,7 @@
 #include <AtomCore/Instance/Instance.h>
 #include <AtomCore/Instance/InstanceData.h>
 
+#include <Atom/RHI.Reflect/BufferScopeAttachmentDescriptor.h>
 #include <Atom/RHI.Reflect/ShaderInputNameIndex.h>
 
 #include <Atom/RPI.Reflect/Pass/PassAttachmentReflect.h>
@@ -156,6 +157,12 @@ namespace AZ
 
             //! Updates the set attachment from the binding connection
             void UpdateConnection(bool useFallback);
+
+            //! Returns the buffer scope descriptor for this binding.
+            //! For pass assets, a buffer view element count of 0 means "use the rest of
+            //! the attached buffer from element offset". The returned descriptor resolves
+            //! that shorthand to a concrete nonzero element count before RHI submission.
+            RHI::BufferScopeAttachmentDescriptor GetResolvedBufferScopeAttachmentDescriptor(const char* passPath) const;
 
             //! Name of the attachment binding so we can find it in a list of attachment binding
             Name m_name;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/RenderPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/RenderPass.h
@@ -99,7 +99,9 @@ namespace AZ
             // Set srgs for pass's execution
             void SetSrgsForDraw(RHI::CommandList* commandList);
             void SetSrgsForDispatch(RHI::CommandList* commandList);
+#if defined(CARBONATED)
             void CollectSrgsToBind(AZStd::vector<const RHI::ShaderResourceGroup*>& srgs);
+#endif
 
             // Set PipelineViewTag associated for this pass
             // If the View bound to the tag exists,the view's srg will be collected to pass' srg bind list

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/RenderPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/RenderPass.h
@@ -99,6 +99,7 @@ namespace AZ
             // Set srgs for pass's execution
             void SetSrgsForDraw(RHI::CommandList* commandList);
             void SetSrgsForDispatch(RHI::CommandList* commandList);
+            void CollectSrgsToBind(AZStd::vector<const RHI::ShaderResourceGroup*>& srgs);
 
             // Set PipelineViewTag associated for this pass
             // If the View bound to the tag exists,the view's srg will be collected to pass' srg bind list

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/ShaderResourceGroup.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/ShaderResourceGroup.h
@@ -90,8 +90,10 @@ namespace AZ
             /// Returns the underlying RHI shader resource group.
             RHI::ShaderResourceGroup* GetRHIShaderResourceGroup();
 
+#if defined(CARBONATED)
             /// Returns the underlying RHI shader resource group.
             const RHI::ShaderResourceGroup* GetRHIShaderResourceGroup() const;
+#endif
 
             //////////////////////////////////////////////////////////////////////////
             // Methods for assignment / access of RPI Image types.

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/ShaderResourceGroup.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/ShaderResourceGroup.h
@@ -90,6 +90,9 @@ namespace AZ
             /// Returns the underlying RHI shader resource group.
             RHI::ShaderResourceGroup* GetRHIShaderResourceGroup();
 
+            /// Returns the underlying RHI shader resource group.
+            const RHI::ShaderResourceGroup* GetRHIShaderResourceGroup() const;
+
             //////////////////////////////////////////////////////////////////////////
             // Methods for assignment / access of RPI Image types.
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/View.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/View.h
@@ -55,8 +55,12 @@ namespace AZ
                 UsageCamera = (1u << 0),
                 UsageShadow = (1u << 1),
                 UsageReflectiveCubeMap = (1u << 2),
+#if defined(CARBONATED)
                 UsageXR = (1u << 3),
                 UsageOther = (1u << 4)
+#else
+                UsageXR = (1u << 3)
+#endif
             };
             //! Only use this function to create a new view object. And force using smart pointer to manage view's life time
             static ViewPtr CreateView(const AZ::Name& name, UsageFlags usage);

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/View.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/View.h
@@ -55,7 +55,8 @@ namespace AZ
                 UsageCamera = (1u << 0),
                 UsageShadow = (1u << 1),
                 UsageReflectiveCubeMap = (1u << 2),
-                UsageXR = (1u << 3)
+                UsageXR = (1u << 3),
+                UsageOther = (1u << 4)
             };
             //! Only use this function to create a new view object. And force using smart pointer to manage view's life time
             static ViewPtr CreateView(const AZ::Name& name, UsageFlags usage);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ParentPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ParentPass.cpp
@@ -485,6 +485,22 @@ namespace AZ
             return nullptr;
         }
 
+        bool ParentPass::UpdateConnectedBinding(uint32_t startChildIndex, PassAttachmentBinding* oldValue, PassAttachmentBinding* newValue)
+        {
+            bool result = false;
+            for (uint32_t i = startChildIndex; i < m_children.size(); ++i)
+            {
+                result |= m_children[i]->UpdateConnectedBinding(oldValue, newValue);
+            }
+            return result;
+        }
+
+        bool ParentPass::UpdateConnectedBinding(PassAttachmentBinding* oldValue, PassAttachmentBinding* newValue)
+        {
+            bool result = Pass::UpdateConnectedBinding(oldValue, newValue);
+            return result || UpdateConnectedBinding(0, oldValue, newValue);
+        }
+
         // --- Debug functions ---
 
         AZStd::span<const Ptr<Pass>> ParentPass::GetChildren() const

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ParentPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ParentPass.cpp
@@ -485,6 +485,7 @@ namespace AZ
             return nullptr;
         }
 
+#if defined(CARBONATED)
         bool ParentPass::UpdateConnectedBinding(uint32_t startChildIndex, PassAttachmentBinding* oldValue, PassAttachmentBinding* newValue)
         {
             bool result = false;
@@ -500,6 +501,7 @@ namespace AZ
             bool result = Pass::UpdateConnectedBinding(oldValue, newValue);
             return result || UpdateConnectedBinding(0, oldValue, newValue);
         }
+#endif
 
         // --- Debug functions ---
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -1061,6 +1061,19 @@ namespace AZ
             }
         }
 
+        bool Pass::UpdateConnectedBinding(PassAttachmentBinding* oldValue, PassAttachmentBinding* newValue)
+        {
+            for (PassAttachmentBinding& binding : m_attachmentBindings)
+            {
+                if (binding.m_connectedBinding == oldValue)
+                {
+                    binding.m_connectedBinding = newValue;
+                    return true;
+                }
+            }
+            return false;
+        }
+
         void Pass::RegisterPipelineGlobalConnections()
         {
             if (!m_pipeline)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -1061,6 +1061,7 @@ namespace AZ
             }
         }
 
+#if defined(CARBONATED)
         bool Pass::UpdateConnectedBinding(PassAttachmentBinding* oldValue, PassAttachmentBinding* newValue)
         {
             for (PassAttachmentBinding& binding : m_attachmentBindings)
@@ -1073,6 +1074,7 @@ namespace AZ
             }
             return false;
         }
+#endif
 
         void Pass::RegisterPipelineGlobalConnections()
         {

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassAttachment.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassAttachment.cpp
@@ -8,13 +8,12 @@
 
 #include <math.h>
 
-#include <inttypes.h>
-#include <limits>
-
 #include <AzFramework/StringFunc/StringFunc.h>
 
 #include <Atom/RHI.Reflect/Bits.h>
+#if defined(CARBONATED)
 #include <Atom/RHI.Reflect/BufferScopeAttachmentDescriptor.h>
+#endif
 #include <Atom/RHI/RHIUtils.h>
 
 
@@ -402,6 +401,7 @@ namespace AZ
             SetAttachment(targetAttachment);
         }
 
+#if defined(CARBONATED)
         RHI::BufferScopeAttachmentDescriptor PassAttachmentBinding::GetResolvedBufferScopeAttachmentDescriptor(const char* passPath) const
         {
             RHI::BufferScopeAttachmentDescriptor bufferScopeDesc = m_unifiedScopeDesc.GetAsBuffer();
@@ -482,6 +482,7 @@ namespace AZ
             bufferViewDesc.m_elementCount = aznumeric_cast<uint32_t>(resolvedElementCount);
             return bufferScopeDesc;
         }
+#endif
 
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassAttachment.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassAttachment.cpp
@@ -8,9 +8,13 @@
 
 #include <math.h>
 
+#include <inttypes.h>
+#include <limits>
+
 #include <AzFramework/StringFunc/StringFunc.h>
 
 #include <Atom/RHI.Reflect/Bits.h>
+#include <Atom/RHI.Reflect/BufferScopeAttachmentDescriptor.h>
 #include <Atom/RHI/RHIUtils.h>
 
 
@@ -396,6 +400,87 @@ namespace AZ
             }
 
             SetAttachment(targetAttachment);
+        }
+
+        RHI::BufferScopeAttachmentDescriptor PassAttachmentBinding::GetResolvedBufferScopeAttachmentDescriptor(const char* passPath) const
+        {
+            RHI::BufferScopeAttachmentDescriptor bufferScopeDesc = m_unifiedScopeDesc.GetAsBuffer();
+            RHI::BufferViewDescriptor& bufferViewDesc = bufferScopeDesc.m_bufferViewDescriptor;
+            if (bufferViewDesc.m_elementCount != 0)
+            {
+                return bufferScopeDesc;
+            }
+
+            // Pass assets can request a full-buffer view by setting element count to 0.
+            // Resolve that data-driven shorthand here so the RHI still receives a strict
+            // descriptor with a valid concrete element count.
+            PassAttachment* attachment = GetAttachment().get();
+            if (!attachment)
+            {
+                return bufferScopeDesc;
+            }
+
+            const uint32_t elementSize = bufferViewDesc.m_elementSize;
+            AZ_Error(
+                "Pass System",
+                elementSize > 0,
+                "Pass [%s] buffer slot [%s] requested a full-buffer view with an invalid element size of 0.",
+                passPath,
+                m_name.GetCStr());
+            if (elementSize == 0)
+            {
+                return bufferScopeDesc;
+            }
+
+            const uint64_t byteCount = attachment->m_descriptor.m_buffer.m_byteCount;
+            AZ_Error(
+                "Pass System",
+                byteCount % elementSize == 0,
+                "Pass [%s] buffer slot [%s] requested a full-buffer view, but attachment [%s] byte count %" PRIu64
+                " is not divisible by element size %u.",
+                passPath,
+                m_name.GetCStr(),
+                attachment->m_name.GetCStr(),
+                byteCount,
+                elementSize);
+            if (byteCount % elementSize != 0)
+            {
+                return bufferScopeDesc;
+            }
+
+            const uint64_t totalElementCount = byteCount / elementSize;
+            const uint64_t elementOffset = bufferViewDesc.m_elementOffset;
+            // Full-buffer views start at elementOffset and cover the remainder. The offset
+            // must still identify an element inside the buffer.
+            AZ_Error(
+                "Pass System",
+                elementOffset < totalElementCount,
+                "Pass [%s] buffer slot [%s] requested a full-buffer view, but element offset %" PRIu64
+                " is outside attachment [%s] with %" PRIu64 " elements.",
+                passPath,
+                m_name.GetCStr(),
+                elementOffset,
+                attachment->m_name.GetCStr(),
+                totalElementCount);
+            if (elementOffset >= totalElementCount)
+            {
+                return bufferScopeDesc;
+            }
+
+            const uint64_t resolvedElementCount = totalElementCount - elementOffset;
+            AZ_Error(
+                "Pass System",
+                resolvedElementCount <= aznumeric_cast<uint64_t>(std::numeric_limits<uint32_t>::max()),
+                "Pass [%s] buffer slot [%s] resolved a full-buffer view element count that is too large.",
+                passPath,
+                m_name.GetCStr());
+            if (resolvedElementCount > aznumeric_cast<uint64_t>(std::numeric_limits<uint32_t>::max()))
+            {
+                return bufferScopeDesc;
+            }
+
+            bufferViewDesc.m_elementCount = aznumeric_cast<uint32_t>(resolvedElementCount);
+            return bufferScopeDesc;
         }
 
     } // namespace RPI

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
@@ -240,11 +240,15 @@ namespace AZ
                     }
                     case RHI::AttachmentType::Buffer:
                     {
+#if defined(CARBONATED)
                         // Resolve pass-asset full-buffer view shorthand before declaring
                         // the attachment. RHI descriptors must have a concrete element count.
                         RHI::BufferScopeAttachmentDescriptor bufferScopeDesc =
                             attachmentBinding.GetResolvedBufferScopeAttachmentDescriptor(GetPathName().GetCStr());
                         frameGraph.UseAttachment(bufferScopeDesc, attachmentBinding.GetAttachmentAccess(), attachmentBinding.m_scopeAttachmentUsage);
+#else
+                        frameGraph.UseAttachment(attachmentBinding.m_unifiedScopeDesc.GetAsBuffer(), attachmentBinding.GetAttachmentAccess(), attachmentBinding.m_scopeAttachmentUsage);
+#endif
                         break;
                     }
                     default:
@@ -430,6 +434,7 @@ namespace AZ
             }
         }
 
+#if defined(CARBONATED)
         void RenderPass::CollectSrgsToBind(AZStd::vector<const RHI::ShaderResourceGroup*>& srgs)
         {
             for (auto itr : m_shaderResourceGroupsToBind)
@@ -437,6 +442,7 @@ namespace AZ
                 srgs.push_back(itr.second);
             }
         }
+#endif
 
         void RenderPass::SetPipelineViewTag(const PipelineViewTag& viewTag)
         {

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
@@ -240,7 +240,11 @@ namespace AZ
                     }
                     case RHI::AttachmentType::Buffer:
                     {
-                        frameGraph.UseAttachment(attachmentBinding.m_unifiedScopeDesc.GetAsBuffer(), attachmentBinding.GetAttachmentAccess(), attachmentBinding.m_scopeAttachmentUsage);
+                        // Resolve pass-asset full-buffer view shorthand before declaring
+                        // the attachment. RHI descriptors must have a concrete element count.
+                        RHI::BufferScopeAttachmentDescriptor bufferScopeDesc =
+                            attachmentBinding.GetResolvedBufferScopeAttachmentDescriptor(GetPathName().GetCStr());
+                        frameGraph.UseAttachment(bufferScopeDesc, attachmentBinding.GetAttachmentAccess(), attachmentBinding.m_scopeAttachmentUsage);
                         break;
                     }
                     default:
@@ -423,6 +427,14 @@ namespace AZ
             for (auto itr : m_shaderResourceGroupsToBind)
             {
                 commandList->SetShaderResourceGroupForDispatch(*(itr.second));
+            }
+        }
+
+        void RenderPass::CollectSrgsToBind(AZStd::vector<const RHI::ShaderResourceGroup*>& srgs)
+        {
+            for (auto itr : m_shaderResourceGroupsToBind)
+            {
+                srgs.push_back(itr.second);
             }
         }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderResourceGroup.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderResourceGroup.cpp
@@ -200,10 +200,12 @@ namespace AZ
             return m_shaderResourceGroup.get();
         }
 
+#if defined(CARBONATED)
         const RHI::ShaderResourceGroup* ShaderResourceGroup::GetRHIShaderResourceGroup() const
         {
             return m_shaderResourceGroup.get();
         }
+#endif
 
         bool ShaderResourceGroup::SetShaderVariantKeyFallbackValue(const ShaderVariantKey& shaderKey)
         {

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderResourceGroup.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderResourceGroup.cpp
@@ -200,6 +200,11 @@ namespace AZ
             return m_shaderResourceGroup.get();
         }
 
+        const RHI::ShaderResourceGroup* ShaderResourceGroup::GetRHIShaderResourceGroup() const
+        {
+            return m_shaderResourceGroup.get();
+        }
+
         bool ShaderResourceGroup::SetShaderVariantKeyFallbackValue(const ShaderVariantKey& shaderKey)
         {
             uint32_t keySize = GetLayout()->GetShaderVariantKeyFallbackSize();

--- a/Gems/Atom/RPI/Code/Tests/Pass/PassTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Pass/PassTests.cpp
@@ -10,7 +10,9 @@
 #include <Atom/RPI.Reflect/Pass/PassRequest.h>
 #include <Atom/RPI.Reflect/Pass/PassTemplate.h>
 
+#if defined(CARBONATED)
 #include <Atom/RHI.Reflect/BufferScopeAttachmentDescriptor.h>
+#endif
 #include <Atom/RPI.Public/Pass/ComputePass.h>
 #include <Atom/RPI.Public/Pass/CopyPass.h>
 #include <Atom/RPI.Public/Pass/ParentPass.h>
@@ -31,6 +33,7 @@ namespace UnitTest
     using namespace AZ;
     using namespace RPI;
 
+#if defined(CARBONATED)
     struct FullBufferViewTestData
     {
         Ptr<PassAttachment> m_attachment;
@@ -69,6 +72,7 @@ namespace UnitTest
         testData.m_binding.SetAttachment(testData.m_attachment);
         return testData;
     }
+#endif
 
     // This class holds and sets up some data for the tests
     // This is it's own class so we can delete it before the teardown phase, otherwise
@@ -785,6 +789,7 @@ namespace UnitTest
         TestCreationMethodsSuccess();
     }
 
+#if defined(CARBONATED)
     TEST_F(PassTests, ResolveFullBufferView_UsesFullBuffer)
     {
         FullBufferViewTestData testData = CreateFullBufferViewTestData(
@@ -853,6 +858,7 @@ namespace UnitTest
             AZ_TEST_STOP_TRACE_SUPPRESSION(1);
         }
     }
+#endif
 
     TEST_F(PassTests, PassFilter_PassHierarchy)
     {

--- a/Gems/Atom/RPI/Code/Tests/Pass/PassTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Pass/PassTests.cpp
@@ -10,6 +10,7 @@
 #include <Atom/RPI.Reflect/Pass/PassRequest.h>
 #include <Atom/RPI.Reflect/Pass/PassTemplate.h>
 
+#include <Atom/RHI.Reflect/BufferScopeAttachmentDescriptor.h>
 #include <Atom/RPI.Public/Pass/ComputePass.h>
 #include <Atom/RPI.Public/Pass/CopyPass.h>
 #include <Atom/RPI.Public/Pass/ParentPass.h>
@@ -29,6 +30,45 @@ namespace UnitTest
 {
     using namespace AZ;
     using namespace RPI;
+
+    struct FullBufferViewTestData
+    {
+        Ptr<PassAttachment> m_attachment;
+        PassAttachmentBinding m_binding;
+    };
+
+    // Builds a minimal buffer attachment and binding so full-buffer view resolution can be
+    // tested without constructing a whole pass graph.
+    FullBufferViewTestData CreateFullBufferViewTestData(
+        uint64_t byteCount,
+        uint32_t elementOffset,
+        uint32_t elementCount,
+        uint32_t elementSize)
+    {
+        PassBufferAttachmentDesc attachmentDesc;
+        attachmentDesc.m_name = "TestBuffer";
+        attachmentDesc.m_bufferDescriptor.m_bindFlags = RHI::BufferBindFlags::ShaderReadWrite;
+        attachmentDesc.m_bufferDescriptor.m_byteCount = byteCount;
+        attachmentDesc.m_bufferDescriptor.m_alignment = 0;
+
+        FullBufferViewTestData testData;
+        testData.m_attachment = aznew PassAttachment(attachmentDesc);
+        testData.m_attachment->ComputePathName(Name("TestPass"));
+
+        PassSlot slot;
+        slot.m_name = "TestBufferSlot";
+        slot.m_slotType = PassSlotType::Input;
+        slot.m_scopeAttachmentUsage = RHI::ScopeAttachmentUsage::Shader;
+        slot.m_bufferViewDesc = AZStd::make_shared<RHI::BufferViewDescriptor>();
+        slot.m_bufferViewDesc->m_elementOffset = elementOffset;
+        slot.m_bufferViewDesc->m_elementCount = elementCount;
+        slot.m_bufferViewDesc->m_elementSize = elementSize;
+        slot.m_bufferViewDesc->m_elementFormat = RHI::Format::Unknown;
+
+        testData.m_binding = PassAttachmentBinding(slot);
+        testData.m_binding.SetAttachment(testData.m_attachment);
+        return testData;
+    }
 
     // This class holds and sets up some data for the tests
     // This is it's own class so we can delete it before the teardown phase, otherwise
@@ -743,6 +783,75 @@ namespace UnitTest
     TEST_F(PassTests, CreationMethodsSuccess)
     {
         TestCreationMethodsSuccess();
+    }
+
+    TEST_F(PassTests, ResolveFullBufferView_UsesFullBuffer)
+    {
+        FullBufferViewTestData testData = CreateFullBufferViewTestData(
+            256,
+            0,
+            0,
+            16);
+
+        RHI::BufferScopeAttachmentDescriptor scopeDescriptor = testData.m_binding.GetResolvedBufferScopeAttachmentDescriptor("TestPass");
+
+        EXPECT_EQ(16, scopeDescriptor.m_bufferViewDescriptor.m_elementCount);
+    }
+
+    TEST_F(PassTests, ResolveFullBufferView_UsesRemainingBufferAfterOffset)
+    {
+        FullBufferViewTestData testData = CreateFullBufferViewTestData(
+            256,
+            4,
+            0,
+            16);
+
+        RHI::BufferScopeAttachmentDescriptor scopeDescriptor = testData.m_binding.GetResolvedBufferScopeAttachmentDescriptor("TestPass");
+
+        EXPECT_EQ(12, scopeDescriptor.m_bufferViewDescriptor.m_elementCount);
+    }
+
+    TEST_F(PassTests, ResolveFullBufferView_KeepsExplicitElementCount)
+    {
+        FullBufferViewTestData testData = CreateFullBufferViewTestData(
+            256,
+            4,
+            6,
+            16);
+
+        RHI::BufferScopeAttachmentDescriptor scopeDescriptor = testData.m_binding.GetResolvedBufferScopeAttachmentDescriptor("TestPass");
+
+        EXPECT_EQ(6, scopeDescriptor.m_bufferViewDescriptor.m_elementCount);
+    }
+
+    TEST_F(PassTests, ResolveFullBufferView_RejectsInvalidFullBufferViews)
+    {
+        {
+            AZ_TEST_START_TRACE_SUPPRESSION;
+            FullBufferViewTestData testData = CreateFullBufferViewTestData(256, 0, 0, 0);
+            RHI::BufferScopeAttachmentDescriptor scopeDescriptor =
+                testData.m_binding.GetResolvedBufferScopeAttachmentDescriptor("TestPass");
+            EXPECT_EQ(0, scopeDescriptor.m_bufferViewDescriptor.m_elementCount);
+            AZ_TEST_STOP_TRACE_SUPPRESSION(1);
+        }
+
+        {
+            AZ_TEST_START_TRACE_SUPPRESSION;
+            FullBufferViewTestData testData = CreateFullBufferViewTestData(258, 0, 0, 16);
+            RHI::BufferScopeAttachmentDescriptor scopeDescriptor =
+                testData.m_binding.GetResolvedBufferScopeAttachmentDescriptor("TestPass");
+            EXPECT_EQ(0, scopeDescriptor.m_bufferViewDescriptor.m_elementCount);
+            AZ_TEST_STOP_TRACE_SUPPRESSION(1);
+        }
+
+        {
+            AZ_TEST_START_TRACE_SUPPRESSION;
+            FullBufferViewTestData testData = CreateFullBufferViewTestData(256, 16, 0, 16);
+            RHI::BufferScopeAttachmentDescriptor scopeDescriptor =
+                testData.m_binding.GetResolvedBufferScopeAttachmentDescriptor("TestPass");
+            EXPECT_EQ(0, scopeDescriptor.m_bufferViewDescriptor.m_elementCount);
+            AZ_TEST_STOP_TRACE_SUPPRESSION(1);
+        }
     }
 
     TEST_F(PassTests, PassFilter_PassHierarchy)

--- a/Gems/AtomTressFX/Assets/Passes/AtomTressFX_MainPipeline.pass
+++ b/Gems/AtomTressFX/Assets/Passes/AtomTressFX_MainPipeline.pass
@@ -144,6 +144,19 @@
                     ]
                 },
                 {
+                    "Name": "ReflectionPreviousFramePass",
+                    "TemplateName": "ReflectionPreviousFramePassTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "PipelineOutput",
+                            "AttachmentRef": {
+                                "Pass": "PipelineGlobal",
+                                "Attachment": "PipelineOutput"
+                            }
+                        }
+                    ]
+                },
+                {
                     "Name": "OpaquePass",
                     "TemplateName": "OpaqueParentTemplate",
                     "Connections": [
@@ -419,6 +432,13 @@
                             "AttachmentRef": {
                                 "Pass": "DeferredFogPass",
                                 "Attachment": "RenderTargetInputOutput"
+                            }
+                        },
+                        {
+                            "LocalSlot": "Output",
+                            "AttachmentRef": {
+                                "Pass": "ReflectionPreviousFramePass",
+                                "Attachment": "PreviousFrameImage"
                             }
                         }
                     ]


### PR DESCRIPTION
## What does this PR do?

Changes needed for implementing the Water gem (https://github.com/carbonated-dev/o3de-gems/pull/70)

- Added ReflectionPreviousFramePass so multiple passes (Reflection and Water) can reference the previous frame image (for reflection). 
- Refactored TraceRayScreenSpace shader function so it receives m_maxRayDistance and m_maxDepthThreshold as arguments instead of reading them from the PassSRG
- Added GetActiveLightDirection to DirectionalLightFeatureProcessorInterface to get the direction of the sun (first light)
- Added SetTargetThreadCounts to RaytracingPass to set the number of rays from C++
- Added CollectSrgsToBind to RaytracingPass to bind the view and scene SRG among others
- Added UpdateConnectedBinding to Pass class to update bindings when a new pass is inserted
- Added support to declare Buffer slots that use the remaining buffer without specifying it's size. BufferViewDescriptor is resolved at runtime with the proper size of the BufferView
- Added UsageFlags::UsageOther to View for caustics View

## How was this PR tested?

Windows DX12 and Vulkan
