### PR TITLE
Minor bug fixes and timing

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
@@ -80,6 +80,10 @@
 
 #include <AzCore/Outcome/Outcome.h> // for unexpect_t
 
+#if defined(CARBONATED)
+//#define CARBONATED_TICK_TIMING  // uncomment to track micro-freezes in OnTick and OnSystemTick, adjust the threshold if needed
+#endif
+
 DECLARE_EBUS_INSTANTIATION_WITH_TRAITS(ComponentApplicationRequests, ComponentApplicationRequestsEBusTraits);
 DECLARE_EBUS_INSTANTIATION(TickEvents);
 DECLARE_EBUS_INSTANTIATION(SystemTickEvents);
@@ -1648,7 +1652,24 @@ namespace AZ
             AZ_PROFILE_SCOPE(AzCore, "ComponentApplication::Tick:OnTick");
             const AZ::TimeUs deltaTimeUs = m_timeSystem->AdvanceTickDeltaTimes();
             const float deltaTimeSeconds = AZ::TimeUsToSeconds(deltaTimeUs);
+#if defined(CARBONATED) && defined(CARBONATED_TICK_TIMING)
+            auto t = GetTimeAtCurrentTick();
+            AZ::TickBus::EnumerateHandlers(
+                [deltaTimeSeconds, t](AZ::TickEvents* listener)
+                {
+                    const AZ::TimeMs begin = AZ::GetRealElapsedTimeMs();
+                    listener->OnTick(deltaTimeSeconds, t);
+                    const AZ::TimeMs end = AZ::GetRealElapsedTimeMs();
+                    const int64_t dt = (int64_t)end - (int64_t)begin;
+                    if (dt > 100)
+                    {
+                        AZ_Info("microfreeze", "Tick for %s took %d ms", listener->RTTI_GetTypeName(), dt);
+                    }
+                    return true;
+                });
+#else
             AZ::TickBus::Broadcast(&TickEvents::OnTick, deltaTimeSeconds, GetTimeAtCurrentTick());
+#endif
         }
 
         m_timeSystem->ApplyTickRateLimiterIfNeeded();
@@ -1659,7 +1680,23 @@ namespace AZ
         AZ_PROFILE_SCOPE(System, "Component application tick");
 
         SystemTickBus::ExecuteQueuedEvents();
+#if defined(CARBONATED) && defined(CARBONATED_TICK_TIMING)
+        AZ::SystemTickBus::EnumerateHandlers(
+            [](AZ::SystemTickEvents* listener)
+            {
+                const AZ::TimeMs begin = AZ::GetRealElapsedTimeMs();
+                listener->OnSystemTick();
+                const AZ::TimeMs end = AZ::GetRealElapsedTimeMs();
+                const int64_t dt = (int64_t)end - (int64_t)begin;
+                if (dt > 100)
+                {
+                    AZ_Info("microfreeze", "SystemTick for %s took %d ms", typeid(*listener).name(), dt);
+                }
+                return true;
+            });
+#else
         SystemTickBus::Broadcast(&SystemTickBus::Events::OnSystemTick);
+#endif
     }
 
     bool ComponentApplication::ShouldAddSystemComponent(AZ::ComponentDescriptor* descriptor)

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorDebugDraw.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorDebugDraw.cpp
@@ -228,7 +228,11 @@ namespace AZ::Render
         }
 
         // Data required for debug drawing colliders and ragdolls
+#if defined(CARBONATED)
+        const AZStd::unordered_set<size_t>* cachedSelectedJointIndices = nullptr;
+#else
         const AZStd::unordered_set<size_t>* cachedSelectedJointIndices;
+#endif
         EMotionFX::JointSelectionRequestBus::BroadcastResult(
             cachedSelectedJointIndices, &EMotionFX::JointSelectionRequests::FindSelectedJointIndices, instance);
 
@@ -469,7 +473,11 @@ namespace AZ::Render
         const size_t lodLevel = instance->GetLODLevel();
         const size_t numJoints = skeleton->GetNumNodes();
 
+#if defined(CARBONATED)
+        const AZStd::unordered_set<size_t>* cachedSelectedJointIndices = nullptr;
+#else
         const AZStd::unordered_set<size_t>* cachedSelectedJointIndices;
+#endif
         EMotionFX::JointSelectionRequestBus::BroadcastResult(
             cachedSelectedJointIndices, &EMotionFX::JointSelectionRequests::FindSelectedJointIndices, instance);
 
@@ -514,7 +522,11 @@ namespace AZ::Render
         const EMotionFX::Pose* pose = transformData->GetCurrentPose();
         const size_t numEnabled = instance->GetNumEnabledNodes();
 
+#if defined(CARBONATED)
+        const AZStd::unordered_set<size_t>* cachedSelectedJointIndices = nullptr;
+#else
         const AZStd::unordered_set<size_t>* cachedSelectedJointIndices;
+#endif
         EMotionFX::JointSelectionRequestBus::BroadcastResult(
             cachedSelectedJointIndices, &EMotionFX::JointSelectionRequests::FindSelectedJointIndices, instance);
 

--- a/Gems/Profiler/Code/Source/CpuProfiler.cpp
+++ b/Gems/Profiler/Code/Source/CpuProfiler.cpp
@@ -101,7 +101,12 @@ namespace Profiler
                 va_list args;
                 va_start(args, eventNameArgCount);
                 // Push it to the stack
+#if defined(CARBONATED)
+                // there is at least a string of 559 characters
+                CachedTimeRegion timeRegion({ budget->Name(), AZStd::fixed_string<1024>::format_arg(eventName, args).c_str() });
+#else
                 CachedTimeRegion timeRegion({ budget->Name(), AZStd::fixed_string<512>::format_arg(eventName, args).c_str() });
+#endif
                 ms_threadLocalStorage->RegionStackPushBack(timeRegion);
             }
 


### PR DESCRIPTION
## What does this PR do?

Plain bug fixes for animation debug display and CPU profiler (which is hardly usable for freeze finding).
Add timing to ticks, I used that code for iOS, then lost it, re-create recently. Let keep it to speed up next freeze detection. Also the code shows how to deal with a buss timing, most likely an investigation involves more busses.

## How was this PR tested?

Local test iOS & Windows.
