### PR TITLE
[CAR-32754] Add "collapse tree" menu item to EntityOutliner context menu.

### DIFF
--- a/Code/Editor/Core/EditorActionsHandler.cpp
+++ b/Code/Editor/Core/EditorActionsHandler.cpp
@@ -823,6 +823,36 @@ void EditorActionsHandler::OnActionRegistrationHook()
         m_hotKeyManagerInterface->SetActionHotKey(actionIdentifier, "F2");
     }
 
+#if defined(CARBONATED) // Add "Collapse outliner tree view" action
+    // Collapse Outliner tree view (in the Entity Outliner)
+    {
+        const AZStd::string_view actionIdentifier = "o3de.action.view.collapseTree";
+        AzToolsFramework::ActionProperties actionProperties;
+        actionProperties.m_name = "Collapse Level Tree";
+        actionProperties.m_description = "Collapse level tree view.";
+        actionProperties.m_category = "Level";
+
+        m_actionManagerInterface->RegisterAction(
+            EditorIdentifiers::MainWindowActionContextIdentifier,
+            actionIdentifier,
+            actionProperties,
+            []()
+            {
+                AzToolsFramework::EntityIdList selectedEntities;
+                AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
+                    selectedEntities, &AzToolsFramework::ToolsApplicationRequests::Bus::Events::GetSelectedEntities);
+
+                // Keep expanded only the 1st selected entity and its ancestors.
+                AZ::EntityId firstSelectedEnity = selectedEntities.empty() ? AZ::EntityId() : selectedEntities.front();
+                AzToolsFramework::EntityOutlinerRequestBus::Broadcast(
+                    &AzToolsFramework::EntityOutlinerRequests::CollapseTreeView, firstSelectedEnity);
+            });
+
+        // Trigger update whenever entity selection changes.
+        m_actionManagerInterface->AddActionToUpdater(EditorIdentifiers::EntitySelectionChangedUpdaterIdentifier, actionIdentifier);
+    }
+#endif
+
     // Find Entity (in the Entity Outliner)
     {
         const AZStd::string_view actionIdentifier = "o3de.action.entityOutliner.findEntity";
@@ -2023,6 +2053,10 @@ void EditorActionsHandler::OnMenuBindingHook()
     m_menuManagerInterface->AddActionToMenu(EditorIdentifiers::EntityOutlinerContextMenuIdentifier, "o3de.action.entity.rename", 70100);
     m_menuManagerInterface->AddSeparatorToMenu(EditorIdentifiers::EntityOutlinerContextMenuIdentifier, 80000);
     m_menuManagerInterface->AddActionToMenu(EditorIdentifiers::EntityOutlinerContextMenuIdentifier, "o3de.action.view.centerOnSelection", 80100);
+#if defined(CARBONATED) // Add "Collapse outliner tree view" action
+    m_menuManagerInterface->AddSeparatorToMenu(EditorIdentifiers::EntityOutlinerContextMenuIdentifier, 90000);
+    m_menuManagerInterface->AddActionToMenu(EditorIdentifiers::EntityOutlinerContextMenuIdentifier, "o3de.action.view.collapseTree", 90100);
+#endif
 
     // Viewport Context Menu
     m_menuManagerInterface->AddSubMenuToMenu(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityModel.cpp
@@ -33,7 +33,6 @@ DECLARE_EBUS_INSTANTIATION(AzToolsFramework::EditorEntityInfoRequests);
 
 #include <QtWidgets/QMessageBox>
 
-#pragma optimize("", off)
 namespace
 {
     template<typename T>
@@ -1879,4 +1878,3 @@ namespace AzToolsFramework
         }
     }
 }   // namespace AzToolsFramework
-#pragma optimize("", on)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityModel.cpp
@@ -33,6 +33,7 @@ DECLARE_EBUS_INSTANTIATION(AzToolsFramework::EditorEntityInfoRequests);
 
 #include <QtWidgets/QMessageBox>
 
+#pragma optimize("", off)
 namespace
 {
     template<typename T>
@@ -1878,3 +1879,4 @@ namespace AzToolsFramework
         }
     }
 }   // namespace AzToolsFramework
+#pragma optimize("", on)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerRequestBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerRequestBus.h
@@ -20,6 +20,11 @@ namespace AzToolsFramework
     public:
         //! Request to trigger the rename workflow on the Entity Outliner for the entity provided.
         virtual void TriggerRenameEntityUi(const AZ::EntityId& entityId) = 0;
+
+#if defined(CARBONATED) // Add "Collapse outliner tree view" action
+        //! Request to collapse the tree view on the Entity Outliner, except for the entity provided.
+        virtual void CollapseTreeView(const AZ::EntityId& entityId) = 0;
+#endif
     };
     using EntityOutlinerRequestBus = AZ::EBus<EntityOutlinerRequests>;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
@@ -1106,6 +1106,21 @@ namespace AzToolsFramework
         }
     }
 
+#if defined(CARBONATED) // Add "Collapse outliner tree view" action
+    void EntityOutlinerWidget::CollapseTreeView(const AZ::EntityId& entityId)
+    {
+        m_gui->m_objectTree->collapseAll();
+
+        const QModelIndex proxyIndex = GetIndexFromEntityId(entityId);
+        if (proxyIndex.isValid())
+        {
+            m_gui->m_objectTree->setCurrentIndex(proxyIndex);
+
+            FocusModeNotificationBus::Broadcast(&FocusModeNotifications::OnEditorFocusChanged, AZ::EntityId(), entityId);
+        }
+    }
+#endif
+
     void EntityOutlinerWidget::OnEditorModeActivated(
         [[maybe_unused]] const AzToolsFramework::ViewportEditorModesInterface& editorModeState, AzToolsFramework::ViewportEditorMode mode)
     {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.hxx
@@ -126,6 +126,9 @@ namespace AzToolsFramework
 
         // EntityOutlinerRequestBus overrides ...
         void TriggerRenameEntityUi(const AZ::EntityId& entityId) override;
+#if defined(CARBONATED) // Add "Collapse outliner tree view" action
+        void CollapseTreeView(const AZ::EntityId& entityId) override;
+#endif
 
         // Build a selection object from the given entities. Entities already in the Widget's selection buffers are ignored.
         template <class EntityIdCollection>


### PR DESCRIPTION
### What does this PR do?

Closes [CAR-32754](https://favro.com/organization/ab098f3312254434882b4396/579ee0f4d0168dab8e8d0252?card=Car-32754)

Adds "collapse tree" menu item to EntityOutliner context menu, thus providing means to collapse tree view on a huge level after searches.


### How was this PR tested?

On PC the correct evaluation of the new menu item in Entity Outliner context menu noted.
* PC build [#45613](http://10.0.1.100:8080/job/Extraction/job/Client/job/build%252Fastarykh%252FCAR-32754-add-collapse-tree-menuitem/3/pipeline-overview/) - xxx ~succeeded~; PC build binaries are to be stored with "nfe-dev" tag.

* Linux build [#45629](http://10.0.1.100:8080/job/Extraction/job/Client/job/build%252Fastarykh%252FCAR-32754-add-collapse-tree-menuitem/5/pipeline-overview/): succeeded.
